### PR TITLE
fix: stop firing interrupt on local transcription (race condition)

### DIFF
--- a/src/services/agent-manager/connect-to-manager.ts
+++ b/src/services/agent-manager/connect-to-manager.ts
@@ -17,7 +17,6 @@ import {
     ConnectionState,
     CreateSessionV2Options,
     CreateStreamOptions,
-    Interrupt,
     StreamEvents,
     StreamType,
     StreamingState,
@@ -167,8 +166,6 @@ type ConnectToManagerOptions = AgentManagerOptions & {
         onVideoIdChange?: (videoId: string | null) => void;
         /** Internal callback for livekit-manager data channel events */
         onMessage?: ChatProgressCallback;
-        /** Internal callback for when interrupt is detected by streaming manager */
-        onInterruptDetected?: (interrupt: Interrupt) => void;
         onFirstAudioDetected?: (metrics: AudioDetectionMetrics) => void;
     };
     chatId?: string;

--- a/src/services/agent-manager/index.ts
+++ b/src/services/agent-manager/index.ts
@@ -203,7 +203,6 @@ export async function createAgentManager(agent: string, options: AgentManagerOpt
                             ...options.callbacks,
                             onVideoIdChange: updateVideoId,
                             onMessage,
-                            onInterruptDetected: interrupt,
                         },
                     },
                     agentsApi,

--- a/src/services/streaming-manager/livekit-manager.test.ts
+++ b/src/services/streaming-manager/livekit-manager.test.ts
@@ -490,14 +490,10 @@ describe('LiveKit Streaming Manager - Microphone Stream', () => {
     });
 
     describe('Transcription Interrupt Detection', () => {
-        let mockOnInterruptDetected: jest.Mock;
         let transcriptionHandler: (segments: any[], participant?: any) => void;
         let dataHandler: (payload: Uint8Array, participant?: any, kind?: any, topic?: string) => void;
 
         beforeEach(async () => {
-            mockOnInterruptDetected = jest.fn();
-            options.callbacks.onInterruptDetected = mockOnInterruptDetected;
-
             await createLiveKitStreamingManager(agentId, sessionOptions, options);
             await simulateConnection();
 
@@ -533,8 +529,6 @@ describe('LiveKit Streaming Manager - Microphone Stream', () => {
             transcriptionHandler([], localParticipant);
 
             expect(mockLatencyTimestampTrackerUpdate).toHaveBeenCalledTimes(1);
-            expect(mockOnInterruptDetected).toHaveBeenCalledTimes(1);
-            expect(mockOnInterruptDetected).toHaveBeenCalledWith({ type: 'audio' });
         });
 
         it('should not detect interrupt when local participant sends transcription during Idle state', () => {
@@ -542,7 +536,6 @@ describe('LiveKit Streaming Manager - Microphone Stream', () => {
             transcriptionHandler([], localParticipant);
 
             expect(mockLatencyTimestampTrackerUpdate).toHaveBeenCalledTimes(1);
-            expect(mockOnInterruptDetected).not.toHaveBeenCalled();
         });
 
         it('should not detect interrupt when local participant sends transcription during Loading state', async () => {
@@ -556,7 +549,6 @@ describe('LiveKit Streaming Manager - Microphone Stream', () => {
             transcriptionHandler([], localParticipant);
 
             expect(mockLatencyTimestampTrackerUpdate).toHaveBeenCalledTimes(1);
-            expect(mockOnInterruptDetected).not.toHaveBeenCalled();
         });
 
         it('should update latency tracker but not detect interrupt when remote participant sends transcription during Talking state', () => {
@@ -567,7 +559,6 @@ describe('LiveKit Streaming Manager - Microphone Stream', () => {
             transcriptionHandler([], remoteParticipant);
 
             expect(mockLatencyTimestampTrackerUpdate).not.toHaveBeenCalled();
-            expect(mockOnInterruptDetected).not.toHaveBeenCalled();
         });
     });
 

--- a/src/services/streaming-manager/livekit-manager.ts
+++ b/src/services/streaming-manager/livekit-manager.ts
@@ -170,7 +170,6 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
         if (participant?.isLocal) {
             latencyTimestampTracker.update();
             if (currentActivityState === AgentActivityState.Talking) {
-                callbacks.onInterruptDetected?.({ type: 'audio' });
                 currentActivityState = AgentActivityState.Idle;
             }
         }

--- a/src/types/stream/stream.ts
+++ b/src/types/stream/stream.ts
@@ -1,7 +1,6 @@
 import { Analytics } from '@sdk/services/analytics/mixpanel';
 import { VideoRTCStatsReport } from '@sdk/services/streaming-manager/stats/report';
 import { Auth } from '../auth';
-import { Interrupt } from '../entities';
 import { ChatProgressCallback } from '../entities/agents/manager';
 import { CreateClipStreamRequest, CreateTalkStreamRequest, SendClipStreamPayload, SendTalkStreamPayload } from './api';
 import { ICreateStreamRequestResponse, IceCandidate, SendStreamPayloadResponse, Status } from './rtc';
@@ -72,7 +71,6 @@ export interface ManagerCallbacks {
     onVideoIdChange?: (videoId: string | null) => void;
     onStreamCreated?: (stream: { stream_id: string; session_id: string; agent_id: string }) => void;
     onStreamReady?: () => void;
-    onInterruptDetected?: (interrupt: Interrupt) => void;
     onToolEvent?: ToolEventCallback;
     onInterruptibleChange?: (interruptible: boolean) => void;
     onFirstAudioDetected?: (metrics: AudioDetectionMetrics) => void;


### PR DESCRIPTION
## Summary
- Removes the internal `onInterruptDetected` wiring that fired on local-participant transcription while the agent was Talking
- This was racy: the transcription-driven interrupt could cancel an in-flight request the user did not actually mean to interrupt
- Public `interrupt()` API on the agent manager is unchanged — explicit interrupts still work as before
- Also drops the now-unused `Interrupt` import and a stale JSDoc comment, and updates `livekit-manager.test.ts` to remove the corresponding mock/assertions

## References
- [Asana](https://app.asana.com/1/856614567666442/project/1214036289203665/task/1214310671057364?focus=true)
## Test plan
- [ ] `npm test` — Transcription Interrupt Detection suite still passes (latency tracker still updates; no interrupt is dispatched)
- [ ] Type-check passes
- [ ] Smoke-test a live agent session: local user speaking during Talking state no longer cancels the active request via the transcription path

🤖 Generated with [Claude Code](https://claude.com/claude-code)