### PR TITLE
fix: no-op unpublish when streaming manager is unavailable

### DIFF
--- a/src/services/agent-manager/index.test.ts
+++ b/src/services/agent-manager/index.test.ts
@@ -743,12 +743,10 @@ describe('createAgentManager', () => {
             expect(mockUnpublish).toHaveBeenCalled();
         });
 
-        it('should throw error when unpublishMicrophoneStream is not available', async () => {
+        it('should no-op when unpublishMicrophoneStream is not available', async () => {
             mockStreamingManager.unpublishMicrophoneStream = undefined;
 
-            await expect(manager.unpublishMicrophoneStream?.()).rejects.toThrow(
-                'unpublishMicrophoneStream is not available for this streaming manager'
-            );
+            await expect(manager.unpublishMicrophoneStream?.()).resolves.toBeUndefined();
         });
     });
 
@@ -796,12 +794,10 @@ describe('createAgentManager', () => {
             expect(mockUnpublish).toHaveBeenCalled();
         });
 
-        it('should throw error when unpublishCameraStream is not available', async () => {
+        it('should no-op when unpublishCameraStream is not available', async () => {
             mockStreamingManager.unpublishCameraStream = undefined;
 
-            await expect(manager.unpublishCameraStream?.()).rejects.toThrow(
-                'unpublishCameraStream is not available for this streaming manager'
-            );
+            await expect(manager.unpublishCameraStream?.()).resolves.toBeUndefined();
         });
     });
 

--- a/src/services/agent-manager/index.ts
+++ b/src/services/agent-manager/index.ts
@@ -288,7 +288,7 @@ export async function createAgentManager(agent: string, options: AgentManagerOpt
         },
         async unpublishMicrophoneStream() {
             if (!items.streamingManager?.unpublishMicrophoneStream) {
-                throw new Error('unpublishMicrophoneStream is not available for this streaming manager');
+                return;
             }
             return items.streamingManager.unpublishMicrophoneStream();
         },
@@ -300,7 +300,7 @@ export async function createAgentManager(agent: string, options: AgentManagerOpt
         },
         async unpublishCameraStream() {
             if (!items.streamingManager?.unpublishCameraStream) {
-                throw new Error('unpublishCameraStream is not available for this streaming manager');
+                return;
             }
             return items.streamingManager.unpublishCameraStream();
         },


### PR DESCRIPTION
## BugFix

- **unpublish mic/camera calls now return early** instead of throwing when the streaming manager is already torn down
- During session restart, the SDK's own `disconnect()` already unpublishes streams. When the UI cleanup effects then call unpublish a second time, the streaming manager has been deleted — causing a console error: `"unpublishMicrophoneStream is not available for this streaming manager"`
- Making these calls idempotent eliminates the spurious error without changing behavior for the normal (connected) case

## Reference Links

N/A