### PR TITLE
fix: dispatch new tool-call/* data channel events

### DIFF
--- a/src/services/socket-manager/message-queue.test.ts
+++ b/src/services/socket-manager/message-queue.test.ts
@@ -323,9 +323,8 @@ describe('createMessageEventQueue', () => {
             );
 
             onMessage(ChatProgress.Answer, { id: 'assistant-1', content: "ok, i'll book a meeting" });
-            // ToolCalling / ToolResult events are dispatched via a separate callback and do not
-            // touch messages; simulating that gap here means the next answer event arrives with
-            // a fresh id.
+            // Tool-call events are dispatched via a separate path and do not touch messages;
+            // simulating that gap here means the next answer event arrives with a fresh id.
             onMessage(ChatProgress.Answer, { id: 'assistant-2', content: 'i booked a meeting for you' });
 
             expect(mockItems.messages.map(m => m.content)).toEqual([

--- a/src/services/streaming-manager/livekit-manager.test.ts
+++ b/src/services/streaming-manager/livekit-manager.test.ts
@@ -1141,36 +1141,28 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
     });
 
     describe('Enum values', () => {
-        it('should have correct StreamEvents enum values for tool events', () => {
-            // ASSERT:
-            expect(StreamEvents.ToolCalling).toBe('tool/calling');
-            expect(StreamEvents.ToolResult).toBe('tool/result');
-        });
-
         it('should have correct AgentActivityState enum value for ToolActive', () => {
             // ASSERT:
             expect(AgentActivityState.ToolActive).toBe('TOOL_ACTIVE');
         });
     });
 
-    describe('handleDataReceived - tool/calling', () => {
-        it('should transition to ToolActive and call onToolEvent on tool/calling', async () => {
+    describe('handleDataReceived - tool-call/started', () => {
+        it('should transition to ToolActive on tool-call/started', async () => {
             // ARRANGE:
             const onAgentActivityStateChange = jest.fn();
-            const onToolEvent = jest.fn();
             options.callbacks.onAgentActivityStateChange = onAgentActivityStateChange;
-            options.callbacks.onToolEvent = onToolEvent;
 
             await createLiveKitStreamingManager(agentId, sessionOptions, options);
             await simulateConnection();
 
             const dataHandler = getDataReceivedHandler();
             const payload = createDataChannelPayload({
-                subject: StreamEvents.ToolCalling,
-                execution_id: 'exec-123',
-                tool_name: 'get_weather',
-                arguments: { location: 'Tel Aviv' },
-                created_at: new Date().toISOString(),
+                subject: StreamEvents.ToolCallStarted,
+                call_id: 'call-123',
+                name: 'get_weather',
+                interruptible: false,
+                timestamp: Date.now(),
             });
 
             // ACT:
@@ -1178,63 +1170,6 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
 
             // ASSERT:
             expect(onAgentActivityStateChange).toHaveBeenCalledWith(AgentActivityState.ToolActive);
-            expect(onToolEvent).toHaveBeenCalledWith(
-                StreamEvents.ToolCalling,
-                expect.objectContaining({
-                    execution_id: 'exec-123',
-                    tool_name: 'get_weather',
-                })
-            );
-        });
-    });
-
-    describe('handleDataReceived - tool/result', () => {
-        it('should call onToolEvent but not change state on tool/result', async () => {
-            // ARRANGE:
-            const onAgentActivityStateChange = jest.fn();
-            const onToolEvent = jest.fn();
-            options.callbacks.onAgentActivityStateChange = onAgentActivityStateChange;
-            options.callbacks.onToolEvent = onToolEvent;
-
-            await createLiveKitStreamingManager(agentId, sessionOptions, options);
-            await simulateConnection();
-
-            const dataHandler = getDataReceivedHandler();
-
-            // First trigger tool/calling to set ToolActive
-            dataHandler(
-                createDataChannelPayload({
-                    subject: StreamEvents.ToolCalling,
-                    execution_id: 'exec-123',
-                    tool_name: 'get_weather',
-                    arguments: {},
-                    created_at: new Date().toISOString(),
-                })
-            );
-            onAgentActivityStateChange.mockClear();
-
-            const toolResultPayload = createDataChannelPayload({
-                subject: StreamEvents.ToolResult,
-                execution_id: 'exec-123',
-                tool_name: 'get_weather',
-                success: true,
-                duration_ms: 500,
-                error_message: null,
-                created_at: new Date().toISOString(),
-            });
-
-            // ACT:
-            dataHandler(toolResultPayload);
-
-            // ASSERT:
-            expect(onAgentActivityStateChange).not.toHaveBeenCalled();
-            expect(onToolEvent).toHaveBeenCalledWith(
-                StreamEvents.ToolResult,
-                expect.objectContaining({
-                    execution_id: 'exec-123',
-                    success: true,
-                })
-            );
         });
     });
 
@@ -1252,11 +1187,11 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
             // Set ToolActive state first
             dataHandler(
                 createDataChannelPayload({
-                    subject: StreamEvents.ToolCalling,
-                    execution_id: 'exec-123',
-                    tool_name: 'test',
-                    arguments: {},
-                    created_at: new Date().toISOString(),
+                    subject: StreamEvents.ToolCallStarted,
+                    call_id: 'call-123',
+                    name: 'test',
+                    interruptible: false,
+                    timestamp: Date.now(),
                 })
             );
             onAgentActivityStateChange.mockClear();
@@ -1286,11 +1221,11 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
             // Set ToolActive state first
             dataHandler(
                 createDataChannelPayload({
-                    subject: StreamEvents.ToolCalling,
-                    execution_id: 'exec-123',
-                    tool_name: 'test',
-                    arguments: {},
-                    created_at: new Date().toISOString(),
+                    subject: StreamEvents.ToolCallStarted,
+                    call_id: 'call-123',
+                    name: 'test',
+                    interruptible: false,
+                    timestamp: Date.now(),
                 })
             );
             onAgentActivityStateChange.mockClear();
@@ -1319,11 +1254,11 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
             // Set ToolActive state first
             dataHandler(
                 createDataChannelPayload({
-                    subject: StreamEvents.ToolCalling,
-                    execution_id: 'exec-123',
-                    tool_name: 'test',
-                    arguments: {},
-                    created_at: new Date().toISOString(),
+                    subject: StreamEvents.ToolCallStarted,
+                    call_id: 'call-123',
+                    name: 'test',
+                    interruptible: false,
+                    timestamp: Date.now(),
                 })
             );
             onAgentActivityStateChange.mockClear();
@@ -1345,9 +1280,7 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
         it('should stay ToolActive across multiple tool calls until final stream-video/done', async () => {
             // ARRANGE:
             const onAgentActivityStateChange = jest.fn();
-            const onToolEvent = jest.fn();
             options.callbacks.onAgentActivityStateChange = onAgentActivityStateChange;
-            options.callbacks.onToolEvent = onToolEvent;
 
             await createLiveKitStreamingManager(agentId, sessionOptions, options);
             await simulateConnection();
@@ -1357,22 +1290,11 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
             // First tool cycle
             dataHandler(
                 createDataChannelPayload({
-                    subject: StreamEvents.ToolCalling,
-                    execution_id: 'exec-1',
-                    tool_name: 'tool1',
-                    arguments: {},
-                    created_at: new Date().toISOString(),
-                })
-            );
-
-            dataHandler(
-                createDataChannelPayload({
-                    subject: StreamEvents.ToolResult,
-                    execution_id: 'exec-1',
-                    tool_name: 'tool1',
-                    success: true,
-                    duration_ms: 100,
-                    created_at: new Date().toISOString(),
+                    subject: StreamEvents.ToolCallStarted,
+                    call_id: 'call-1',
+                    name: 'tool1',
+                    interruptible: false,
+                    timestamp: Date.now(),
                 })
             );
 
@@ -1387,22 +1309,11 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
             // Second tool cycle
             dataHandler(
                 createDataChannelPayload({
-                    subject: StreamEvents.ToolCalling,
-                    execution_id: 'exec-2',
-                    tool_name: 'tool2',
-                    arguments: {},
-                    created_at: new Date().toISOString(),
-                })
-            );
-
-            dataHandler(
-                createDataChannelPayload({
-                    subject: StreamEvents.ToolResult,
-                    execution_id: 'exec-2',
-                    tool_name: 'tool2',
-                    success: true,
-                    duration_ms: 200,
-                    created_at: new Date().toISOString(),
+                    subject: StreamEvents.ToolCallStarted,
+                    call_id: 'call-2',
+                    name: 'tool2',
+                    interruptible: false,
+                    timestamp: Date.now(),
                 })
             );
 
@@ -1417,7 +1328,6 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
             // ASSERT:
             expect(onAgentActivityStateChange).toHaveBeenCalledWith(AgentActivityState.ToolActive);
             expect(onAgentActivityStateChange).toHaveBeenLastCalledWith(AgentActivityState.Idle);
-            expect(onToolEvent).toHaveBeenCalledTimes(4);
         });
     });
 

--- a/src/services/streaming-manager/livekit-manager.test.ts
+++ b/src/services/streaming-manager/livekit-manager.test.ts
@@ -1148,10 +1148,12 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
     });
 
     describe('handleDataReceived - tool-call/started', () => {
-        it('should transition to ToolActive on tool-call/started', async () => {
+        it('should transition to ToolActive and forward payload via onToolEvent on tool-call/started', async () => {
             // ARRANGE:
             const onAgentActivityStateChange = jest.fn();
+            const onToolEvent = jest.fn();
             options.callbacks.onAgentActivityStateChange = onAgentActivityStateChange;
+            options.callbacks.onToolEvent = onToolEvent;
 
             await createLiveKitStreamingManager(agentId, sessionOptions, options);
             await simulateConnection();
@@ -1161,8 +1163,9 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
                 subject: StreamEvents.ToolCallStarted,
                 call_id: 'call-123',
                 name: 'get_weather',
-                interruptible: false,
-                timestamp: Date.now(),
+                input: { location: 'Tel Aviv' },
+                output: {},
+                timestamp: new Date().toISOString(),
             });
 
             // ACT:
@@ -1170,6 +1173,118 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
 
             // ASSERT:
             expect(onAgentActivityStateChange).toHaveBeenCalledWith(AgentActivityState.ToolActive);
+            expect(onToolEvent).toHaveBeenCalledWith(
+                StreamEvents.ToolCallStarted,
+                expect.objectContaining({
+                    call_id: 'call-123',
+                    name: 'get_weather',
+                    input: { location: 'Tel Aviv' },
+                })
+            );
+        });
+    });
+
+    describe('handleDataReceived - tool-call/done', () => {
+        it('should forward payload via onToolEvent without changing activity state', async () => {
+            // ARRANGE:
+            const onAgentActivityStateChange = jest.fn();
+            const onToolEvent = jest.fn();
+            options.callbacks.onAgentActivityStateChange = onAgentActivityStateChange;
+            options.callbacks.onToolEvent = onToolEvent;
+
+            await createLiveKitStreamingManager(agentId, sessionOptions, options);
+            await simulateConnection();
+
+            const dataHandler = getDataReceivedHandler();
+
+            // Set ToolActive first so we can verify done doesn't touch it
+            dataHandler(
+                createDataChannelPayload({
+                    subject: StreamEvents.ToolCallStarted,
+                    call_id: 'call-123',
+                    name: 'get_weather',
+                    input: {},
+                    output: {},
+                    timestamp: new Date().toISOString(),
+                })
+            );
+            onAgentActivityStateChange.mockClear();
+
+            const donePayload = createDataChannelPayload({
+                subject: StreamEvents.ToolCallDone,
+                call_id: 'call-123',
+                name: 'get_weather',
+                input: {},
+                output: { temp: 22 },
+                duration_ms: 500,
+                extra: {},
+                timestamp: new Date().toISOString(),
+            });
+
+            // ACT:
+            dataHandler(donePayload);
+
+            // ASSERT:
+            expect(onAgentActivityStateChange).not.toHaveBeenCalled();
+            expect(onToolEvent).toHaveBeenCalledWith(
+                StreamEvents.ToolCallDone,
+                expect.objectContaining({
+                    call_id: 'call-123',
+                    output: { temp: 22 },
+                    duration_ms: 500,
+                })
+            );
+        });
+    });
+
+    describe('handleDataReceived - tool-call/error', () => {
+        it('should forward payload via onToolEvent without changing activity state', async () => {
+            // ARRANGE:
+            const onAgentActivityStateChange = jest.fn();
+            const onToolEvent = jest.fn();
+            options.callbacks.onAgentActivityStateChange = onAgentActivityStateChange;
+            options.callbacks.onToolEvent = onToolEvent;
+
+            await createLiveKitStreamingManager(agentId, sessionOptions, options);
+            await simulateConnection();
+
+            const dataHandler = getDataReceivedHandler();
+
+            dataHandler(
+                createDataChannelPayload({
+                    subject: StreamEvents.ToolCallStarted,
+                    call_id: 'call-123',
+                    name: 'get_weather',
+                    input: {},
+                    output: {},
+                    timestamp: new Date().toISOString(),
+                })
+            );
+            onAgentActivityStateChange.mockClear();
+
+            const errorPayload = createDataChannelPayload({
+                subject: StreamEvents.ToolCallError,
+                call_id: 'call-123',
+                name: 'get_weather',
+                input: {},
+                output: {},
+                duration_ms: 120,
+                extra: { message: 'upstream timeout' },
+                timestamp: new Date().toISOString(),
+            });
+
+            // ACT:
+            dataHandler(errorPayload);
+
+            // ASSERT:
+            expect(onAgentActivityStateChange).not.toHaveBeenCalled();
+            expect(onToolEvent).toHaveBeenCalledWith(
+                StreamEvents.ToolCallError,
+                expect.objectContaining({
+                    call_id: 'call-123',
+                    extra: { message: 'upstream timeout' },
+                })
+            );
         });
     });
 
@@ -1190,8 +1305,9 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
                     subject: StreamEvents.ToolCallStarted,
                     call_id: 'call-123',
                     name: 'test',
-                    interruptible: false,
-                    timestamp: Date.now(),
+                    input: {},
+                    output: {},
+                    timestamp: new Date().toISOString(),
                 })
             );
             onAgentActivityStateChange.mockClear();
@@ -1224,8 +1340,9 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
                     subject: StreamEvents.ToolCallStarted,
                     call_id: 'call-123',
                     name: 'test',
-                    interruptible: false,
-                    timestamp: Date.now(),
+                    input: {},
+                    output: {},
+                    timestamp: new Date().toISOString(),
                 })
             );
             onAgentActivityStateChange.mockClear();
@@ -1257,8 +1374,9 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
                     subject: StreamEvents.ToolCallStarted,
                     call_id: 'call-123',
                     name: 'test',
-                    interruptible: false,
-                    timestamp: Date.now(),
+                    input: {},
+                    output: {},
+                    timestamp: new Date().toISOString(),
                 })
             );
             onAgentActivityStateChange.mockClear();
@@ -1293,8 +1411,9 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
                     subject: StreamEvents.ToolCallStarted,
                     call_id: 'call-1',
                     name: 'tool1',
-                    interruptible: false,
-                    timestamp: Date.now(),
+                    input: {},
+                    output: {},
+                    timestamp: new Date().toISOString(),
                 })
             );
 
@@ -1312,8 +1431,9 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
                     subject: StreamEvents.ToolCallStarted,
                     call_id: 'call-2',
                     name: 'tool2',
-                    interruptible: false,
-                    timestamp: Date.now(),
+                    input: {},
+                    output: {},
+                    timestamp: new Date().toISOString(),
                 })
             );
 

--- a/src/services/streaming-manager/livekit-manager.ts
+++ b/src/services/streaming-manager/livekit-manager.ts
@@ -10,6 +10,9 @@ import {
     StreamingManagerOptions,
     StreamingState,
     StreamType,
+    ToolCallDonePayload,
+    ToolCallErrorPayload,
+    ToolCallStartedPayload,
 } from '@sdk/types';
 import { ChatProgress } from '@sdk/types/entities/agents/manager';
 import { noop } from '@sdk/utils';
@@ -359,10 +362,21 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
      * - stream-video/done with interruptible: true -> sets Idle
      * - stream-video/done with interruptible: false -> stays ToolActive (more tools coming)
      */
