### PR TITLE
feature / add deployment workflows to prod and staging

### DIFF
--- a/.github/workflows/publish-prod.yml
+++ b/.github/workflows/publish-prod.yml
@@ -1,0 +1,31 @@
+name: Publish Production (agents-sdk)
+
+on:
+  push:
+    branches:
+      - prod
+
+jobs:
+  publish-prod:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org/'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Set package name to agents-sdk
+        run: |
+          jq '.name = "agents-sdk"' package.json > package.tmp.json && mv package.tmp.json package.json
+
+      - name: Publish to NPM (prod)
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public

--- a/.github/workflows/publish-staging.yml
+++ b/.github/workflows/publish-staging.yml
@@ -1,0 +1,59 @@
+name: Publish Staging (agents-sdk-staging)
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  bump-version-and-publish-staging:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Cache node modules
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org/'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build package
+        run: npm run build
+        continue-on-error: false
+
+      - name: Bump version (patch)
+        run: |
+          npm version patch --no-git-tag-version
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add package.json package-lock.json || true
+          git commit -m "chore: bump version [skip ci]" || echo "No changes to commit"
+          git push origin main
+        continue-on-error: false
+
+      - name: Swap package name to agents-sdk-staging (temp)
+        run: |
+          cp package.json package.json.bak
+          jq '.name = "agents-sdk-staging"' package.json > package.tmp.json && mv package.tmp.json package.json
+
+      - name: Publish to NPM (staging)
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public
+        continue-on-error: false
+
+      - name: Revert package name after publish
+        run: mv package.json.bak package.json
+        if: always()


### PR DESCRIPTION
This PR introduces separate GitHub Actions workflows for publishing the SDK to NPM as distinct staging and production packages:

**Staging** (main branch):

Bumps the version in `package.json` and commits it.
Temporarily sets the package name to agents-sdk-staging before publishing.
Publishes to NPM as agents-sdk-staging.
Reverts the package name after publish.


**Production** (prod branch):

Ensures the package name is set to agents-sdk.
Publishes to NPM as agents-sdk (no version bump).
These changes improve release velocity and ensure clear separation between staging and production SDK releases.