### PR TITLE
fix: preserve multiple assistant messages within the same turn

### DIFF
--- a/src/services/socket-manager/message-queue.test.ts
+++ b/src/services/socket-manager/message-queue.test.ts
@@ -232,4 +232,127 @@ describe('createMessageEventQueue', () => {
             expect(lastMessage.content).toBe('Fresh');
         });
     });
+
+    describe('multi-message assistant turns', () => {
+        beforeEach(() => {
+            mockItems.messages.push({
+                id: 'user-1',
+                role: 'user',
+                content: 'please book a meeting',
+                created_at: new Date().toISOString(),
+                transcribed: true,
+            });
+        });
+
+        it('should append a new assistant message when answer arrives with a different id', () => {
+            const { onMessage } = createMessageEventQueue(
+                mockAnalytics,
+                mockItems,
+                mockOptions,
+                mockAgent,
+                mockOnStreamDone
+            );
+
+            onMessage(ChatProgress.Answer, { id: 'assistant-1', content: "ok, i'll book a meeting" });
+            onMessage(ChatProgress.Answer, { id: 'assistant-2', content: 'i booked a meeting for you' });
+
+            const assistantMessages = mockItems.messages.filter(m => m.role === 'assistant');
+            expect(assistantMessages).toHaveLength(2);
+            expect(assistantMessages[0].id).toBe('assistant-1');
+            expect(assistantMessages[0].content).toBe("ok, i'll book a meeting");
+            expect(assistantMessages[1].id).toBe('assistant-2');
+            expect(assistantMessages[1].content).toBe('i booked a meeting for you');
+        });
+
+        it('should preserve the first assistant message when a second arrives after a tool call', () => {
+            const { onMessage } = createMessageEventQueue(
+                mockAnalytics,
+                mockItems,
+                mockOptions,
+                mockAgent,
+                mockOnStreamDone
+            );
+
+            onMessage(ChatProgress.Answer, { id: 'assistant-1', content: "ok, i'll book a meeting" });
+            // ToolCalling / ToolResult events are dispatched via a separate callback and do not
+            // touch messages; simulating that gap here means the next answer event arrives with
+            // a fresh id.
+            onMessage(ChatProgress.Answer, { id: 'assistant-2', content: 'i booked a meeting for you' });
+
+            expect(mockItems.messages.map(m => m.content)).toEqual([
+                'please book a meeting',
+                "ok, i'll book a meeting",
+                'i booked a meeting for you',
+            ]);
+        });
+
+        it('should overwrite the last assistant message when answer has the same id', () => {
+            const { onMessage } = createMessageEventQueue(
+                mockAnalytics,
+                mockItems,
+                mockOptions,
+                mockAgent,
+                mockOnStreamDone
+            );
+
+            onMessage(ChatProgress.Answer, { id: 'assistant-1', content: 'first draft' });
+            onMessage(ChatProgress.Answer, { id: 'assistant-1', content: 'final answer' });
+
+            const assistantMessages = mockItems.messages.filter(m => m.role === 'assistant');
+            expect(assistantMessages).toHaveLength(1);
+            expect(assistantMessages[0].content).toBe('final answer');
+        });
+
+        it('should overwrite the last assistant message when answer has no id (legacy backends)', () => {
+            const { onMessage } = createMessageEventQueue(
+                mockAnalytics,
+                mockItems,
+                mockOptions,
+                mockAgent,
+                mockOnStreamDone
+            );
+
+            onMessage(ChatProgress.Answer, { content: 'first' });
+            onMessage(ChatProgress.Answer, { content: 'second' });
+
+            const assistantMessages = mockItems.messages.filter(m => m.role === 'assistant');
+            expect(assistantMessages).toHaveLength(1);
+            expect(assistantMessages[0].content).toBe('second');
+        });
+
+        it('should not leak content from the previous assistant message into the new one', () => {
+            const { onMessage } = createMessageEventQueue(
+                mockAnalytics,
+                mockItems,
+                mockOptions,
+                mockAgent,
+                mockOnStreamDone
+            );
+
+            onMessage(ChatProgress.Answer, { id: 'assistant-1', content: "ok, i'll book a meeting" });
+            onMessage(ChatProgress.Answer, { id: 'assistant-2', content: 'done' });
+
+            const assistantMessages = mockItems.messages.filter(m => m.role === 'assistant');
+            expect(assistantMessages).toHaveLength(2);
+            expect(assistantMessages[1].content).toBe('done');
+            expect(assistantMessages[1].content).not.toContain("ok, i'll book");
+        });
+
+        it('should keep streaming partials into the same assistant message', () => {
+            const { onMessage } = createMessageEventQueue(
+                mockAnalytics,
+                mockItems,
+                mockOptions,
+                mockAgent,
+                mockOnStreamDone
+            );
+
+            onMessage(ChatProgress.Partial, { content: 'Hello', sequence: 0 });
+            onMessage(ChatProgress.Partial, { content: ' World', sequence: 1 });
+
+            const assistantMessages = mockItems.messages.filter(m => m.role === 'assistant');
+            expect(assistantMessages).toHaveLength(1);
+            expect(assistantMessages[0].content).toBe('Hello World');
+        });
+    });
 });

