### PR TITLE
feat: track tool-call/* events to Mixpanel

### DIFF
--- a/src/services/agent-manager/connect-to-manager.test.ts
+++ b/src/services/agent-manager/connect-to-manager.test.ts
@@ -86,6 +86,7 @@ describe('connect-to-manager', () => {
                 onSrcObjectReady: jest.fn(),
                 onNewMessage: jest.fn(),
                 onNewChat: jest.fn(),
+                onToolEvent: jest.fn(),
             },
         };
 
@@ -239,6 +240,7 @@ describe('connect-to-manager', () => {
         let onAgentActivityStateChange: (state: AgentActivityState) => void;
         let onFirstAudioDetected: ((metrics: { latency?: number; networkLatency?: number }) => void) | undefined;
         let onStreamReady: (() => void) | undefined;
+        let onToolEvent: ((event: StreamEvents, data: any) => void) | undefined;
 
         beforeEach(async () => {
             // Initialize callbacks to avoid undefined errors
@@ -252,6 +254,7 @@ describe('connect-to-manager', () => {
                 onAgentActivityStateChange = options.callbacks.onAgentActivityStateChange;
                 onFirstAudioDetected = options.callbacks.onFirstAudioDetected;
                 onStreamReady = options.callbacks.onStreamReady;
+                onToolEvent = options.callbacks.onToolEvent;
 
                 return new Promise(resolve => {
                     setTimeout(() => {
@@ -445,6 +448,79 @@ describe('connect-to-manager', () => {
                     event: 'ready',
                     latency: 2000,
                 });
+            });
+        });
+
+        describe('onToolEvent', () => {
+            const startedPayload = {
+                call_id: 'call-1',
+                name: 'lookup',
+                input: { q: 'hello' },
+                output: {},
+                timestamp: '2026-04-28T00:00:00Z',
+            };
+            const donePayload = {
+                ...startedPayload,
+                output: { result: 'ok' },
+                duration_ms: 123,
+                extra: { region: 'eu' },
+            };
+            const errorPayload = {
+                ...donePayload,
+                extra: { reason: 'timeout', code: 504 },
+            };
+
+            beforeEach(() => {
+                (mockAnalytics.track as jest.Mock).mockClear();
+            });
+
+            it('forwards started event to user callback and tracks agent-tool-call', () => {
+                onToolEvent?.(StreamEvents.ToolCallStarted, startedPayload as any);
+
+                expect(mockOptions.callbacks.onToolEvent).toHaveBeenCalledWith(
+                    StreamEvents.ToolCallStarted,
+                    startedPayload
+                );
+                expect(mockAnalytics.track).toHaveBeenCalledWith('agent-tool-call', {
+                    event: 'started',
+                    call_id: 'call-1',
+                    name: 'lookup',
+                });
+            });
+
+            it('tracks done event with duration_ms and extra_keys count', () => {
+                onToolEvent?.(StreamEvents.ToolCallDone, donePayload as any);
+
+                expect(mockAnalytics.track).toHaveBeenCalledWith('agent-tool-call', {
+                    event: 'done',
+                    call_id: 'call-1',
+                    name: 'lookup',
+                    duration_ms: 123,
+                    extra_keys: 1,
+                });
+            });
+
+            it('tracks error event with duration_ms and extra_keys count', () => {
+                onToolEvent?.(StreamEvents.ToolCallError, errorPayload as any);
+
+                expect(mockAnalytics.track).toHaveBeenCalledWith('agent-tool-call', {
+                    event: 'error',
+                    call_id: 'call-1',
+                    name: 'lookup',
+                    duration_ms: 123,
+                    extra_keys: 2,
+                });
+            });
+
+            it('handles missing extra map by emitting extra_keys=0', () => {
+                const { extra: _extra, ...donePayloadWithoutExtra } = donePayload;
+
+                onToolEvent?.(StreamEvents.ToolCallDone, donePayloadWithoutExtra as any);
+
+                expect(mockAnalytics.track).toHaveBeenCalledWith(
+                    'agent-tool-call',
+                    expect.objectContaining({ extra_keys: 0 })
+                );
             });
         });
     });

--- a/src/services/agent-manager/connect-to-manager.ts
+++ b/src/services/agent-manager/connect-to-manager.ts
@@ -20,6 +20,9 @@ import {
     StreamEvents,
     StreamType,
     StreamingState,
+    ToolCallDonePayload,
+    ToolCallErrorPayload,
+    ToolEventPayload,
     TransportProvider,
 } from '@sdk/types';
 import { isStreamsV2Agent } from '@sdk/utils/agent';
@@ -161,6 +164,30 @@ function trackLegacyVideoAnalytics(
     }
 }
 
+function trackToolEventAnalytics(
+    event: StreamEvents.ToolCallStarted | StreamEvents.ToolCallDone | StreamEvents.ToolCallError,
+    payload: ToolEventPayload,
+    analytics: Analytics
+) {
+    const baseProps: Record<string, unknown> = {
+        call_id: payload.call_id,
+        name: payload.name,
+    };
+
+    if (event === StreamEvents.ToolCallStarted) {
+        analytics.track('agent-tool-call', { ...baseProps, event: 'started' });
+        return;
+    }
+
+    const finishedPayload = payload as ToolCallDonePayload | ToolCallErrorPayload;
+    analytics.track('agent-tool-call', {
+        ...baseProps,
+        event: event === StreamEvents.ToolCallDone ? 'done' : 'error',
+        duration_ms: finishedPayload.duration_ms,
+        extra_keys: finishedPayload.extra ? Object.keys(finishedPayload.extra).length : 0,
+    });
+}
+
 type ConnectToManagerOptions = AgentManagerOptions & {
     callbacks: AgentManagerOptions['callbacks'] & {
         onVideoIdChange?: (videoId: string | null) => void;
@@ -263,6 +290,10 @@ function connectToManager(
                             const readyLatency = streamReadyTimestampTracker.get(true);
                             analytics.track('agent-chat', { event: 'ready', latency: readyLatency });
                         },
+                        onToolEvent: ((event: any, data: any) => {
+                            options.callbacks.onToolEvent?.(event, data);
+                            trackToolEventAnalytics(event, data, analytics);
+                        }) as typeof options.callbacks.onToolEvent,
                     },
                 },
                 signal


### PR DESCRIPTION
## Summary
- Adds `agent-tool-call` Mixpanel event with an `event: 'started' | 'done' | 'error'` discriminator, mirroring the `agent-sdk` / `agent-chat` / `agent-video` pattern already used elsewhere in the SDK.
- Hooks tracking into the existing callbacks-spread in `connect-to-manager.ts` next to connection / video / activity analytics, so the streaming-manager layer stays unaware of analytics.
- Forwards the user's `onToolEvent` callback first, then tracks — same ordering as the other wrapped callbacks.

## Event shape
- `started`: `call_id`, `name`
- `done` / `error`: `call_id`, `name`, `duration_ms`, `extra_keys` (count of keys in backend's `extra` map, not the content)

Deliberately no `input`/`output` content — tool args may carry user-supplied PII. We can add an opt-in flag later if a use case shows up.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx jest src/services/agent-manager` — 92/92 pass
- [ ] Manual smoke: trigger a tool call in a real session and confirm `agent-tool-call` events arrive in Mixpanel with started→done pairs sharing the same `call_id`
- [ ] Manual smoke: force a tool error path and confirm `event: 'error'` arrives with `duration_ms` populated