### PR TITLE
bugfix: remove random session-key suffix from Client-Key auth header

### DIFF
--- a/src/auth/get-auth-header.test.ts
+++ b/src/auth/get-auth-header.test.ts
@@ -128,7 +128,7 @@ describe('getAuthHeader', () => {
             const auth: Auth = { type: 'key', clientKey: 'test-client-key' };
             const result = getAuthHeader(auth);
 
-            expect(result).toBe('Client-Key test-client-key.generated-external-id_mocked-random-id');
+            expect(result).toBe('Client-Key test-client-key.generated-external-id');
         });
 
         it('should use provided externalId in Client-Key header', () => {
@@ -136,8 +136,7 @@ describe('getAuthHeader', () => {
             const externalId = 'user-123';
             const result = getAuthHeader(auth, externalId);
 
-            expect(result).toBe('Client-Key test-client-key.user-123_mocked-random-id');
-            expect(result).toContain('user-123');
+            expect(result).toBe('Client-Key test-client-key.user-123');
         });
 
         it('should use externalId from localStorage when not provided', () => {
@@ -147,8 +146,7 @@ describe('getAuthHeader', () => {
             const auth: Auth = { type: 'key', clientKey: 'test-client-key' };
             const result = getAuthHeader(auth);
 
-            expect(result).toBe('Client-Key test-client-key.stored-user-id_mocked-random-id');
-            expect(result).toContain('stored-user-id');
+            expect(result).toBe('Client-Key test-client-key.stored-user-id');
         });
 
         it('should generate new externalId and store it when localStorage is empty', () => {
@@ -158,8 +156,7 @@ describe('getAuthHeader', () => {
             const auth: Auth = { type: 'key', clientKey: 'test-client-key' };
             const result = getAuthHeader(auth);
 
-            expect(result).toBe('Client-Key test-client-key.new-generated-id_mocked-random-id');
-            expect(result).toContain('new-generated-id');
+            expect(result).toBe('Client-Key test-client-key.new-generated-id');
             expect(window.localStorage.getItem('did_external_key_id')).toBe(mockRandomId);
         });
 

--- a/src/auth/get-auth-header.ts
+++ b/src/auth/get-auth-header.ts
@@ -18,14 +18,13 @@ export function getExternalId(externalId?: string): string {
     return key;
 }
 
-let sessionKey = getRandom();
 export function getAuthHeader(auth: Auth, externalId?: string) {
     if (auth.type === 'bearer') {
         return `Bearer ${auth.token}`;
     } else if (auth.type === 'basic') {
         return `Basic ${'token' in auth ? auth.token : btoa(`${auth.username}:${auth.password}`)}`;
     } else if (auth.type === 'key') {
-        return `Client-Key ${auth.clientKey}.${getExternalId(externalId)}_${sessionKey}`;
+        return `Client-Key ${auth.clientKey}.${getExternalId(externalId)}`;
     } else {
         throw new Error(`Unknown auth type: ${auth}`);
     }


### PR DESCRIPTION
### Pull Request Type

🐛 BugFix

### Description

- The SDK was appending a per-page-load random `_${sessionKey}` to the `Client-Key` auth header (`Client-Key <key>.<externalId>_<random>`). The backend authorizer splits only on `.`, so the suffix gets stored as part of the `external_id` request attribute and propagates downstream.
- This silently breaks per-user persistence: e.g. `memory_id = user.external_id` (`packages/services/agents/src/functions/triggers-adapter/services/publish-memory-extract.ts:24`) becomes a new value on every reload, so `scope: 'user'` memory writes a fresh S3 key per page load instead of accumulating against the same user. Same pattern inflates the `unique_users` count returned by `GET /sessions/aggregations`.
- Verified no backend code reads the `_${sessionKey}` portion as a session identifier. The only place that explicitly handled it (`chat-event.handler.ts:81` doing `external_id.split('_')[0]`) becomes a harmless no-op and can be cleaned up after old SDKs roll out of the wild.

### Reference Links