### PR TITLE
fix: migrate npm publish to OIDC Trusted Publisher

### DIFF
--- a/.github/workflows/publish-on-merge.yml
+++ b/.github/workflows/publish-on-merge.yml
@@ -49,6 +49,8 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           cache: "yarn"
 
+      # npm Trusted Publisher requires CLI >= 11.5.1 for OIDC token exchange.
+      # Bypass the broken arborist in the cached Node 22 image by extracting the tarball directly.
       - name: Upgrade NPM
         env:
           NODE_VERSION: ${{ steps.setup-node.outputs.node-version }}
@@ -66,7 +68,6 @@ jobs:
             || logger -l error -m "Failed to upgrade NPM"
 
           logger -l info -m "Upgrade NPM succeeded"
-          npm --version
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/publish-on-merge.yml
+++ b/.github/workflows/publish-on-merge.yml
@@ -66,6 +66,7 @@ jobs:
             || logger -l error -m "Failed to upgrade NPM"
 
           logger -l info -m "Upgrade NPM succeeded"
+          npm --version
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/publish-on-merge.yml
+++ b/.github/workflows/publish-on-merge.yml
@@ -49,7 +49,13 @@ jobs:
           cache: "yarn"
 
       - name: Upgrade npm
-        run: npm install -g npm@^11.5.1
+        run: |
+          # The Node 22 tool-cache ships with a broken npm (promise-retry missing
+          # from @npmcli/arborist), so npm install -g itself fails. Bypass by
+          # extracting the npm 11.5.1 tarball directly from the registry.
+          NPM_DIR=$(node -e "const p=require('path');process.stdout.write(p.join(p.dirname(p.dirname(process.execPath)),'lib','node_modules','npm'))")
+          curl -fsSL https://registry.npmjs.org/npm/-/npm-11.5.1.tgz | tar -xz --strip-components=1 -C "$NPM_DIR"
+          npm --version
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/publish-on-merge.yml
+++ b/.github/workflows/publish-on-merge.yml
@@ -12,6 +12,7 @@ on:
         type: boolean
 
 permissions:
+  id-token: write # Required for Trusted Publisher on NPMJS
   contents: write
 
 jobs:
@@ -46,6 +47,9 @@ jobs:
           node-version: 22
           registry-url: "https://registry.npmjs.org"
           cache: "yarn"
+
+      - name: Upgrade npm
+        run: npm install -g npm@^11.5.1
 
       - name: Install dependencies
         run: |
@@ -113,7 +117,7 @@ jobs:
 
       - name: Publish to NPM
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PACKAGE_UPLOAD_TOKEN }}
+          NODE_AUTH_TOKEN: '' # unset in order to use OIDC
         run: |
           if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
             logger -l info -m "🔍 DRY RUN MODE: Would publish version ${{ steps.version.outputs.version }} with tag ${{ steps.version.outputs.tag }}"

--- a/.github/workflows/publish-on-merge.yml
+++ b/.github/workflows/publish-on-merge.yml
@@ -51,10 +51,16 @@ jobs:
 
       - name: Upgrade NPM
         env:
-          NPM_DIR: /opt/hostedtoolcache/node/${{ steps.setup-node.outputs.node-version }}/x64/lib/node_modules/npm
+          NODE_VERSION: ${{ steps.setup-node.outputs.node-version }}
           NPM_VERSION: 11.5.1
         run: |
-          which npm
+          NODE_VERSION_STRIPED=${NODE_VERSION#v}
+          NPM_DIR="/opt/hostedtoolcache/node/$NODE_VERSION_STRIPED/x64/lib/node_modules/npm"
+
+          logger -l debug -m "NODE_VERSION_STRIPED: $NODE_VERSION_STRIPED"
+          logger -l debug -m "NPM_DIR: $NPM_DIR"
+          logger -l debug -m "NPM_VERSION: $NPM_VERSION"
+
           logger -l info -m "Upgrading NPM to version: $NPM_VERSION"
           curl -fsSL https://registry.npmjs.org/npm/-/npm-$NPM_VERSION.tgz | tar -xz --strip-components=1 -C "$NPM_DIR" \
             || logger -l error -m "Failed to upgrade NPM"

--- a/.github/workflows/publish-on-merge.yml
+++ b/.github/workflows/publish-on-merge.yml
@@ -42,22 +42,24 @@ jobs:
           sudo chmod +x /usr/local/bin/logger
 
       - name: Setup Node.js
+        id: setup-node
         uses: actions/setup-node@v6
         with:
           node-version: 22
           registry-url: "https://registry.npmjs.org"
           cache: "yarn"
 
-      - name: Upgrade npm
+      - name: Upgrade NPM
+        env:
+          NPM_DIR: /opt/hostedtoolcache/node/${{ steps.setup-node.outputs.node-version }}/x64/lib/node_modules/npm
+          NPM_VERSION: 11.5.1
         run: |
-          # The Node 22 tool-cache ships with a broken npm (promise-retry missing
-          # from @npmcli/arborist), so npm install -g itself fails. Bypass by
-          # extracting the npm 11.5.1 tarball directly from the registry.
-          NPM_DIR=$(node -e "const p=require('path');process.stdout.write(p.join(p.dirname(p.dirname(process.execPath)),'lib','node_modules','npm'))")
-          echo $NPM_DIR
-          curl -fsSL https://registry.npmjs.org/npm/-/npm-11.5.1.tgz | tar -xz --strip-components=1 -C "$NPM_DIR"
-          npm --version
-          exit
+          which npm
+          logger -l info -m "Upgrading NPM to version: $NPM_VERSION"
+          curl -fsSL https://registry.npmjs.org/npm/-/npm-$NPM_VERSION.tgz | tar -xz --strip-components=1 -C "$NPM_DIR" \
+            || logger -l error -m "Failed to upgrade NPM"
+
+          logger -l info -m "Upgrade NPM succeeded"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/publish-on-merge.yml
+++ b/.github/workflows/publish-on-merge.yml
@@ -54,8 +54,10 @@ jobs:
           # from @npmcli/arborist), so npm install -g itself fails. Bypass by
           # extracting the npm 11.5.1 tarball directly from the registry.
           NPM_DIR=$(node -e "const p=require('path');process.stdout.write(p.join(p.dirname(p.dirname(process.execPath)),'lib','node_modules','npm'))")
+          echo $NPM_DIR
           curl -fsSL https://registry.npmjs.org/npm/-/npm-11.5.1.tgz | tar -xz --strip-components=1 -C "$NPM_DIR"
           npm --version
+          exit
 
       - name: Install dependencies
         run: |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@d-id/client-sdk",
     "private": false,
-    "version": "1.1.64",
+    "version": "1.1.63",
     "type": "module",
     "description": "d-id client sdk",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@d-id/client-sdk",
     "private": false,
-    "version": "1.1.63",
+    "version": "1.1.64",
     "type": "module",
     "description": "d-id client sdk",
     "repository": {


### PR DESCRIPTION
- Add id-token: write permission required for OIDC token exchange
- Upgrade npm to ^11.5.1 (minimum version required by Trusted Publisher)
- Clear NODE_AUTH_TOKEN on publish step so npm uses OIDC instead of the old user token

### Pull Request Type

🔮 Feature
🐛 BugFix
⚒️ Refactor
🧹 Chore
🔥 HotFix
🚀 Release
<leave only relevant line>

### Description
-

### Reference Links
-   [Asana]() <add link inside brackets or delete line>
-   [DataDog]() <add link inside brackets or delete line>