--- a/src/services/socket-manager/message-queue.test.ts
+++ b/src/services/socket-manager/message-queue.test.ts
@@ -354,5 +354,29 @@ describe('createMessageEventQueue', () => {
             expect(assistantMessages).toHaveLength(1);
             expect(assistantMessages[0].content).toBe('Hello World');
         });
+
+        it('should append a new assistant message when partials arrive with a different id', () => {
+            const { onMessage } = createMessageEventQueue(
+                mockAnalytics,
+                mockItems,
+                mockOptions,
+                mockAgent,
+                mockOnStreamDone
+            );
+
+            onMessage(ChatProgress.Partial, { id: 'assistant-1', content: 'first ', sequence: 0 });
+            onMessage(ChatProgress.Partial, { id: 'assistant-1', content: 'message', sequence: 1 });
+            onMessage(ChatProgress.Answer, { id: 'assistant-1', content: 'first message' });
+
+            onMessage(ChatProgress.Partial, { id: 'assistant-2', content: 'second ', sequence: 0 });
+            onMessage(ChatProgress.Partial, { id: 'assistant-2', content: 'message', sequence: 1 });
+            onMessage(ChatProgress.Answer, { id: 'assistant-2', content: 'second message' });
+
+            const assistantMessages = mockItems.messages.filter(m => m.role === 'assistant');
+            expect(assistantMessages).toHaveLength(2);
+            expect(assistantMessages[0].content).toBe('first message');
+            expect(assistantMessages[1].content).toBe('second message');
+            expect(assistantMessages[1].content).not.toContain('first');
+        });
     });
 });

