### PR TITLE
relying on stream/started event to start streaming

### DIFF
--- a/src/createStreamingManager.ts
+++ b/src/createStreamingManager.ts
@@ -62,7 +62,6 @@ function pollStats(peerConnection, onVideoStateChange, analytics) {
                         if (prevPlaying !== isPlaying) {
                             if (isPlaying) {
                                 videoStatsStartIndex = videoStats.length;
-                                onVideoStateChange?.(StreamingState.Start, videoStatsReport);
                             } else {
                                 const stats = videoStats.slice(videoStatsStartIndex);
                                 const previousStats =
@@ -155,6 +154,8 @@ export async function createStreamingManager<T extends CreateStreamOptions>(
             if (event === StreamEvents.StreamReady) {
                 clearTimeout(timeoutId);
                 callbacks.onConnectionStateChange?.(ConnectionState.Connected);
+            } else if (event === StreamEvents.StreamStarted) {
+                callbacks.onVideoStateChange?.(StreamingState.Start);
             }
         }
     };


### PR DESCRIPTION
- rather than webrtc stats
- to avoid first sentence cut-off
- in agents-ui we set opacity to 1 when it actually start playing so no risk 
https://app.asana.com/0/1207192568376365/1207237906837102/f