### PR TITLE
Bugfix/mic stream

### DIFF
--- a/demo/hooks/useAgentManager.ts
+++ b/demo/hooks/useAgentManager.ts
@@ -52,7 +52,6 @@ export function useAgentManager(props: UseAgentManagerOptions) {
     const [srcObject, setSrcObject] = useState<MediaStream | null>(null);
     const [agentManager, setAgentManager] = useState<AgentManager | null>(null);
     const [connectionState, setConnectionState] = useState<ConnectionState>(ConnectionState.New);
-    const [isMicrophonePublished, setIsMicrophonePublished] = useState(false);
     const streamType = agentManager?.getStreamType();
 
     useEffect(() => {
@@ -194,7 +193,6 @@ export function useAgentManager(props: UseAgentManagerOptions) {
                 throw new Error('publishMicrophoneStream is not available for this streaming manager');
             }
             await agentManager.publishMicrophoneStream(stream);
-            setIsMicrophonePublished(true);
         },
         [agentManager]
     );
@@ -208,7 +206,22 @@ export function useAgentManager(props: UseAgentManagerOptions) {
             throw new Error('unpublishMicrophoneStream is not available for this streaming manager');
         }
         await agentManager.unpublishMicrophoneStream();
-        setIsMicrophonePublished(false);
+    }, [agentManager]);
+
+    const muteMicrophoneStream = useCallback(async () => {
+        if (!agentManager?.muteMicrophoneStream) {
+            console.warn('muteMicrophoneStream is not available.');
+            return;
+        }
+        await agentManager.muteMicrophoneStream();
+    }, [agentManager]);
+
+    const unmuteMicrophoneStream = useCallback(async () => {
+        if (!agentManager?.unmuteMicrophoneStream) {
+            console.warn('unmuteMicrophoneStream is not available.');
+            return;
+        }
+        await agentManager.unmuteMicrophoneStream();
     }, [agentManager]);
 
     const microphoneEnabled = useMemo(() => {
@@ -230,7 +243,8 @@ export function useAgentManager(props: UseAgentManagerOptions) {
         interrupt,
         publishMicrophoneStream,
         unpublishMicrophoneStream,
+        muteMicrophoneStream,
+        unmuteMicrophoneStream,
         microphoneEnabled,
-        isMicrophonePublished,
     };
 }

--- a/demo/hooks/useMicrophoneStream.ts
+++ b/demo/hooks/useMicrophoneStream.ts
@@ -1,0 +1,307 @@
+import { ConnectionState } from '@sdk/types';
+import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
+
+interface UseMicrophoneStreamOptions {
+    connectionState: ConnectionState;
+    microphoneSupported: boolean; // Whether the presenter supports microphone
+    publishMicrophoneStream?: (stream: MediaStream) => Promise<void>;
+    unpublishMicrophoneStream?: () => Promise<void>;
+    muteMicrophoneStream?: () => Promise<void>;
+    unmuteMicrophoneStream?: () => Promise<void>;
+}
+
+export function useMicrophoneStream(options: UseMicrophoneStreamOptions) {
+    const {
+        connectionState,
+        microphoneSupported,
+        publishMicrophoneStream,
+        unpublishMicrophoneStream,
+        muteMicrophoneStream,
+        unmuteMicrophoneStream,
+    } = options;
+
+    const [isEnabled, setIsEnabled] = useState(true); // User's checkbox preference
+    const [isPublished, setIsPublished] = useState(false);
+    const [isMuted, setIsMuted] = useState(false);
+    const [stream, setStream] = useState<MediaStream | undefined>(undefined);
+    const streamRef = useRef<MediaStream | undefined>(undefined);
+    const isPublishingRef = useRef(false); // Guard against double-publish race condition
+    const [audioDevices, setAudioDevices] = useState<MediaDeviceInfo[]>([]);
+    const [selectedDeviceId, setSelectedDeviceId] = useState<string>('');
+
+    const findRealMicrophoneDevice = useCallback(async (): Promise<string | undefined> => {
+        try {
+            const devices = await navigator.mediaDevices.enumerateDevices();
+            const audioInputs = devices.filter(device => device.kind === 'audioinput');
+
+            const realDevices = audioInputs.filter(
+                device =>
+                    !device.label.toLowerCase().includes('blackhole') &&
+                    !device.label.toLowerCase().includes('virtual')
+            );
+
+            if (realDevices.length > 0) {
+                console.log('[useMicrophoneStream] Found real microphone:', realDevices[0].label);
+                return realDevices[0].deviceId;
+            }
+
+            // Fall back to first available if no "real" devices found
+            if (audioInputs.length > 0) {
+                return audioInputs[0].deviceId;
+            }
+
+            return undefined;
+        } catch (error) {
+            console.error('[useMicrophoneStream] Failed to enumerate devices:', error);
+            return undefined;
+        }
+    }, []);
+
+    const acquireStream = useCallback(async (deviceId?: string) => {
+        // If stream already exists and is live, reuse it
+        if (streamRef.current && streamRef.current.getAudioTracks()[0]?.readyState === 'live') {
+            return streamRef.current;
+        }
+
+        try {
+            // If no device specified, find a real microphone
+            let effectiveDeviceId = deviceId;
+            if (!effectiveDeviceId) {
+                effectiveDeviceId = await findRealMicrophoneDevice();
+            }
+
+            const audioConstraints: MediaStreamConstraints['audio'] = effectiveDeviceId
+                ? { deviceId: { exact: effectiveDeviceId } }
+                : true;
+            const newStream = await navigator.mediaDevices.getUserMedia({ audio: audioConstraints });
+            setStream(newStream);
+            streamRef.current = newStream;
+            return newStream;
+        } catch (error) {
+            console.error('[useMicrophoneStream] Failed to acquire microphone:', error);
+            throw error;
+        }
+    }, [findRealMicrophoneDevice]);
+
+    const prepareStream = useCallback(async () => {
+        if (!isEnabled) return;
+
+        try {
+            const stream = await acquireStream(selectedDeviceId);
+            const track = stream.getAudioTracks()[0];
+            console.log('[useMicrophoneStream] Stream prepared before connect', {
+                selectedDeviceId,
+                trackId: track?.id,
+                trackLabel: track?.label,
+                trackReadyState: track?.readyState,
+                trackEnabled: track?.enabled,
+                trackMuted: track?.muted,
+            });
+        } catch (error) {
+            console.error('[useMicrophoneStream] Failed to prepare stream:', error);
+            throw error;
+        }
+    }, [isEnabled, acquireStream, selectedDeviceId]);
+
+    const releaseStream = useCallback(() => {
+        if (streamRef.current) {
+            streamRef.current.getTracks().forEach(track => track.stop());
+            streamRef.current = undefined;
+            setStream(undefined);
+        }
+    }, []);
+
+    const updateAudioDevices = useCallback(async () => {
+        try {
+            if (!streamRef.current) {
+                const permissionStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+                permissionStream.getTracks().forEach(t => t.stop());
+            }
+
+            const devices = await navigator.mediaDevices.enumerateDevices();
+            const audioInputs = devices.filter(device => device.kind === 'audioinput');
+
+            const realDevices = audioInputs.filter(
+                device =>
+                    !device.label.toLowerCase().includes('blackhole') &&
+                    !device.label.toLowerCase().includes('virtual')
+            );
+
+            const devicesToShow = realDevices.length > 0 ? realDevices : audioInputs;
+            setAudioDevices(devicesToShow);
+
+            if (devicesToShow.length > 0 && !selectedDeviceId) {
+                setSelectedDeviceId(devicesToShow[0].deviceId);
+            }
+        } catch (error) {
+            console.error('[useMicrophoneStream] Failed to enumerate audio devices:', error);
+        }
+    }, [selectedDeviceId]);
+
+    const mute = useCallback(async () => {
+        if (!muteMicrophoneStream) {
+            console.warn('[useMicrophoneStream] muteMicrophoneStream not available');
+            return;
+        }
+        try {
+            await muteMicrophoneStream();
+            setIsMuted(true);
+        } catch (error) {
+            console.error('[useMicrophoneStream] Failed to mute:', error);
+            throw error;
+        }
+    }, [muteMicrophoneStream]);
+
+    const unmute = useCallback(async () => {
+        if (!unmuteMicrophoneStream) {
+            console.warn('[useMicrophoneStream] unmuteMicrophoneStream not available');
+            return;
+        }
+        try {
+            await unmuteMicrophoneStream();
+            setIsMuted(false);
+        } catch (error) {
+            console.error('[useMicrophoneStream] Failed to unmute:', error);
+            throw error;
+        }
+    }, [unmuteMicrophoneStream]);
+
+    const publish = useCallback(async () => {
+        if (!publishMicrophoneStream) {
+            console.warn('[useMicrophoneStream] publishMicrophoneStream not available');
+            return;
+        }
+
+        // Guard against double-publish race condition
+        if (isPublishingRef.current) {
+            console.log('[useMicrophoneStream] Already publishing, skipping');
+            return;
+        }
+        isPublishingRef.current = true;
+
+        try {
+            // Acquire stream if not already acquired
+            let currentStream = streamRef.current;
+            if (!currentStream) {
+                console.log('[useMicrophoneStream] No existing stream, acquiring new one');
+                currentStream = await acquireStream(selectedDeviceId);
+            }
+
+            const track = currentStream.getAudioTracks()[0];
+            console.log('[useMicrophoneStream] Publishing stream', {
+                streamId: currentStream.id,
+                trackId: track?.id,
+                trackLabel: track?.label,
+                trackReadyState: track?.readyState,
+                trackEnabled: track?.enabled,
+                trackMuted: track?.muted,
+            });
+
+            await publishMicrophoneStream(currentStream);
+            setIsPublished(true);
+            setIsMuted(false);
+        } catch (error) {
+            console.error('[useMicrophoneStream] Failed to publish:', error);
+            throw error;
+        } finally {
+            isPublishingRef.current = false;
+        }
+    }, [publishMicrophoneStream, acquireStream, selectedDeviceId]);
+
+    const unpublish = useCallback(async () => {
+        if (!unpublishMicrophoneStream) {
+            console.warn('[useMicrophoneStream] unpublishMicrophoneStream not available');
+            return;
+        }
+
+        try {
+            await unpublishMicrophoneStream();
+            setIsPublished(false);
+            setIsMuted(false);
+        } catch (error) {
+            console.error('[useMicrophoneStream] Failed to unpublish:', error);
+            throw error;
+        }
+    }, [unpublishMicrophoneStream]);
+
+    // Toggle microphone (enable/disable from UI)
+    const toggle = useCallback(
+        async (enabled: boolean) => {
+            setIsEnabled(enabled);
+
+            // If not connected, just update the preference
+            if (connectionState !== ConnectionState.Connected) {
+                return;
+            }
+
+            if (enabled) {
+                if (!isPublished) {
+                    // First time enabling - publish
+                    await publish();
+                } else if (isMuted) {
+                    // Already published but muted - unmute
+                    await unmute();
+                }
+            } else {
+                if (isPublished && !isMuted) {
+                    // Mute (keep track alive for fast unmute)
+                    await mute();
+                }
+            }
+        },
+        [connectionState, isPublished, isMuted, publish, unpublish, mute, unmute]
+    );
+
+    // Reset state on disconnect
+    useEffect(() => {
+        if (connectionState === ConnectionState.New || connectionState === ConnectionState.Disconnected) {
+            setIsPublished(false);
+            setIsMuted(false);
+            // Release stream on disconnect
+            releaseStream();
+        }
+    }, [connectionState, releaseStream]);
+
+    // Auto-publish on connect if enabled
+    useEffect(() => {
+        if (
+            connectionState === ConnectionState.Connected &&
+            isEnabled &&
+            microphoneSupported &&
+            publishMicrophoneStream &&
+            !isPublished
+        ) {
+            console.log('[useMicrophoneStream] Auto-publishing microphone...');
+            publish().catch(error => {
+                console.error('[useMicrophoneStream] Auto-publish failed:', error);
+            });
+        }
+    }, [connectionState, isEnabled, microphoneSupported, publishMicrophoneStream, isPublished, publish]);
+
+    useEffect(() => {
+        if (isEnabled && microphoneSupported && streamRef.current) {
+            updateAudioDevices();
+        }
+    }, [isEnabled, microphoneSupported, stream, updateAudioDevices]);
+
+    useEffect(() => {
+        return releaseStream;
+    }, [releaseStream]);
+
+    return {
+        isEnabled,
+        isPublished,
+        isMuted,
+        stream,
+        audioDevices,
+        selectedDeviceId,
+
+        setSelectedDeviceId,
+        toggle,
+        mute,
+        unmute,
+        publish,
+        unpublish,
+        prepareStream, // Call before connect() to acquire stream early
+    };
+}

--- a/src/services/agent-manager/index.ts
+++ b/src/services/agent-manager/index.ts
@@ -287,6 +287,18 @@ export async function createAgentManager(agent: string, options: AgentManagerOpt
             }
             return items.streamingManager.unpublishMicrophoneStream();
         },