--- a/src/services/socket-manager/message-queue.ts
+++ b/src/services/socket-manager/message-queue.ts
@@ -73,10 +73,7 @@ function processChatEvent(
     // assistant messages in a row) is signalled by an answer event whose `id` differs from the
     // last assistant message. Without this branch, the SDK overwrites the previous message.
     const isNewAssistantMessage =
-        event === ChatProgress.Answer &&
-        data.id &&
-        lastMessage?.role === 'assistant' &&
-        lastMessage.id !== data.id;
+        event === ChatProgress.Answer && data.id && lastMessage?.role === 'assistant' && lastMessage.id !== data.id;
 
     let currentMessage: Message;
     if (lastMessage?.transcribed && lastMessage.role === 'user') {

--- a/src/services/socket-manager/message-queue.ts
+++ b/src/services/socket-manager/message-queue.ts
@@ -55,7 +55,8 @@ function processChatEvent(
     data: any,
     chatEventQueue: ChatEventQueue,
     items: AgentManagerItems,
-    onNewMessage: AgentManagerOptions['callbacks']['onNewMessage']
+    onNewMessage: AgentManagerOptions['callbacks']['onNewMessage'],
+    clearQueue: () => void
 ) {
     if (event === ChatProgress.Transcribe && data.content) {
         handleAudioTranscribedMessage(data, items, onNewMessage);
@@ -68,11 +69,29 @@ function processChatEvent(
 
     const lastMessage = items.messages[items.messages.length - 1];
 
+    // A new assistant message within the same turn (e.g. after a client tool call, or several
+    // assistant messages in a row) is signalled by an answer event whose `id` differs from the
+    // last assistant message. Without this branch, the SDK overwrites the previous message.
+    const isNewAssistantMessage =
+        event === ChatProgress.Answer &&
+        data.id &&
+        lastMessage?.role === 'assistant' &&
+        lastMessage.id !== data.id;
+
     let currentMessage: Message;
     if (lastMessage?.transcribed && lastMessage.role === 'user') {
-        const initialContent = event === ChatProgress.Answer ? data.content || '' : '';
         currentMessage = {
             id: data.id || `assistant-${Date.now()}`,
+            role: data.role || 'assistant',
+            content: data.content || '',
+            created_at: data.created_at || new Date().toISOString(),
+        };
+        items.messages.push(currentMessage);
+    } else if (isNewAssistantMessage) {
+        // Reset the streaming buffer so the next message does not inherit the previous one's content.
+        clearQueue();
+        currentMessage = {
+            id: data.id,
             role: data.role || 'assistant',
             content: data.content || '',
             created_at: data.created_at || new Date().toISOString(),
@@ -129,7 +148,7 @@ export function createMessageEventQueue(
                         : event === StreamEvents.ChatAudioTranscribed
                           ? ChatProgress.Transcribe
                           : (event as ChatProgress);
-                processChatEvent(chatEvent, data, chatEventQueue, items, onNewMessage);
+                processChatEvent(chatEvent, data, chatEventQueue, items, onNewMessage, clearQueue);
 
                 if (chatEvent === ChatProgress.Answer) {
                     analytics.track('agent-message-received', {

--- a/src/services/socket-manager/message-queue.ts
+++ b/src/services/socket-manager/message-queue.ts
@@ -70,10 +70,11 @@ function processChatEvent(
     const lastMessage = items.messages[items.messages.length - 1];
 
     // A new assistant message within the same turn (e.g. after a client tool call, or several
-    // assistant messages in a row) is signalled by an answer event whose `id` differs from the
-    // last assistant message. Without this branch, the SDK overwrites the previous message.
-    const isNewAssistantMessage =
-        event === ChatProgress.Answer && data.id && lastMessage?.role === 'assistant' && lastMessage.id !== data.id;
+    // assistant messages in a row) is signalled by a chat event whose `id` differs from the
+    // last assistant message. The new message typically starts with `Partial` events and ends
+    // with `Answer`, so both branches must detect the id change — otherwise the SDK overwrites
+    // the previous message on the first partial of the new one.
+    const isNewAssistantMessage = data.id && lastMessage?.role === 'assistant' && lastMessage.id !== data.id;
 
     let currentMessage: Message;
     if (lastMessage?.transcribed && lastMessage.role === 'user') {
@@ -88,7 +89,7 @@ function processChatEvent(
         // Reset the streaming buffer so the next message does not inherit the previous one's content.
         clearQueue();
         currentMessage = {
-            id: data.id,
+            id: data.id || `assistant-${Date.now()}`,
             role: data.role || 'assistant',
             content: data.content || '',
             created_at: data.created_at || new Date().toISOString(),


### PR DESCRIPTION
## Summary

- Detects when a `chat/answer` event introduces a **new** assistant message (different `id`) vs. updates the current one (same/missing `id`), and appends instead of overwriting.
- Clears the streaming buffer when pushing the new message so its content does not inherit the previous message's partials.
- Backward compatible: answers with the same `id` or without `id` keep the existing overwrite behaviour.

## Problem

With client tools, the agent can emit more than one assistant message per turn:

```
user:      please book a meeting
assistant: ok, i'll book a meeting
[tool_call / tool_result]
assistant: i booked a meeting for you
```

The same also happens when the agent simply decides to send two assistant messages in a row without any tool call in between.

Today the SDK keeps only the last assistant message. In `processChatEvent`, when the last item in `items.messages` has role `assistant`, the code reuses it (`currentMessage = lastMessage`) and overwrites its `content`. The decision is based purely on role — the message `id` is never compared — so the first assistant message is silently replaced.

## Change

`src/services/socket-manager/message-queue.ts`: add an `isNewAssistantMessage` discriminator that fires only on `ChatProgress.Answer` when `data.id` is present and differs from the last assistant message's id. In that branch we `clearQueue()` (so `getMessageContent()` does not concatenate the previous message's answer into the new one) and push a fresh `Message`. `processChatEvent` now takes `clearQueue` as a parameter, wired from the closure in `createMessageEventQueue`.

## Caveats / follow-ups

- Assumes the backend emits distinct `id`s on `chat/answer` for distinct assistant messages. If the same `id` is sent twice, behaviour is unchanged (still overwrites) — which matches streaming partials semantics, so this is the right fallback. **Needs live verification** with a client-tool-enabled agent before merging out of draft.
- When the backend omits `id` entirely (legacy), we keep overwriting the last message. A covered test pins this behaviour.

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx jest --no-coverage` — 338/338 pass, includes 6 new cases under `multi-message assistant turns`:
  - append on distinct id
  - preserve first message across tool-call gap
  - overwrite on matching id
  - overwrite when id is missing (legacy)
  - no content leakage between messages
  - partial streaming still updates a single message
- [ ] Manual: run agent with a client tool, confirm both assistant bubbles render in the chat UI
- [ ] Manual: run agent that emits two messages without a tool call, confirm both render

## Related

- Asana: https://app.asana.com/1/856614567666442/project/1213882276505882/task/1214081847771983
- Touches the same area as #361 (`message-queue.ts`); expect a small merge conflict to resolve once either lands.