### PR TITLE
feature: Add client tool registration via LiveKit RPC

### DIFF
--- a/src/services/agent-manager/index.test.ts
+++ b/src/services/agent-manager/index.test.ts
@@ -832,4 +832,75 @@ describe('createAgentManager', () => {
             });
         });
     });
+
+    describe('registerClientTool', () => {
+        let manager: AgentManager;
+
+        beforeEach(async () => {
+            mockStreamingManager.registerRpcMethod = jest.fn();
+            mockStreamingManager.unregisterRpcMethod = jest.fn();
+            manager = await createAgentManager('agent-123', mockOptions);
+        });
+
+        it('should register tool and call registerRpcMethod after connect', async () => {
+            const handler = jest.fn().mockResolvedValue('result');
+
+            await manager.connect();
+            manager.registerClientTool('testTool', handler);
+
+            expect(mockStreamingManager.registerRpcMethod).toHaveBeenCalledWith('testTool', expect.any(Function));
+        });
+
+        it('should buffer tool registration before connect and flush on connect', async () => {
+            const handler = jest.fn().mockResolvedValue('result');
+
+            manager.registerClientTool('testTool', handler);
+            expect(mockStreamingManager.registerRpcMethod).not.toHaveBeenCalled();
+
+            await manager.connect();
+            expect(mockStreamingManager.registerRpcMethod).toHaveBeenCalledWith('testTool', expect.any(Function));
+        });
+
+        it('should not call registerRpcMethod twice for same tool name', async () => {
+            const handler1 = jest.fn().mockResolvedValue('result1');
+            const handler2 = jest.fn().mockResolvedValue('result2');
+
+            await manager.connect();
+            manager.registerClientTool('testTool', handler1);
+            manager.registerClientTool('testTool', handler2);
+
+            expect(mockStreamingManager.registerRpcMethod).toHaveBeenCalledTimes(1);
+        });
+
+        it('should unregister tool from map and room', async () => {
+            const handler = jest.fn().mockResolvedValue('result');
+
+            await manager.connect();
+            manager.registerClientTool('testTool', handler);
+            manager.unregisterClientTool('testTool');
+
+            expect(mockStreamingManager.unregisterRpcMethod).toHaveBeenCalledWith('testTool');
+        });
+
+        it('should invoke latest handler when RPC is called after re-registration', async () => {
+            const handler1 = jest.fn().mockResolvedValue('result1');
+            const handler2 = jest.fn().mockResolvedValue('result2');
+
+            await manager.connect();
+            manager.registerClientTool('testTool', handler1);
+
+            // Get the RPC handler that was registered
+            const rpcHandler = mockStreamingManager.registerRpcMethod.mock.calls[0][1];
+
+            // Re-register with new handler (same name — only updates Map)
+            manager.registerClientTool('testTool', handler2);
+
+            // Invoke the RPC handler — should use handler2 from Map
+            const result = await rpcHandler({ payload: '{"key": "val"}' });
+
+            expect(handler1).not.toHaveBeenCalled();
+            expect(handler2).toHaveBeenCalledWith({ key: 'val' });
+            expect(result).toBe('result2');
+        });
+    });
 });

--- a/src/services/agent-manager/index.ts
+++ b/src/services/agent-manager/index.ts
@@ -5,6 +5,7 @@ import {
     Chat,
     ChatMode,
     ChatResponse,
+    ClientToolHandler,
     ConnectionState,
     CreateSessionV2Options,
     CreateStreamOptions,
@@ -128,6 +129,43 @@ export async function createAgentManager(agent: string, options: AgentManagerOpt
         }
     };
 
