### PR TITLE
remove presenter id/url from stream request

### DIFF
--- a/src/api/clipStream.ts
+++ b/src/api/clipStream.ts
@@ -7,7 +7,6 @@ import {
     SendClipStreamPayload,
     SendStreamPayloadResponse,
     Status,
-    VideoType,
 } from '$/types/index';
 import { createClient } from './getClient';
 
@@ -22,37 +21,31 @@ export function createApi(
     return {
         createStream(options: ClipStreamOptions) {
             return client.post<ICreateStreamRequestResponse>('/streams', {
-                driver_id: options.driver_id,
-                presenter_id: options.presenter_id,
                 compatibility_mode: options.compatibility_mode,
                 stream_warmup: options.stream_warmup,
                 session_timeout: options.session_timeout,
-                type: VideoType.Clip,
             });
         },
         startConnection(streamId: string, answer: RTCSessionDescriptionInit, sessionId?: string) {
             return client.post<Status>(`/streams/${streamId}/sdp`, {
                 session_id: sessionId,
                 answer,
-                type: VideoType.Clip,
             });
         },
         addIceCandidate(streamId: string, candidate: IceCandidate, sessionId: string) {
             return client.post<Status>(`/streams/${streamId}/ice`, {
                 session_id: sessionId,
                 ...candidate,
-                type: VideoType.Clip,
             });
         },
         sendStreamRequest(streamId: string, sessionId: string, payload: SendClipStreamPayload) {
             return client.post<SendStreamPayloadResponse>(`/streams/${streamId}`, {
                 session_id: sessionId,
                 ...payload,
-                type: VideoType.Clip,
             });
         },
         close(streamId: string, sessionId: string) {
-            return client.delete<Status>(`/streams/${streamId}`, { session_id: sessionId, type: VideoType.Clip });
+            return client.delete<Status>(`/streams/${streamId}`, { session_id: sessionId });
         },
     };
 }

--- a/src/api/talkStream.ts
+++ b/src/api/talkStream.ts
@@ -7,7 +7,6 @@ import {
     SendTalkStreamPayload,
     Status,
     TalkStreamOptions,
-    VideoType,
 } from '$/types/index';
 import { createClient } from './getClient';
 
@@ -24,7 +23,6 @@ export function createApi(
             return client.post<ICreateStreamRequestResponse>(
                 '/streams',
                 {
-                    source_url: streamOptions.source_url,
                     driver_url: streamOptions.driver_url,
                     face: streamOptions.face,
                     config: streamOptions.config,
@@ -32,7 +30,6 @@ export function createApi(
                     stream_warmup: streamOptions.stream_warmup,
                     output_resolution: streamOptions.output_resolution,
                     session_timeout: streamOptions.session_timeout,
-                    type: VideoType.Talk,
                 },
                 options
             );
@@ -45,14 +42,14 @@ export function createApi(
         ) {
             return client.post<Status>(
                 `/streams/${streamId}/sdp`,
-                { session_id: sessionId, answer, type: VideoType.Talk },
+                { session_id: sessionId, answer },
                 options
             );
         },
         addIceCandidate(streamId: string, candidate: IceCandidate, sessionId: string, options?: RequestInit) {
             return client.post<Status>(
                 `/streams/${streamId}/ice`,
-                { session_id: sessionId, ...candidate, type: VideoType.Talk },
+                { session_id: sessionId, ...candidate },
                 options
             );
         },
@@ -62,7 +59,6 @@ export function createApi(
                 {
                     session_id: sessionId,
                     ...payload,
-                    type: VideoType.Talk,
                 },
                 options
             );
@@ -70,7 +66,7 @@ export function createApi(
         close(streamId: string, sessionId: string, options?: RequestInit) {
             return client.delete<Status>(
                 `/streams/${streamId}`,
-                { session_id: sessionId, type: VideoType.Talk },
+                { session_id: sessionId },
                 options
             );
         },

--- a/src/createAgentManager.ts
+++ b/src/createAgentManager.ts
@@ -42,13 +42,9 @@ interface ChatEventQueue {
 }
 
 function getAgentStreamArgs(agent: Agent, options?: AgentManagerOptions): CreateStreamOptions {
-    if (!agent.presenter) {
-        throw new Error('Presenter is not initialized');
-    } else if (agent.presenter.type === VideoType.Clip) {
+    if (agent.presenter.type === VideoType.Clip) {
         return {
             videoType: VideoType.Clip,
-            driver_id: agent.presenter.driver_id,
-            presenter_id: agent.presenter.presenter_id,
             session_timeout: options?.streamOptions?.sessionTimeout,
             stream_warmup: options?.streamOptions?.streamWarmup ?? true,
             compatibility_mode: options?.streamOptions?.compatibilityMode,
@@ -57,7 +53,6 @@ function getAgentStreamArgs(agent: Agent, options?: AgentManagerOptions): Create
 
     return {
         videoType: VideoType.Talk,
-        source_url: agent.presenter.source_url,
         session_timeout: options?.streamOptions?.sessionTimeout,
         stream_warmup: options?.streamOptions?.streamWarmup ?? true,
         compatibility_mode: options?.streamOptions?.compatibilityMode,

--- a/src/types/stream/api/clip.ts
+++ b/src/types/stream/api/clip.ts
@@ -30,17 +30,6 @@ interface ClipConfig {
 
 export interface CreateClipStreamRequest {
     /**
-     * ID of the selected presenter.
-     * @example "rian-lZC6MmWfC1"
-     */
-    presenter_id: string;
-    /**
-     * ID of the selected driver.
-     * If not provided a driver video will be selected for you from the predefined drivers bank.
-     * @example "mXra4jY38i"
-     */
-    driver_id?: string;
-    /**
      * Defines the video codec to be used in the stream.
      * When set to on: VP8 will be used.
      * When set to off: H264 will be used

--- a/src/types/stream/api/talk.ts
+++ b/src/types/stream/api/talk.ts
@@ -2,7 +2,6 @@ import { StreamScript } from '../..';
 import { CompatibilityMode } from '../stream';
 
 export interface CreateTalkStreamRequest {
-    source_url: string;
     driver_url?: string;
     face?: {
         size: number;


### PR DESCRIPTION
- goal: better sdk experience, as those fields are retrieved from agent db

- remove presenter_id + driver_id from clipStreamRequest
- remove source_url from talkStreamRequest

- ***do not merge***
- [Asana] https://app.asana.com/0/1207408129476039/1207494032839673/f
