### PR TITLE
refactor: make Message.parts non-optional

### DIFF
--- a/src/services/agent-manager/index.test.ts
+++ b/src/services/agent-manager/index.test.ts
@@ -140,7 +140,7 @@ describe('createAgentManager', () => {
 
         it('should handle initial messages correctly', async () => {
             const initialMessages = [
-                { id: '1', role: 'user' as const, content: 'Hello', created_at: new Date().toISOString() },
+                { id: '1', role: 'user' as const, content: 'Hello', parts: [], created_at: new Date().toISOString() },
             ];
             (getInitialMessages as jest.Mock).mockReturnValue(initialMessages);
 

--- a/src/services/socket-manager/message-queue.test.ts
+++ b/src/services/socket-manager/message-queue.test.ts
@@ -51,6 +51,7 @@ describe('createMessageEventQueue', () => {
                 id: 'user-1',
                 role: 'user',
                 content: 'first question',
+                parts: [],
                 created_at: new Date().toISOString(),
                 transcribed: true,
             });
@@ -86,6 +87,7 @@ describe('createMessageEventQueue', () => {
                 id: 'user-1',
                 role: 'user',
                 content: 'test',
+                parts: [],
                 created_at: new Date().toISOString(),
                 transcribed: true,
             });
@@ -111,6 +113,7 @@ describe('createMessageEventQueue', () => {
                 id: 'user-1',
                 role: 'user',
                 content: 'test',
+                parts: [],
                 created_at: new Date().toISOString(),
                 transcribed: true,
             });
@@ -137,6 +140,7 @@ describe('createMessageEventQueue', () => {
                 id: 'user-1',
                 role: 'user',
                 content: 'test',
+                parts: [],
                 created_at: new Date().toISOString(),
                 transcribed: true,
             });
@@ -164,6 +168,7 @@ describe('createMessageEventQueue', () => {
                 id: 'user-1',
                 role: 'user',
                 content: 'first message',
+                parts: [],
                 created_at: new Date().toISOString(),
                 transcribed: true,
             });
@@ -258,6 +263,7 @@ describe('createMessageEventQueue', () => {
                 id: 'user-1',
                 role: 'user',
                 content: 'test',
+                parts: [],
                 created_at: new Date().toISOString(),
                 transcribed: true,
             });
@@ -290,6 +296,7 @@ describe('createMessageEventQueue', () => {
                 id: 'assistant-1',
                 role: 'assistant',
                 content: '',
+                parts: [],
                 created_at: new Date().toISOString(),
             });
 
@@ -316,6 +323,7 @@ describe('createMessageEventQueue', () => {
                 id: 'user-1',
                 role: 'user',
                 content: 'test',
+                parts: [],
                 created_at: new Date().toISOString(),
                 transcribed: true,
             });
@@ -343,6 +351,7 @@ describe('createMessageEventQueue', () => {
                 id: 'user-1',
                 role: 'user',
                 content: 'test',
+                parts: [],
                 created_at: new Date().toISOString(),
                 transcribed: true,
             });

--- a/src/services/socket-manager/message-queue.ts
+++ b/src/services/socket-manager/message-queue.ts
@@ -78,6 +78,7 @@ function processChatEvent(
             id: data.id || `assistant-${Date.now()}`,
             role: data.role || 'assistant',
             content: data.content || '',
+            parts: [],
             created_at: data.created_at || new Date().toISOString(),
         };
         items.messages.push(currentMessage);

--- a/src/types/entities/agents/chat.ts
+++ b/src/types/entities/agents/chat.ts
@@ -34,7 +34,7 @@ export interface Message {
     id: string;
     role?: 'system' | 'assistant' | 'user' | 'function' | 'tool';
     content: string;
-    parts?: MessagePart[];
+    parts: MessagePart[];
     created_at?: string;
     matches?: ChatResponse['matches'];
     context?: string;


### PR DESCRIPTION
## Summary
- Change `Message.parts` from `parts?: MessagePart[]` to `parts: MessagePart[]` so consumers can render directly from `parts` without defensive fallbacks.
- Fix the one construction site that previously omitted `parts` — streaming assistant message initialization in `socket-manager/message-queue.ts` — by initializing `parts: []`. Every other `Message` construction path already populated `parts` via `parseMessagePartsMemo`.
- Update internal test fixtures accordingly.

## Why
The `parts?` optional typing allowed a narrow window where `items.messages` contained a `Message` without `parts` (the assistant message created before the first content chunk). Downstream consumers iterating `items.messages` could observe `undefined`, forcing defensive code. Making `parts` required closes this contract gap and unblocks agents-ui#953 from carrying a legacy markdown-parsing fallback.

This is a type-level tightening that matches the actual runtime contract — SDK already populates `parts` everywhere except the one edge case this PR fixes.

## Test plan
- [x] `yarn type-check` — clean
- [x] `yarn test:ci` — 358/358 passing
- [x] `yarn lint` — clean
- [ ] Verify integration with agents-ui#953 via `npm link`