+    const clientToolHandlers = new Map<string, ClientToolHandler>();
+
+    function createRpcHandler(toolName: string) {
+        return async (data: { payload: string }): Promise<string> => {
+            const handler = clientToolHandlers.get(toolName);
+            if (!handler) {
+                throw new Error(`No handler registered for client tool: ${toolName}`);
+            }
+            try {
+                const args = JSON.parse(data.payload);
+                return await handler(args);
+            } catch (error) {
+                throw new Error(`Client tool "${toolName}" failed: ${(error as Error).message}`);
+            }
+        };
+    }
+
+    function flushClientToolsToRoom() {
+        for (const [name] of clientToolHandlers) {
+            items.streamingManager?.unregisterRpcMethod?.(name);
+            items.streamingManager?.registerRpcMethod?.(name, createRpcHandler(name));
+        }
+    }
+
+    function registerClientTool(name: string, handler: ClientToolHandler): void {
+        const isNew = !clientToolHandlers.has(name);
+        clientToolHandlers.set(name, handler);
+        if (isNew) {
+            items.streamingManager?.registerRpcMethod?.(name, createRpcHandler(name));
+        }
+    }
+
+    function unregisterClientTool(name: string): void {
+        clientToolHandlers.delete(name);
+        items.streamingManager?.unregisterRpcMethod?.(name);
+    }
+
     const loadedTimestamp = Date.now();
     defer(() => {
         analytics.track('agent-sdk', { event: 'loaded', ...getAnalyticsInfo(agentEntity) }, loadedTimestamp);
@@ -196,6 +234,8 @@ export async function createAgentManager(agent: string, options: AgentManagerOpt
         items.streamingManager = streamingManager;
         items.socketManager = socketManager;
         items.chat = chat;
+
+        flushClientToolsToRoom();
 
         firstConnection = false;
 
@@ -554,5 +594,7 @@ export async function createAgentManager(agent: string, options: AgentManagerOpt
             });
         },
         interrupt,
+        registerClientTool,
+        unregisterClientTool,
     };
 }

--- a/src/services/streaming-manager/common.ts
+++ b/src/services/streaming-manager/common.ts
@@ -85,4 +85,17 @@ export type StreamingManager<T extends CreateStreamOptions | CreateSessionV2Opti
      * Whether the current stream segment can be interrupted by the user
      */
     isInterruptible: boolean;
+
+    /**
+     * Register an RPC method handler on the LiveKit room.
+     * Used internally by the agent-manager for client tool delegation.
+     * supported only for livekit manager
+     */
+    registerRpcMethod?(method: string, handler: (data: any) => Promise<string>): void;
+
+    /**
+     * Unregister a previously registered RPC method.
+     * supported only for livekit manager
+     */
+    unregisterRpcMethod?(method: string): void;
 };

--- a/src/services/streaming-manager/livekit-manager.ts
+++ b/src/services/streaming-manager/livekit-manager.ts
@@ -721,6 +721,13 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
         publishCameraStream,
         unpublishCameraStream,
 
+        registerRpcMethod(method: string, handler: (data: any) => Promise<string>) {
+            room?.registerRpcMethod(method, handler);
+        },
+        unregisterRpcMethod(method: string) {
+            room?.unregisterRpcMethod(method);
+        },
+
         sessionId,
         streamId: sessionId,
         streamType,

--- a/src/types/entities/agents/manager.ts
+++ b/src/types/entities/agents/manager.ts
@@ -2,6 +2,7 @@ import { STTTokenResponse } from '@sdk/types';
 import { Auth } from '@sdk/types/auth';
 import {
     AgentActivityState,
+    ClientToolHandler,
     CompatibilityMode,
     ConnectionState,
     ConnectivityState,
@@ -279,4 +280,18 @@ export interface AgentManager {
      * Only available for Fluent streams and when there's an active video to interrupt
      */
     interrupt: (interrupt: Interrupt) => void;
+
+    /**
+     * Register a handler for a client tool. When the agent's LLM calls this tool,
+     * the handler executes on the client and returns the result to the LLM.
+     * @param name - Tool name (must match the tool name defined in the agent config)
+     * @param handler - Async function receiving args, must return a JSON string (max 15KiB)
+     */
+    registerClientTool: (name: string, handler: ClientToolHandler) => void;
+
+    /**
+     * Remove a previously registered client tool handler.
+     * @param name - Tool name to unregister
+     */
+    unregisterClientTool: (name: string) => void;
 }

--- a/src/types/stream/stream.ts
+++ b/src/types/stream/stream.ts
@@ -194,6 +194,8 @@ export interface StreamInterruptPayload {
     timestamp: number;
 }
 
+export type ClientToolHandler = (args: Record<string, unknown>) => Promise<string>;
+
 export interface ToolCallingPayload {
     execution_id: string;
     tool_name: string;


### PR DESCRIPTION
### Pull Request Type

🔮 Feature

### Description

- Add `registerClientTool` / `unregisterClientTool` to `AgentManager` for client-side tool handler registration
- Each tool is registered as a per-tool RPC method on the LiveKit room via `StreamingManager.registerRpcMethod`
- Map-based reconnect safety net — tools are re-flushed to new rooms on hard reconnect
- `ClientToolHandler` type exported for consumer use
- RPC handler reads from Map at call time — re-registration with same name updates handler without touching the room

### Reference Links

- [Asana](https://app.asana.com/1/856614567666442/project/1213882276505882/task/1213878307928494)