### PR TITLE
increase the connection retry timeout to 1 minute

### DIFF
--- a/src/createAgentManager.ts
+++ b/src/createAgentManager.ts
@@ -27,7 +27,7 @@ import { Analytics, initializeAnalytics } from './services/mixpanel';
 import { getAnaliticsInfo, getStreamAnalyticsProps } from './utils/analytics';
 
 let messageSentTimestamp = 0;
-const connectionRetryTimeoutInMs = 40 * 1000;
+const connectionRetryTimeoutInMs = 60 * 1000;
 
 interface AgentManagerItems {
     chat?: Chat;

--- a/src/createAgentManager.ts
+++ b/src/createAgentManager.ts
@@ -27,7 +27,7 @@ import { Analytics, initializeAnalytics } from './services/mixpanel';
 import { getAnaliticsInfo, getStreamAnalyticsProps } from './utils/analytics';
 
 let messageSentTimestamp = 0;
-const connectionRetryTimeoutInMs = 20 * 1000; // 20 seconds
+const connectionRetryTimeoutInMs = 40 * 1000;
 
 interface AgentManagerItems {
     chat?: Chat;


### PR DESCRIPTION
since @eladmotola  introduced a fix for failing connections we don't really need this retry mechanism.
we increase it so we won't experience reconnection on presenter download