### PR TITLE
Agent - allow append mode

### DIFF
--- a/demo/app.tsx
+++ b/demo/app.tsx
@@ -127,7 +127,7 @@ export function App() {
 
     async function onChat() {
         const newMessages: any[] = [{ role: 'user', content: text.trim(), created_at: new Date().toISOString() }];
-        const response = agentAPI?.chat(newMessages);
+        const response = agentAPI?.chat(newMessages, true);
     }
 
     function disconnect() {

--- a/src/createAgentManager.ts
+++ b/src/createAgentManager.ts
@@ -125,7 +125,7 @@ export async function createAgentManager(agent: string | Agent, options: AgentMa
 
             return streamingManager.disconnect();
         },
-        chat(messages: Message[]) {
+        chat(messages: Message[], append_chat: boolean = false) {
             if (messages.length === 0) {
                 throw new Error('Messages cannot be empty');
             }
@@ -138,7 +138,7 @@ export async function createAgentManager(agent: string | Agent, options: AgentMa
             return agentsApi.chat(
                 agentInstance.id,
                 chat.id,
-                { sessionId: streamingManager.sessionId, streamId: streamingManager.streamId, messages },
+                { sessionId: streamingManager.sessionId, streamId: streamingManager.streamId, messages, append_chat },
                 { signal: abortController.signal }
             );
         },

--- a/src/types/entities/agents/chat.ts
+++ b/src/types/entities/agents/chat.ts
@@ -32,6 +32,7 @@ export interface Message {
 
 export interface ChatPayload {
     messages: Message[];
+    append_chat?: boolean;
     streamId: string;
     sessionId: string;
 }

--- a/src/types/entities/agents/manager.ts
+++ b/src/types/entities/agents/manager.ts
@@ -101,6 +101,7 @@ export interface AgentManager {
     /**
      * Method to send a chat message to existing chat with the agent
      * @param messages
+     * @param append_chat: when true, append to existing agent chat, rather than creating a new one.
      */
     chat: (messages: Message[], append_chat?: boolean) => Promise<ChatResponse>;
     /**

--- a/src/types/entities/agents/manager.ts
+++ b/src/types/entities/agents/manager.ts
@@ -102,7 +102,7 @@ export interface AgentManager {
      * Method to send a chat message to existing chat with the agent
      * @param messages
      */
-    chat: (messages: Message[]) => Promise<ChatResponse>;
+    chat: (messages: Message[], append_chat?: boolean) => Promise<ChatResponse>;
     /**
      * Method to rate the answer in chat
      * @param score: 1 | -1 - score of the answer. 1 for positive, -1 for negative


### PR DESCRIPTION
Allow append mode so that sdk/api user does not have to specify all message history