+        async muteMicrophoneStream() {
+            if (!items.streamingManager?.muteMicrophoneStream) {
+                throw new Error('muteMicrophoneStream is not available for this streaming manager');
+            }
+            return items.streamingManager.muteMicrophoneStream();
+        },
+        async unmuteMicrophoneStream() {
+            if (!items.streamingManager?.unmuteMicrophoneStream) {
+                throw new Error('unmuteMicrophoneStream is not available for this streaming manager');
+            }
+            return items.streamingManager.unmuteMicrophoneStream();
+        },
         async chat(userMessage: string) {
             const validateChatRequest = () => {
                 if (isChatModeWithoutChat(mode)) {

--- a/src/services/streaming-manager/common.ts
+++ b/src/services/streaming-manager/common.ts
@@ -48,6 +48,20 @@ export type StreamingManager<T extends CreateStreamOptions | CreateSessionV2Opti
     unpublishMicrophoneStream?(): Promise<void>;
 
     /**
+     * Mute the currently published microphone stream
+     * Fast operation that keeps the track published but stops sending audio
+     * supported only for livekit manager
+     */
+    muteMicrophoneStream?(): Promise<void>;
+
+    /**
+     * Unmute the currently published microphone stream
+     * Fast operation that resumes sending audio on the published track
+     * supported only for livekit manager
+     */
+    unmuteMicrophoneStream?(): Promise<void>;
+
+    /**
      * Session identifier information, should be returned in the body of all streaming requests
      */
     sessionId: string;

--- a/src/services/streaming-manager/livekit-manager.test.ts
+++ b/src/services/streaming-manager/livekit-manager.test.ts
@@ -113,11 +113,18 @@ function createMockAudioTrack(id: string = TEST_AUDIO_TRACK_ID, additionalProps:
     } as any;
 }
 
+function createMockSender() {
+    return {
+        replaceTrack: jest.fn().mockResolvedValue(undefined),
+    } as any;
+}
+
 function createMockTrack(id: string = TEST_AUDIO_TRACK_ID, mediaStreamTrack?: MediaStreamTrack) {
     return {
         kind: 'audio',
         id,
         mediaStreamTrack: mediaStreamTrack || createMockAudioTrack(id),
+        sender: createMockSender(),
     } as any;
 }
 
@@ -379,6 +386,106 @@ describe('LiveKit Streaming Manager - Microphone Stream', () => {
 
             // Try to publish before connection
             await expect(manager.publishMicrophoneStream?.(mockStream)).rejects.toThrow('Room is not connected');
+        });
+    });
+
+    describe('Microphone Stream Mute/Unmute', () => {
+        it('should mute microphone track by replacing with null via RTCRtpSender', async () => {
+            const mockAudioTrack = createMockAudioTrack();
+            const mockStream = createMockStream([mockAudioTrack]);
+            const mockPublication = createMockPublication();
+            mockPublishTrack.mockResolvedValue(mockPublication);
+
+            const manager = await createLiveKitStreamingManager(agentId, sessionOptions, options);
+            await simulateConnection();
+
+            await manager.publishMicrophoneStream?.(mockStream);
+            await manager.muteMicrophoneStream?.();
+
+            expect(mockPublication.track.sender.replaceTrack).toHaveBeenCalledWith(null);
+        });
+
+        it('should unmute microphone track by replacing with mediaStreamTrack via RTCRtpSender', async () => {
+            const mockAudioTrack = createMockAudioTrack();
+            const mockStream = createMockStream([mockAudioTrack]);
+            const mockPublication = createMockPublication();
+            mockPublishTrack.mockResolvedValue(mockPublication);
+
+            const manager = await createLiveKitStreamingManager(agentId, sessionOptions, options);
+            await simulateConnection();
+
+            await manager.publishMicrophoneStream?.(mockStream);
+            await manager.muteMicrophoneStream?.();
+            await manager.unmuteMicrophoneStream?.();
+
+            // First call is mute (null), second call is unmute (track.mediaStreamTrack)
+            expect(mockPublication.track.sender.replaceTrack).toHaveBeenCalledTimes(2);
+            expect(mockPublication.track.sender.replaceTrack).toHaveBeenLastCalledWith(mockPublication.track.mediaStreamTrack);
+        });
+
+        it('should not throw when muting without published track', async () => {
+            const manager = await createLiveKitStreamingManager(agentId, sessionOptions, options);
+            await simulateConnection();
+
+            await expect(manager.muteMicrophoneStream?.()).resolves.not.toThrow();
+        });
+
+        it('should not throw when unmuting without published track', async () => {
+            const manager = await createLiveKitStreamingManager(agentId, sessionOptions, options);
+            await simulateConnection();
+
+            await expect(manager.unmuteMicrophoneStream?.()).resolves.not.toThrow();
+        });
+
+        it('should throw error when mute fails', async () => {
+            const mockAudioTrack = createMockAudioTrack();
+            const mockStream = createMockStream([mockAudioTrack]);
+            const mockPublication = createMockPublication();
+            mockPublication.track.sender.replaceTrack = jest.fn().mockRejectedValue(new Error('Mute failed'));
+            mockPublishTrack.mockResolvedValue(mockPublication);
+
+            const manager = await createLiveKitStreamingManager(agentId, sessionOptions, options);
+            await simulateConnection();
+
+            await manager.publishMicrophoneStream?.(mockStream);
+            await expect(manager.muteMicrophoneStream?.()).rejects.toThrow('Mute failed');
+        });
+
+        it('should throw error when unmute fails', async () => {
+            const mockAudioTrack = createMockAudioTrack();
+            const mockStream = createMockStream([mockAudioTrack]);
+            const mockPublication = createMockPublication();
+            // First call (mute) succeeds, second call (unmute) fails
+            mockPublication.track.sender.replaceTrack = jest.fn()
+                .mockResolvedValueOnce(undefined)
+                .mockRejectedValueOnce(new Error('Unmute failed'));
+            mockPublishTrack.mockResolvedValue(mockPublication);
+
+            const manager = await createLiveKitStreamingManager(agentId, sessionOptions, options);
+            await simulateConnection();
+
+            await manager.publishMicrophoneStream?.(mockStream);
+            await manager.muteMicrophoneStream?.();
+            await expect(manager.unmuteMicrophoneStream?.()).rejects.toThrow('Unmute failed');
+        });
+
+        it('should allow multiple mute/unmute cycles', async () => {
+            const mockAudioTrack = createMockAudioTrack();
+            const mockStream = createMockStream([mockAudioTrack]);
+            const mockPublication = createMockPublication();
+            mockPublishTrack.mockResolvedValue(mockPublication);
+
+            const manager = await createLiveKitStreamingManager(agentId, sessionOptions, options);
+            await simulateConnection();
+
+            await manager.publishMicrophoneStream?.(mockStream);
+            await manager.muteMicrophoneStream?.();
+            await manager.unmuteMicrophoneStream?.();
+            await manager.muteMicrophoneStream?.();
+            await manager.unmuteMicrophoneStream?.();
+
+            // 2 mutes (null) + 2 unmutes (original track) = 4 calls
+            expect(mockPublication.track.sender.replaceTrack).toHaveBeenCalledTimes(4);
         });
     });
 

