### PR TITLE
chore: remove triggersAvailable from SDK

### DIFF
--- a/src/services/agent-manager/index.ts
+++ b/src/services/agent-manager/index.ts
@@ -232,7 +232,6 @@ export async function createAgentManager(agent: string, options: AgentManagerOpt
         agent: agentEntity,
         getStreamType: () => items.streamingManager?.streamType,
         getIsInterruptAvailable: () => items.streamingManager?.interruptAvailable ?? false,
-        getIsTriggersAvailable: () => items.streamingManager?.triggersAvailable ?? false,
         starterMessages: agentEntity.knowledge?.starter_message || [],
         getSTTToken: () => agentsApi.getSTTToken(agentEntity.id),
         changeMode,

--- a/src/services/streaming-manager/common.ts
+++ b/src/services/streaming-manager/common.ts
@@ -86,8 +86,4 @@ export type StreamingManager<T extends CreateStreamOptions | CreateSessionV2Opti
      */
     isInterruptible: boolean;
 
-    /**
-     * Whether triggers functionality is available for this stream
-     */
-    triggersAvailable: boolean;
 };

--- a/src/services/streaming-manager/common.ts
+++ b/src/services/streaming-manager/common.ts
@@ -85,5 +85,4 @@ export type StreamingManager<T extends CreateStreamOptions | CreateSessionV2Opti
      * Whether the current stream segment can be interrupted by the user
      */
     isInterruptible: boolean;
-
 };

--- a/src/services/streaming-manager/livekit-manager.ts
+++ b/src/services/streaming-manager/livekit-manager.ts
@@ -724,7 +724,6 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
         streamType,
         interruptAvailable: true,
         isInterruptible: currentInterruptible,
-        triggersAvailable: false,
     };
 }
 

--- a/src/services/streaming-manager/webrtc-manager.ts
+++ b/src/services/streaming-manager/webrtc-manager.ts
@@ -170,7 +170,6 @@ export async function createWebRTCStreamingManager<T extends CreateStreamOptions
         session_id,
         fluent,
         interrupt_enabled: interruptAvailable,
-        triggers_enabled: triggersAvailable,
     } = await createStream(streamOptions, signal);
     callbacks.onStreamCreated?.({ stream_id: streamIdFromServer, session_id: session_id as string, agent_id: agentId });
     const peerConnection = new actualRTCPC({ iceServers: ice_servers });
@@ -398,7 +397,6 @@ export async function createWebRTCStreamingManager<T extends CreateStreamOptions
         streamType,
         interruptAvailable: interruptAvailable ?? false,
         isInterruptible: true,
-        triggersAvailable: triggersAvailable ?? false,
     };
 }
 

--- a/src/types/entities/agents/manager.ts
+++ b/src/types/entities/agents/manager.ts
@@ -195,11 +195,6 @@ export interface AgentManager {
     getIsInterruptAvailable: () => boolean;
 
     /**
-     * Get if the stream supports triggers
-     */
-    getIsTriggersAvailable: () => boolean;
-
-    /**
      * Array of starter messages that will be sent to the agent when the chat starts
      */
     starterMessages: string[];

--- a/src/types/stream/rtc.ts
+++ b/src/types/stream/rtc.ts
@@ -39,7 +39,6 @@ export interface ICreateStreamRequestResponse extends StickyRequest {
     ice_servers: IceServer[];
     fluent?: boolean;
     interrupt_enabled?: boolean;
-    triggers_enabled?: boolean;
 }
 
 export interface IceCandidate {


### PR DESCRIPTION
### Pull Request Type

🧹 Chore

### Description
- Remove `triggers_enabled` from `ICreateStreamRequestResponse` type
- Remove `triggersAvailable` from `StreamingManager` type
- Remove destructuring/returning of `triggersAvailable` in `webrtc-manager.ts` and `livekit-manager.ts`
- Remove `getIsTriggersAvailable` from agent manager interface and implementation
- Triggers availability is now computed in agents-ui directly from the agent object

### Reference Links
-   [Asana](https://app.asana.com/1/856614567666442/project/1213658929732899/task/1213653051036791)