### PR TITLE
feature/webrtc stats

### DIFF
--- a/demo-app/app.tsx
+++ b/demo-app/app.tsx
@@ -59,7 +59,7 @@ export function App() {
         }
     }
 
-    const onVideoStateChange = function(state) {
+    const onVideoStateChange = function(state, stats) {
         setStreamState(streamState => {
             if (streamState === State.Speaking) {
                 return state === StreamingState.Stop ? State.Connected : State.Speaking;
@@ -67,6 +67,9 @@ export function App() {
 
             return streamState;
         });
+        if (state === StreamingState.Stop && stats) {
+            console.log('Video stats', stats);
+        }
     }
 
     const callbacks ={

--- a/src/lib/utils/webrtc.ts
+++ b/src/lib/utils/webrtc.ts
@@ -1,0 +1,40 @@
+import { SlimRTCStatsReport } from "../../types";
+
+export function createVideoStatsReport(stats: SlimRTCStatsReport[], previousStats?: SlimRTCStatsReport): SlimRTCStatsReport[] {
+    return stats.map((report, index) => {
+        if (index === 0) {
+            return !previousStats ? {
+                index,
+                timestamp: report.timestamp,
+                bytesReceived: report.bytesReceived,
+                packetsReceived: report.packetsReceived,
+                packetsLost: report.packetsLost,
+                jitter: report.jitter,
+                frameWidth: report.frameWidth,
+                frameHeight: report.frameHeight,
+                frameRate: report.frameRate,
+            } :
+                {
+                    index,
+                    timestamp: report.timestamp,
+                    bytesReceived: report.bytesReceived - previousStats.bytesReceived,
+                    packetsReceived: report.packetsReceived - previousStats.packetsReceived,
+                    packetsLost: report.packetsLost - previousStats.packetsLost,
+                    jitter: report.jitter,
+                    frameWidth: report.frameWidth,
+                    frameHeight: report.frameHeight,
+                    frameRate: report.frameRate,
+                };
+        } else return {
+            index,
+            timestamp: report.timestamp,
+            bytesReceived: report.bytesReceived - stats[index - 1].bytesReceived,
+            packetsReceived: report.packetsReceived - stats[index - 1].packetsReceived,
+            packetsLost: report.packetsLost - stats[index - 1].packetsLost,
+            jitter: report.jitter,
+            frameWidth: report.frameWidth,
+            frameHeight: report.frameHeight,
+            frameRate: report.frameRate,
+        }
+    });
+}

--- a/src/types/entities/agents/manager.ts
+++ b/src/types/entities/agents/manager.ts
@@ -1,6 +1,6 @@
 import { SupportedStreamScipt } from '$/types/StreamScript';
 import { Auth } from '../../auth';
-import { SendStreamPayloadResponse, StreamingState } from '../../stream';
+import { SendStreamPayloadResponse, SlimRTCStatsReport, StreamingState } from '../../stream';
 import { Agent } from './agent';
 import { ChatResponse, Message, RatingEntity, RatingPayload } from './chat';
 
@@ -28,7 +28,7 @@ enum ChatProgress {
 
 export type ChatProgressCallback = (progress: ChatProgress) => void;
 export type ConnectionStateChangeCallback = (state: RTCIceConnectionState) => void;
-export type VideoStateChangeCallback = (state: StreamingState) => void
+export type VideoStateChangeCallback = (state: StreamingState, stats?: SlimRTCStatsReport[]) => void
 
 interface ManagerCallbacks {
     /**

--- a/src/types/stream/stream.ts
+++ b/src/types/stream/stream.ts
@@ -59,3 +59,15 @@ export interface StreamingManagerOptions {
     debug?: boolean;
     auth: Auth;
 }
+
+export interface SlimRTCStatsReport {
+    index: number;
+    timestamp: any;
+    bytesReceived: any;
+    packetsReceived: any;
+    packetsLost: any;
+    jitter: any;
+    frameWidth: any;
+    frameHeight: any;
+    frameRate: any;
+}


### PR DESCRIPTION
Gather webrtc stats and send report to callback

report includes segmented stats about each second of the video, and takes the 5 highest offenders in regards to packet loss.