### PR TITLE
bugfix: create assistant message for streamed greetings

### DIFF
--- a/src/services/socket-manager/message-queue.test.ts
+++ b/src/services/socket-manager/message-queue.test.ts
@@ -190,6 +190,48 @@ describe('createMessageEventQueue', () => {
         });
     });
 
+    describe('first assistant turn (greeting)', () => {
+        it('creates an assistant message when partials arrive with no prior messages', () => {
+            const { onMessage } = createMessageEventQueue(
+                mockAnalytics,
+                mockItems,
+                mockOptions,
+                mockAgent,
+                mockOnStreamDone
+            );
+
+            onMessage(ChatProgress.Partial, { content: 'Hello', sequence: 0 });
+            onMessage(ChatProgress.Partial, { content: ' there', sequence: 1 });
+            onMessage(ChatProgress.Answer, { content: 'Hello there!' });
+
+            expect(mockItems.messages).toHaveLength(1);
+            expect(mockItems.messages[0]).toMatchObject({
+                role: 'assistant',
+                content: 'Hello there!',
+            });
+            expect(mockOnNewMessage).toHaveBeenCalled();
+        });
+
+        it('streams partials live for a greeting before the final answer', () => {
+            const { onMessage } = createMessageEventQueue(
+                mockAnalytics,
+                mockItems,
+                mockOptions,
+                mockAgent,
+                mockOnStreamDone
+            );
+
+            onMessage(ChatProgress.Partial, { content: 'Hel', sequence: 0 });
+            onMessage(ChatProgress.Partial, { content: 'lo', sequence: 1 });
+
+            expect(mockItems.messages).toHaveLength(1);
+            expect(mockItems.messages[0]).toMatchObject({ role: 'assistant', content: 'Hello' });
+            expect(mockOnNewMessage).toHaveBeenCalled();
+            const lastCall = mockOnNewMessage.mock.calls[mockOnNewMessage.mock.calls.length - 1];
+            expect(lastCall[1]).toBe(ChatProgress.Partial);
+        });
+    });
+
     describe('clearQueue function', () => {
         it('should expose clearQueue for external use', () => {
             const { clearQueue } = createMessageEventQueue(

--- a/src/services/socket-manager/message-queue.ts
+++ b/src/services/socket-manager/message-queue.ts
@@ -69,8 +69,9 @@ function processChatEvent(
     const lastMessage = items.messages[items.messages.length - 1];
 
     let currentMessage: Message;
-    if (lastMessage?.transcribed && lastMessage.role === 'user') {
-        const initialContent = event === ChatProgress.Answer ? data.content || '' : '';
+    if (lastMessage?.role === 'assistant') {
+        currentMessage = lastMessage;
+    } else if (!lastMessage || (lastMessage.transcribed && lastMessage.role === 'user')) {
         currentMessage = {
             id: data.id || `assistant-${Date.now()}`,
             role: data.role || 'assistant',
@@ -78,8 +79,6 @@ function processChatEvent(
             created_at: data.created_at || new Date().toISOString(),
         };
         items.messages.push(currentMessage);
-    } else if (lastMessage?.role === 'assistant') {
-        currentMessage = lastMessage;
     } else {
         return;
     }


### PR DESCRIPTION
### Pull Request Type

🐛 BugFix

### Description

- The first assistant turn of a session (an unsolicited greeting) was silently dropped from the chat UI. `processChatEvent` only created a new assistant message when the last message was a transcribed user turn; with an empty message list, every partial and final answer hit the fallback early return.
- Broaden the message-creation branch to also fire when there is no `lastMessage`, so greeting partials stream live and the final answer persists.
- Adds two unit tests covering the full greeting stream and live partial delivery.

### Reference Links
- [Asana](https://app.asana.com/1/856614567666442/project/1214036289203665/task/1214079020472513?focus=true)