### PR TITLE
Feature/enrich mixpanel with stream metadata

### DIFF
--- a/src/services/analytics/mixpanel.ts
+++ b/src/services/analytics/mixpanel.ts
@@ -67,19 +67,7 @@ export function initializeAnalytics(config: AnalyticsOptions): Analytics {
         additionalProperties: {},
         isEnabled: config.isEnabled ?? true,
         getRandom,
-        enrich(properties: Record<string, any>) {
-            const props = {};
-
-            if (properties && typeof properties !== 'object') {
-                throw new Error('properties must be a flat json object');
-            }
-
-            for (let prop in properties) {
-                if (typeof properties[prop] === 'string' || typeof properties[prop] === 'number') {
-                    props[prop] = properties[prop];
-                }
-            }
-
+        enrich(props: Record<string, any>) {
             this.additionalProperties = { ...this.additionalProperties, ...props };
         },
         async track(event: string, props?: Record<string, any>) {

--- a/src/services/streaming-manager/index.ts
+++ b/src/services/streaming-manager/index.ts
@@ -50,11 +50,10 @@ function parseDataChannelMessage(message: string): { subject: StreamEvents, data
     let data = rawData;
     try {
         data = rawData ? JSON.parse(rawData) : undefined;
+        log('parsed data channel message', { subject, data });
     } catch {
         log('Failed to parse data channel message', { subject, rawData });
     }
-
-    log('parsed data channel message', { subject, data });
 
     return { subject: subject as StreamEvents, data };
 }

--- a/src/services/streaming-manager/index.ts
+++ b/src/services/streaming-manager/index.ts
@@ -49,11 +49,11 @@ function mapConnectionState(state: RTCIceConnectionState): ConnectionState {
 function parseDataChannelMessage(message: string): { subject: StreamEvents, data: DataChannelPayload } {
     const [subject, rawData = ''] = message.split(/:(.+)/);
     try {
-        const data = JSON.parse(rawData) as Record<string, unknown>;
+        const data = JSON.parse(rawData);
         log('parsed data channel message', { subject, data });
         return { subject: subject as StreamEvents, data };
     } catch (e) {
-        log('Failed to parse data channel message', { subject, rawData, error: e });
+        log('Failed to parse data channel message, returning data as string', { subject, rawData, error: e });
         return { subject: subject as StreamEvents, data: rawData };
     }
 }
@@ -232,7 +232,8 @@ export async function createStreamingManager<T extends CreateStreamOptions>(
     }
 
     function handleStreamReadyEvent(_subject: StreamEvents.StreamReady, payload?: DataChannelPayload) {
-        analytics.enrich({ streamMetadata: typeof payload === 'string' ? payload : payload?.metadata })
+        const streamMetadata = typeof payload === 'string' ? payload : payload?.metadata;
+        streamMetadata && analytics.enrich({ streamMetadata });
         analytics.track('agent-chat', { event: 'ready' });
     }
 

--- a/src/services/streaming-manager/index.ts
+++ b/src/services/streaming-manager/index.ts
@@ -221,9 +221,11 @@ export async function createStreamingManager<T extends CreateStreamOptions>(
     };
 
     function handleStreamVideoEvent(subject: StreamEvents.StreamStarted | StreamEvents.StreamDone) {
+        dataChannelSignal = subject === StreamEvents.StreamStarted ? StreamingState.Start : StreamingState.Stop;
+
         handleStreamState({
             statsSignal: streamType === StreamType.Legacy ? statsSignal : undefined,
-            dataChannelSignal: subject === StreamEvents.StreamStarted ? StreamingState.Start : StreamingState.Stop,
+            dataChannelSignal,
             onVideoStateChange: callbacks.onVideoStateChange,
             onAgentActivityStateChange: callbacks.onAgentActivityStateChange,
             streamType,

--- a/src/services/streaming-manager/index.ts
+++ b/src/services/streaming-manager/index.ts
@@ -233,7 +233,8 @@ export async function createStreamingManager<T extends CreateStreamOptions>(
     }
 
     function handleStreamReadyEvent(_subject: StreamEvents.StreamReady, payload: any) {
-        payload?.metadata && analytics.enrich({ streamMetadata: payload.metadata })
+        analytics.enrich({ streamMetadata: payload?.metadata })
+        analytics.track('agent-chat', { event: 'ready' });
     }
 
     const dataChannelHandlers = {

--- a/src/types/stream/stream.ts
+++ b/src/types/stream/stream.ts
@@ -23,11 +23,6 @@ export enum AgentActivityState {
     Talking = 'TALKING',
 }
 
-export const DataChannelSignalMap: Record<string, StreamingState> = {
-    'stream/started': StreamingState.Start,
-    'stream/done': StreamingState.Stop,
-};
-
 export enum StreamEvents {
     ChatAnswer = 'chat/answer',
     ChatPartial = 'chat/partial',


### PR DESCRIPTION
- enrich mixpanel with stream/ready dc message metadata.
- fix enrich function
- add proper parsing for DC messages
- add agent-chat event with status /ready
- Motivation: [Network accelerator analytics ](https://app.asana.com/1/856614567666442/project/1210185824838545/task/1210067141643747?focus=true)