### PR TITLE
chore: sync version 1.1.7 from prod

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,48 +1,48 @@
 {
-    "name": "@d-id/client-sdk",
-    "private": false,
-    "version": "1.1.6",
-    "type": "module",
-    "description": "d-id client sdk",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/de-id/agents-sdk"
-    },
-    "keywords": [
-        "d-id",
-        "sdk",
-        "client-sdk"
-    ],
-    "license": "MIT",
-    "author": "d-id",
-    "files": [
-        "dist/*"
-    ],
-    "main": "./dist/index.umd.cjs",
-    "module": "./dist/index.js",
-    "types": "./dist/src/index.d.ts",
-    "scripts": {
-        "dev": "vite",
-        "build": "node ./infra/build.js -m production",
-        "build:dev": "node ./infra/build.js -m development",
-        "dev:prod": "export NODE_ENV=production && vite --mode production",
-        "deploy:prod": "node ./infra/deploy.js --version beta",
-        "preview": "vite preview",
-        "test-build": "node .infra/build.js -m development",
-        "build:docs": "typedoc"
-    },
-    "devDependencies": {
-        "@preact/preset-vite": "^2.8.1",
-        "@trivago/prettier-plugin-sort-imports": "^4.3.0",
-        "@types/node": "^22.15.0",
-        "commander": "^11.1.0",
-        "glob": "^10.3.10",
-        "preact": "^10.19.6",
-        "prettier": "^3.2.5",
-        "prettier-plugin-organize-imports": "^3.2.4",
-        "typedoc": "^0.25.7",
-        "typescript": "^5.3.3",
-        "vite": "^5.1.4",
-        "vite-plugin-dts": "^3.7.3"
-    }
+  "name": "@d-id/client-sdk",
+  "private": false,
+  "version": "1.1.7",
+  "type": "module",
+  "description": "d-id client sdk",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/de-id/agents-sdk"
+  },
+  "keywords": [
+    "d-id",
+    "sdk",
+    "client-sdk"
+  ],
+  "license": "MIT",
+  "author": "d-id",
+  "files": [
+    "dist/*"
+  ],
+  "main": "./dist/index.umd.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/src/index.d.ts",
+  "scripts": {
+    "dev": "vite",
+    "build": "node ./infra/build.js -m production",
+    "build:dev": "node ./infra/build.js -m development",
+    "dev:prod": "export NODE_ENV=production && vite --mode production",
+    "deploy:prod": "node ./infra/deploy.js --version beta",
+    "preview": "vite preview",
+    "test-build": "node .infra/build.js -m development",
+    "build:docs": "typedoc"
+  },
+  "devDependencies": {
+    "@preact/preset-vite": "^2.8.1",
+    "@trivago/prettier-plugin-sort-imports": "^4.3.0",
+    "@types/node": "^22.15.0",
+    "commander": "^11.1.0",
+    "glob": "^10.3.10",
+    "preact": "^10.19.6",
+    "prettier": "^3.2.5",
+    "prettier-plugin-organize-imports": "^3.2.4",
+    "typedoc": "^0.25.7",
+    "typescript": "^5.3.3",
+    "vite": "^5.1.4",
+    "vite-plugin-dts": "^3.7.3"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,48 +1,48 @@
 {
-  "name": "@d-id/client-sdk",
-  "private": false,
-  "version": "1.1.7",
-  "type": "module",
-  "description": "d-id client sdk",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/de-id/agents-sdk"
-  },
-  "keywords": [
-    "d-id",
-    "sdk",
-    "client-sdk"
-  ],
-  "license": "MIT",
-  "author": "d-id",
-  "files": [
-    "dist/*"
-  ],
-  "main": "./dist/index.umd.cjs",
-  "module": "./dist/index.js",
-  "types": "./dist/src/index.d.ts",
-  "scripts": {
-    "dev": "vite",
-    "build": "node ./infra/build.js -m production",
-    "build:dev": "node ./infra/build.js -m development",
-    "dev:prod": "export NODE_ENV=production && vite --mode production",
-    "deploy:prod": "node ./infra/deploy.js --version beta",
-    "preview": "vite preview",
-    "test-build": "node .infra/build.js -m development",
-    "build:docs": "typedoc"
-  },
-  "devDependencies": {
-    "@preact/preset-vite": "^2.8.1",
-    "@trivago/prettier-plugin-sort-imports": "^4.3.0",
-    "@types/node": "^22.15.0",
-    "commander": "^11.1.0",
-    "glob": "^10.3.10",
-    "preact": "^10.19.6",
-    "prettier": "^3.2.5",
-    "prettier-plugin-organize-imports": "^3.2.4",
-    "typedoc": "^0.25.7",
-    "typescript": "^5.3.3",
-    "vite": "^5.1.4",
-    "vite-plugin-dts": "^3.7.3"
-  }
+    "name": "@d-id/client-sdk",
+    "private": false,
+    "version": "1.1.7",
+    "type": "module",
+    "description": "d-id client sdk",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/de-id/agents-sdk"
+    },
+    "keywords": [
+        "d-id",
+        "sdk",
+        "client-sdk"
+    ],
+    "license": "MIT",
+    "author": "d-id",
+    "files": [
+        "dist/*"
+    ],
+    "main": "./dist/index.umd.cjs",
+    "module": "./dist/index.js",
+    "types": "./dist/src/index.d.ts",
+    "scripts": {
+        "dev": "vite",
+        "build": "node ./infra/build.js -m production",
+        "build:dev": "node ./infra/build.js -m development",
+        "dev:prod": "export NODE_ENV=production && vite --mode production",
+        "deploy:prod": "node ./infra/deploy.js --version beta",
+        "preview": "vite preview",
+        "test-build": "node .infra/build.js -m development",
+        "build:docs": "typedoc"
+    },
+    "devDependencies": {
+        "@preact/preset-vite": "^2.8.1",
+        "@trivago/prettier-plugin-sort-imports": "^4.3.0",
+        "@types/node": "^22.15.0",
+        "commander": "^11.1.0",
+        "glob": "^10.3.10",
+        "preact": "^10.19.6",
+        "prettier": "^3.2.5",
+        "prettier-plugin-organize-imports": "^3.2.4",
+        "typedoc": "^0.25.7",
+        "typescript": "^5.3.3",
+        "vite": "^5.1.4",
+        "vite-plugin-dts": "^3.7.3"
+    }
 }


### PR DESCRIPTION
## Version Sync

  This PR syncs the version number from the production release back to the main branch.

  ### Changes
  - Updated version from previous version to 1.1.7

  ### Related
  - Production Release: [v1.1.7](https://github.com/d-id/agents-sdk/releases/tag/v1.1.7)
  - NPM Package: [@d-id/client-sdk@1.1.7](https://www.npmjs.com/package/@d-id/client-sdk/v/1.1.7)

  ### Next Steps
  - [ ] Review the changes
  - [ ] Merge when ready