### PR TITLE
fix for code scanning alert : Workflow does not contain permissions

### DIFF
--- a/.github/workflows/manual-e2e.yml
+++ b/.github/workflows/manual-e2e.yml
@@ -1,4 +1,6 @@
 name: Manual E2E Validation
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:

--- a/.github/workflows/pr-main-e2e.yml
+++ b/.github/workflows/pr-main-e2e.yml
@@ -1,5 +1,8 @@
 name: UI prod e2e with local sdk build
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [main]

--- a/.github/workflows/pr-prod-e2e.yml
+++ b/.github/workflows/pr-prod-e2e.yml
@@ -1,4 +1,6 @@
 name: UI prod e2e with staging sdk build
+permissions:
+  contents: read
 
 on:
   pull_request:

--- a/.github/workflows/publish-on-merge.yml
+++ b/.github/workflows/publish-on-merge.yml
@@ -13,6 +13,9 @@ on:
 
 jobs:
   publish:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/de-id/agents-sdk/security/code-scanning/9](https://github.com/de-id/agents-sdk/security/code-scanning/9)

The best way to fix this problem is to define the `permissions` block explicitly at the workflow level (top-level, applies to all jobs unless overridden) or at the individual job as needed. This ensures the GITHUB_TOKEN only has specific privileges, adhering to the principle of least privilege. 

1. Set a top-level (root) permissions block with the *minimal* necessary privileges for the majority of actions (for example, starting with `contents: read`).
2. Within the `publish` job, where steps require more permissions (such as pushing commits or tags, or making releases), override at the job level with more granular permissions, such as `contents: write` and/or `packages: write`, and `pull-requests: write` if PRs are created via the workflow.
3. If some steps require even narrower permissions, you can use separate keys, but generally, adding a `permissions` block to the job with only the required write scopes is best.

Given this workflow, adding (at minimum) `contents: write` and `pull-requests: write` at the job level for `publish` is required (for `git push` and PR creation), and this is best practice.  
**Change:**  
- In `.github/workflows/publish-on-merge.yml`, add under (for example) line 15, before `runs-on`, a `permissions` block:

```yaml
permissions:
  contents: write
  pull-requests: write
```

If you want to apply it to all jobs, you can instead add it at the top-level, after the `name` or after `on:`.  
Given this workflow has only a single job, it is functionally equivalent, but job-specific is slightly more future-proof if you add jobs later.

**Summary:**  
- Add a `permissions` block either at root or at `jobs.publish`
- Set only required privileges: `contents: write`, `pull-requests: write`


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