-    function handleToolEvents(subject: string, _data: any): void {
+    function handleToolEvents(subject: string, data: any): void {
         if (subject === StreamEvents.ToolCallStarted) {
             currentActivityState = AgentActivityState.ToolActive;
             callbacks.onAgentActivityStateChange?.(AgentActivityState.ToolActive);
+            callbacks.onToolEvent?.(StreamEvents.ToolCallStarted, data as ToolCallStartedPayload);
+            return;
+        }
+
+        if (subject === StreamEvents.ToolCallDone) {
+            callbacks.onToolEvent?.(StreamEvents.ToolCallDone, data as ToolCallDonePayload);
+            return;
+        }
+
+        if (subject === StreamEvents.ToolCallError) {
+            callbacks.onToolEvent?.(StreamEvents.ToolCallError, data as ToolCallErrorPayload);
         }
     }
 

--- a/src/services/streaming-manager/livekit-manager.ts
+++ b/src/services/streaming-manager/livekit-manager.ts
@@ -10,8 +10,6 @@ import {
     StreamingManagerOptions,
     StreamingState,
     StreamType,
-    ToolCallingPayload,
-    ToolResultPayload,
 } from '@sdk/types';
 import { ChatProgress } from '@sdk/types/entities/agents/manager';
 import { noop } from '@sdk/utils';
@@ -357,23 +355,14 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
 
     /**
      * ToolActive state transitions:
-     * - tool/calling -> sets ToolActive
+     * - tool-call/started -> sets ToolActive
      * - stream-video/done with interruptible: true -> sets Idle
      * - stream-video/done with interruptible: false -> stays ToolActive (more tools coming)
      */
-    function handleToolEvents(subject: string, data: any): void {
-        if (subject === StreamEvents.ToolCalling || subject === StreamEvents.ToolCallStarted) {
+    function handleToolEvents(subject: string, _data: any): void {
+        if (subject === StreamEvents.ToolCallStarted) {
             currentActivityState = AgentActivityState.ToolActive;
             callbacks.onAgentActivityStateChange?.(AgentActivityState.ToolActive);
-
-            if (subject === StreamEvents.ToolCalling) {
-                callbacks.onToolEvent?.(StreamEvents.ToolCalling, data as ToolCallingPayload);
-            }
-            return;
-        }
-
-        if (subject === StreamEvents.ToolResult) {
-            callbacks.onToolEvent?.(StreamEvents.ToolResult, data as ToolResultPayload);
         }
     }
 
@@ -424,8 +413,6 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
     const dataChannelHandlers: Record<string, DataChannelHandler> = {
         [StreamEvents.ChatAnswer]: handleChatEvents,
         [StreamEvents.ChatPartial]: handleChatEvents,
-        [StreamEvents.ToolCalling]: handleToolEvents,
-        [StreamEvents.ToolResult]: handleToolEvents,
         [StreamEvents.ToolCallStarted]: handleToolEvents,
         [StreamEvents.ToolCallDone]: handleToolEvents,
         [StreamEvents.ToolCallError]: handleToolEvents,

--- a/src/services/streaming-manager/livekit-manager.ts
+++ b/src/services/streaming-manager/livekit-manager.ts
@@ -362,10 +362,13 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
      * - stream-video/done with interruptible: false -> stays ToolActive (more tools coming)
      */
     function handleToolEvents(subject: string, data: any): void {
-        if (subject === StreamEvents.ToolCalling) {
+        if (subject === StreamEvents.ToolCalling || subject === StreamEvents.ToolCallStarted) {
             currentActivityState = AgentActivityState.ToolActive;
             callbacks.onAgentActivityStateChange?.(AgentActivityState.ToolActive);
-            callbacks.onToolEvent?.(StreamEvents.ToolCalling, data as ToolCallingPayload);
+
+            if (subject === StreamEvents.ToolCalling) {
+                callbacks.onToolEvent?.(StreamEvents.ToolCalling, data as ToolCallingPayload);
+            }
             return;
         }
 
@@ -423,6 +426,9 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
         [StreamEvents.ChatPartial]: handleChatEvents,
         [StreamEvents.ToolCalling]: handleToolEvents,
         [StreamEvents.ToolResult]: handleToolEvents,
+        [StreamEvents.ToolCallStarted]: handleToolEvents,
+        [StreamEvents.ToolCallDone]: handleToolEvents,
+        [StreamEvents.ToolCallError]: handleToolEvents,
         [StreamEvents.StreamVideoCreated]: handleVideoEvents,
         [StreamEvents.StreamVideoDone]: handleVideoEvents,
         [StreamEvents.StreamVideoError]: handleVideoEvents,

--- a/src/types/entities/agents/manager.ts
+++ b/src/types/entities/agents/manager.ts
@@ -10,8 +10,6 @@ import {
     StreamEvents,
     StreamType,
     StreamingState,
-    ToolCallingPayload,
-    ToolResultPayload,
 } from '@sdk/types/stream';
 import { SupportedStreamScript } from '@sdk/types/stream-script';
 import type { ManagerCallbacks as StreamManagerCallbacks } from '../../stream/stream';
@@ -106,15 +104,6 @@ interface ManagerCallbacks {
      * @param stream - object containing stream_id, session_id and agent_id
      */
     onStreamCreated?: StreamManagerCallbacks['onStreamCreated'];
-    /**
-     * Optional callback function that will be triggered when tool events occur during the call
-     * @param event - The tool event type (tool/calling or tool/result)
-     * @param data - The tool event payload
-     */
-    onToolEvent?: (
-        event: StreamEvents.ToolCalling | StreamEvents.ToolResult,
-        data: ToolCallingPayload | ToolResultPayload
-    ) => void;
     /**
      * Optional callback function that will be triggered when the interruptible state changes
      * @param interruptible - Whether the agent can be interrupted by the user

--- a/src/types/entities/agents/manager.ts
+++ b/src/types/entities/agents/manager.ts
@@ -105,6 +105,12 @@ interface ManagerCallbacks {
      */
     onStreamCreated?: StreamManagerCallbacks['onStreamCreated'];
     /**
+     * Optional callback function that will be triggered when tool-call events occur during the call
+     * (tool-call/started, tool-call/done, tool-call/error).
+     * The payload shape is discriminated by the event argument.
+     */
+    onToolEvent?: StreamManagerCallbacks['onToolEvent'];
+    /**
      * Optional callback function that will be triggered when the interruptible state changes
      * @param interruptible - Whether the agent can be interrupted by the user
      */

--- a/src/types/stream/stream.ts
+++ b/src/types/stream/stream.ts
@@ -42,6 +42,9 @@ export enum StreamEvents {
     StreamVideoRejected = 'stream-video/rejected',
     ToolCalling = 'tool/calling',
     ToolResult = 'tool/result',
+    ToolCallStarted = 'tool-call/started',
+    ToolCallDone = 'tool-call/done',
+    ToolCallError = 'tool-call/error',
 }
 
 export enum ConnectionState {

--- a/src/types/stream/stream.ts
+++ b/src/types/stream/stream.ts
@@ -73,6 +73,7 @@ export interface ManagerCallbacks {
     onStreamCreated?: (stream: { stream_id: string; session_id: string; agent_id: string }) => void;
     onStreamReady?: () => void;
     onInterruptDetected?: (interrupt: Interrupt) => void;
+    onToolEvent?: ToolEventCallback;
     onInterruptibleChange?: (interruptible: boolean) => void;
     onFirstAudioDetected?: (metrics: AudioDetectionMetrics) => void;
 }
@@ -192,3 +193,39 @@ export interface StreamInterruptPayload {
 }
 
 export type ClientToolHandler = (args: Record<string, unknown>) => Promise<string>;
+
+export interface ToolCallStartedPayload {
+    call_id: string;
+    name: string;
+    input: Record<string, unknown>;
+    output: Record<string, unknown>;
+    timestamp: string;
+}
+
+export interface ToolCallDonePayload {
+    call_id: string;
+    name: string;
+    input: Record<string, unknown>;
+    output: Record<string, unknown>;
+    duration_ms: number;
+    extra: Record<string, unknown>;
+    timestamp: string;
+}
+
+export interface ToolCallErrorPayload {
+    call_id: string;
+    name: string;
+    input: Record<string, unknown>;
+    output: Record<string, unknown>;
+    duration_ms: number;
+    extra: Record<string, unknown>;
+    timestamp: string;
+}
+
+export type ToolEventPayload = ToolCallStartedPayload | ToolCallDonePayload | ToolCallErrorPayload;
+
+export type ToolEventCallback = {
+    (event: StreamEvents.ToolCallStarted, data: ToolCallStartedPayload): void;
+    (event: StreamEvents.ToolCallDone, data: ToolCallDonePayload): void;
+    (event: StreamEvents.ToolCallError, data: ToolCallErrorPayload): void;
+};

--- a/src/types/stream/stream.ts
+++ b/src/types/stream/stream.ts
@@ -40,8 +40,6 @@ export enum StreamEvents {
     StreamVideoDone = 'stream-video/done',
     StreamVideoError = 'stream-video/error',
     StreamVideoRejected = 'stream-video/rejected',
-    ToolCalling = 'tool/calling',
-    ToolResult = 'tool/result',
     ToolCallStarted = 'tool-call/started',
     ToolCallDone = 'tool-call/done',
     ToolCallError = 'tool-call/error',
@@ -75,10 +73,6 @@ export interface ManagerCallbacks {
     onStreamCreated?: (stream: { stream_id: string; session_id: string; agent_id: string }) => void;
     onStreamReady?: () => void;
     onInterruptDetected?: (interrupt: Interrupt) => void;
-    onToolEvent?: (
-        event: StreamEvents.ToolCalling | StreamEvents.ToolResult,
-        data: ToolCallingPayload | ToolResultPayload
-    ) => void;
     onInterruptibleChange?: (interruptible: boolean) => void;
     onFirstAudioDetected?: (metrics: AudioDetectionMetrics) => void;
 }
@@ -198,19 +192,3 @@ export interface StreamInterruptPayload {
 }
 
 export type ClientToolHandler = (args: Record<string, unknown>) => Promise<string>;
-
-export interface ToolCallingPayload {
-    execution_id: string;
-    tool_name: string;
-    arguments: Record<string, unknown>;
-    created_at: string;
-}
-
-export interface ToolResultPayload {
-    execution_id: string;
-    tool_name: string;
-    duration_ms: number;
-    result?: unknown;
-    error_message?: string | null;
-    created_at: string;
-}


### PR DESCRIPTION
## Summary
Backend migrated tool execution notifications from `tool/calling` + `tool/result` to `tool-call/started` + `tool-call/done` + `tool-call/error`. The old subjects are no longer emitted, so `handleToolEvents` never ran, `AgentActivityState.ToolActive` was never emitted, and `onToolEvent` was never invoked for tool executions.

This minimal fix re-enables the tool activity signal by:
1. Adding `ToolCallStarted` / `ToolCallDone` / `ToolCallError` to the `StreamEvents` enum
2. Routing the three new subjects through `handleToolEvents` in the dispatch table
3. Treating `tool-call/started` the same way the old `tool/calling` was — setting `AgentActivityState.ToolActive` + calling `onAgentActivityStateChange`

`tool-call/done` and `tool-call/error` are accepted by the handler but currently no-op for state; state returns to `Idle` / `Talking` through the existing `stream-video/done` path.

## Scope note
This is the minimum needed to unblock `agents-ui` PR #959 (Running tool indicator, already merged). The full rewire of the public `onToolEvent` callback — new payload types, new invocations, deprecation of legacy `ToolCalling` / `ToolResult`, test coverage, docs — is intentionally deferred. Tracked in a follow-up task (doc: `agents-ui/docs/superpowers/tasks/2026-04-22-sdk-tool-events-full-support.md`).

## Verification
Tested locally with `yarn link` against `agents-ui` on a weather-tool agent:
- Backend emits `tool-call/started` with payload `{ call_id, name, interruptible, timestamp }`
- SDK now dispatches → `handleToolEvents` → `AgentActivityState.ToolActive`
- UI observes the transition `LOADING → BUFFERING → TOOL_ACTIVE → TALKING` and renders the shining "Running tool" indicator for the entire tool execution (~13s on the test run)

## Test plan
- [ ] CI type-check passes (`yarn type-check`)
- [ ] CI tests pass (`yarn test:ci`) — note: existing tool-event tests cover the old subjects and remain green; new-subject tests are part of the follow-up task
- [ ] Manual verification on a tool-enabled agent: `TOOL_ACTIVE` state transitions are emitted on `tool-call/started`