--- a/src/services/streaming-manager/livekit-manager.ts
+++ b/src/services/streaming-manager/livekit-manager.ts
@@ -90,7 +90,7 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
 ): Promise<StreamingManager<T> & { reconnect(): Promise<void> }> {
     const log = createStreamingLogger(options.debug || false, 'LiveKitStreamingManager');
 
-    const { Room, RoomEvent, ConnectionState: LiveKitConnectionState } = await importLiveKit();
+    const { Room, RoomEvent, ConnectionState: LiveKitConnectionState, Track } = await importLiveKit();
 
     const { callbacks, auth, baseURL, analytics, microphoneStream } = options;
     let room: Room | null = null;
@@ -372,10 +372,9 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
         log('Track subscription failed:', { trackSid, participant, reason });
     }
 
-    async function findPublishedMicrophoneTrack(audioTrack: MediaStreamTrack): Promise<LocalTrackPublication | null> {
+    function findPublishedMicrophoneTrack(audioTrack: MediaStreamTrack): LocalTrackPublication | null {
         if (!room) return null;
 
-        const { Track } = await importLiveKit();
         const publishedTracks = room.localParticipant.audioTrackPublications;
 
         if (publishedTracks) {
@@ -418,9 +417,8 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
         }
 
         const audioTrack = audioTracks[0];
-        const { Track } = await importLiveKit();
 
-        const existingPublication = await findPublishedMicrophoneTrack(audioTrack);
+        const existingPublication = findPublishedMicrophoneTrack(audioTrack);
         if (existingPublication) {
             log('Microphone track is already published, skipping', {
                 trackId: audioTrack.id,

--- a/src/types/entities/agents/manager.ts
+++ b/src/types/entities/agents/manager.ts
@@ -218,6 +218,18 @@ export interface AgentManager {
      */
     unpublishMicrophoneStream?: () => Promise<void>;
     /**
+     * Mute the currently published microphone stream
+     * Fast operation that keeps the track published but stops sending audio
+     * supported only for livekit manager
+     */
+    muteMicrophoneStream?: () => Promise<void>;
+    /**
+     * Unmute the currently published microphone stream
+     * Fast operation that resumes sending audio on the published track
+     * supported only for livekit manager
+     */
+    unmuteMicrophoneStream?: () => Promise<void>;
+    /**
      * Method to send a chat message to existing chat with the agent
      * @param messages
      */


### PR DESCRIPTION
Fixing mute/unmute microphone issues

Add light functionality that doesn't close the stream publication but replaces the current track with null

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces first-class microphone mute/unmute and centralizes mic management.
> 
> - Adds `muteMicrophoneStream`/`unmuteMicrophoneStream` across `StreamingManager`, `LiveKit` manager, `agent-manager`, and types; LiveKit implementation uses `RTCRtpSender.replaceTrack(null|mediaStreamTrack)` to mute/unmute without unpublishing
> - New `useMicrophoneStream` hook consolidates device selection, acquisition, publish/unpublish, and mute/unmute; `demo/app.tsx` rewired UI to this hook and simplified legacy mic logic
> - Extends tests in `livekit-manager.test.ts` to cover mute/unmute flows, error cases, and multiple cycles
> 
> - Minor refactors: remove `isMicrophonePublished`, streamline device enumeration, and avoid redundant LiveKit imports
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76d0783f24fcddb100314058936bdf974f49268e. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->