### PR TITLE
fix: ensure codec is captured in WebRTC stats report

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@d-id/client-sdk",
     "private": false,
-    "version": "1.1.63",
+    "version": "1.1.64",
     "type": "module",
     "description": "d-id client sdk",
     "repository": {

--- a/src/services/streaming-manager/stats/report.test.ts
+++ b/src/services/streaming-manager/stats/report.test.ts
@@ -1,0 +1,154 @@
+import { formatStats } from './report';
+
+type StatEntry = Record<string, any>;
+
+function buildStats(entries: StatEntry[]): RTCStatsReport {
+    const map = new Map<string, StatEntry>();
+    for (const entry of entries) {
+        map.set(entry.id, entry);
+    }
+    return map as unknown as RTCStatsReport;
+}
+
+const inboundRtpVideo: StatEntry = {
+    id: 'IT_video',
+    type: 'inbound-rtp',
+    kind: 'video',
+    codecId: 'CIT_video_vp8',
+    timestamp: 1_700_000_000_000,
+    bytesReceived: 1_234_567,
+    packetsReceived: 1_000,
+    packetsLost: 2,
+    framesDropped: 1,
+    framesDecoded: 600,
+    jitter: 0.01,
+    jitterBufferDelay: 30,
+    jitterBufferEmittedCount: 600,
+    frameWidth: 1280,
+    frameHeight: 720,
+    framesPerSecond: 30,
+    freezeCount: 0,
+    totalFreezesDuration: 0,
+};
+
+const codecVp8: StatEntry = { id: 'CIT_video_vp8', type: 'codec', mimeType: 'video/VP8' };
+const codecH264: StatEntry = { id: 'CIT_video_h264', type: 'codec', mimeType: 'video/H264' };
+const codecAudio: StatEntry = { id: 'CIT_audio_opus', type: 'codec', mimeType: 'audio/opus' };
+const inboundRtpAudio: StatEntry = { id: 'IT_audio', type: 'inbound-rtp', kind: 'audio' };
+
+const nominatedPair: StatEntry = {
+    id: 'CP_nominated',
+    type: 'candidate-pair',
+    nominated: true,
+    currentRoundTripTime: 0.05,
+};
+const backupPair: StatEntry = {
+    id: 'CP_backup',
+    type: 'candidate-pair',
+    nominated: false,
+    currentRoundTripTime: 0.2,
+};
+
+describe('formatStats', () => {
+    describe('codec extraction', () => {
+        it.each([
+            ['codec stat is iterated before inbound-rtp video', [codecVp8, inboundRtpVideo]],
+            ['codec stat is iterated after inbound-rtp video', [inboundRtpVideo, codecVp8]],
+        ])('returns the codec when %s', (_label, entries) => {
+            expect(formatStats(buildStats(entries)).codec).toBe('VP8');
+        });
+
+        it('returns the codec linked by codecId when multiple video codecs exist', () => {
+            const inboundUsingH264 = { ...inboundRtpVideo, codecId: codecH264.id };
+            expect(formatStats(buildStats([codecVp8, codecH264, inboundUsingH264])).codec).toBe('H264');
+        });
+
+        it.each([
+            [
+                'codecId does not match any codec entry',
+                [codecVp8, { ...inboundRtpVideo, codecId: 'unknown-id' }],
+            ],
+            [
+                'inbound-rtp omits codecId entirely',
+                [codecVp8, (() => { const { codecId, ...rest } = inboundRtpVideo; return rest; })()],
+            ],
+        ])('falls back to any video codec when %s', (_label, entries) => {
+            expect(formatStats(buildStats(entries)).codec).toBe('VP8');
+        });
+
+        it('ignores audio codec entries when picking a video codec', () => {
+            expect(formatStats(buildStats([codecAudio, codecVp8, inboundRtpVideo])).codec).toBe('VP8');
+        });
+
+        it('returns an empty codec string when no video codec is present', () => {
+            const inboundNoLink = { ...inboundRtpVideo, codecId: undefined };
+            expect(formatStats(buildStats([codecAudio, inboundNoLink])).codec).toBe('');
+        });
+
+        it('does not throw when a codec entry has no mimeType', () => {
+            const malformed = { id: 'CIT_bad', type: 'codec' };
+            expect(() => formatStats(buildStats([malformed, inboundRtpVideo]))).not.toThrow();
+        });
+    });
+
+    describe('inbound-rtp routing', () => {
+        it('returns an empty report when no video inbound-rtp is present', () => {
+            expect(formatStats(buildStats([codecVp8, inboundRtpAudio]))).toEqual({});
+        });
+
+        it('passes inbound-rtp fields through to the result', () => {
+            const result = formatStats(buildStats([codecVp8, inboundRtpVideo]));
+            expect(result).toMatchObject({
+                codec: 'VP8',
+                timestamp: inboundRtpVideo.timestamp,
+                bytesReceived: inboundRtpVideo.bytesReceived,
+                packetsReceived: inboundRtpVideo.packetsReceived,
+                packetsLost: inboundRtpVideo.packetsLost,
+                framesDropped: inboundRtpVideo.framesDropped,
+                framesDecoded: inboundRtpVideo.framesDecoded,
+                jitter: inboundRtpVideo.jitter,
+                jitterBufferDelay: inboundRtpVideo.jitterBufferDelay,
+                jitterBufferEmittedCount: inboundRtpVideo.jitterBufferEmittedCount,
+                frameWidth: inboundRtpVideo.frameWidth,
+                frameHeight: inboundRtpVideo.frameHeight,
+                framesPerSecond: inboundRtpVideo.framesPerSecond,
+                freezeCount: inboundRtpVideo.freezeCount,
+                freezeDuration: inboundRtpVideo.totalFreezesDuration,
+            });
+        });
+
+        it('derives avgJitterDelayInInterval as jitterBufferDelay / jitterBufferEmittedCount', () => {
+            const result = formatStats(buildStats([codecVp8, inboundRtpVideo]));
+            expect(result.avgJitterDelayInInterval).toBeCloseTo(
+                inboundRtpVideo.jitterBufferDelay / inboundRtpVideo.jitterBufferEmittedCount
+            );
+        });
+    });
+
+    describe('RTT priority', () => {
+        function rttFromPairs(pairs: StatEntry[]): number {
+            return formatStats(buildStats([...pairs, codecVp8, inboundRtpVideo])).rtt;
+        }
+
+        it('uses the nominated pair when no other pair is present', () => {
+            expect(rttFromPairs([nominatedPair])).toBe(nominatedPair.currentRoundTripTime);
+        });
+
+        it('uses the nominated pair when a backup pair appears before it', () => {
+            expect(rttFromPairs([backupPair, nominatedPair])).toBe(nominatedPair.currentRoundTripTime);
+        });
+
+        it('keeps the nominated pair when a backup pair appears after it', () => {
+            expect(rttFromPairs([nominatedPair, backupPair])).toBe(nominatedPair.currentRoundTripTime);
+        });
+
+        it('uses the backup pair when no nominated pair is present', () => {
+            expect(rttFromPairs([backupPair])).toBe(backupPair.currentRoundTripTime);
+        });
+
+        it('ignores candidate-pair entries with non-positive RTT', () => {
+            const zeroRttPair = { ...backupPair, currentRoundTripTime: 0 };
+            expect(rttFromPairs([zeroRttPair])).toBe(0);
+        });
+    });
+});

--- a/src/services/streaming-manager/stats/report.test.ts
+++ b/src/services/streaming-manager/stats/report.test.ts
@@ -64,13 +64,16 @@ describe('formatStats', () => {
         });
 
         it.each([
-            [
-                'codecId does not match any codec entry',
-                [codecVp8, { ...inboundRtpVideo, codecId: 'unknown-id' }],
-            ],
+            ['codecId does not match any codec entry', [codecVp8, { ...inboundRtpVideo, codecId: 'unknown-id' }]],
             [
                 'inbound-rtp omits codecId entirely',
-                [codecVp8, (() => { const { codecId, ...rest } = inboundRtpVideo; return rest; })()],
+                [
+                    codecVp8,
+                    (() => {
+                        const { codecId, ...rest } = inboundRtpVideo;
+                        return rest;
+                    })(),
+                ],
             ],
         ])('falls back to any video codec when %s', (_label, entries) => {
             expect(formatStats(buildStats(entries)).codec).toBe('VP8');

--- a/src/services/streaming-manager/stats/report.ts
+++ b/src/services/streaming-manager/stats/report.ts
@@ -77,19 +77,22 @@ function extractAnomalies(stats: AnalyticsRTCStatsReport[]): AnalyticsRTCStatsRe
 export function formatStats(stats: RTCStatsReport): SlimRTCStatsReport {
     let codec = '';
     let currRtt: number = 0;
+    let videoInboundRtp: RTCInboundRtpStreamStats | null = null;
+    const codecIdToMime = new Map<string, string>();
 
+    // RTCStatsReport iteration order is not guaranteed across browsers.
+    // Walk the full report once to collect codec/rtt/inbound-rtp before returning,
+    // otherwise we may return before the codec entry is seen and emit codec=''.
     for (const report of stats.values()) {
-        if (report && report.type === 'codec' && report.mimeType.startsWith('video')) {
-            codec = report.mimeType.split('/')[1];
-        }
-        if (report && report.type === 'candidate-pair') {
-            const rtt = report.currentRoundTripTime;
-            const candidatePair = report as any;
-            const isNominated = candidatePair.nominated === true;
+        if (!report) continue;
 
-            // Prioritize RTT from the nominated candidate-pair (the active connection path).
-            // This ensures we capture the actual network latency being used, not just any candidate.
-            // Only update if we have a valid positive RTT value to avoid overwriting with invalid data.
+        if (report.type === 'codec' && report.mimeType?.startsWith('video')) {
+            codecIdToMime.set(report.id, report.mimeType.split('/')[1]);
+        } else if (report.type === 'candidate-pair') {
+            const rtt = report.currentRoundTripTime;
+            const isNominated = (report as any).nominated === true;
+            // Prefer RTT from the nominated candidate-pair (the active connection path).
+            // Fall back to the first valid pair only until a nominated value arrives.
             if (rtt > 0) {
                 if (isNominated) {
                     currRtt = rtt;
@@ -97,30 +100,44 @@ export function formatStats(stats: RTCStatsReport): SlimRTCStatsReport {
                     currRtt = rtt;
                 }
             }
-        }
-        if (report && report.type === 'inbound-rtp' && report.kind === 'video') {
-            return {
-                codec,
-                rtt: currRtt,
-                timestamp: report.timestamp,
-                bytesReceived: report.bytesReceived,
-                packetsReceived: report.packetsReceived,
-                packetsLost: report.packetsLost,
-                framesDropped: report.framesDropped,
-                framesDecoded: report.framesDecoded,
-                jitter: report.jitter,
-                jitterBufferDelay: report.jitterBufferDelay,
-                jitterBufferEmittedCount: report.jitterBufferEmittedCount,
-                avgJitterDelayInInterval: report.jitterBufferDelay / report.jitterBufferEmittedCount,
-                frameWidth: report.frameWidth,
-                frameHeight: report.frameHeight,
-                framesPerSecond: report.framesPerSecond,
-                freezeCount: report.freezeCount,
-                freezeDuration: report.totalFreezesDuration,
-            } as SlimRTCStatsReport;
+        } else if (report.type === 'inbound-rtp' && report.kind === 'video') {
+            videoInboundRtp = report as RTCInboundRtpStreamStats;
         }
     }
-    return {} as SlimRTCStatsReport;
+
+    if (!videoInboundRtp) {
+        return {} as SlimRTCStatsReport;
+    }
+
+    // WebRTC marks every numeric field optional, but SlimRTCStatsReport expects
+    // required values. Single boundary cast avoids per-field null checks below.
+    const inbound = videoInboundRtp as Required<RTCInboundRtpStreamStats>;
+
+    if (inbound.codecId && codecIdToMime.has(inbound.codecId)) {
+        codec = codecIdToMime.get(inbound.codecId)!;
+    } else if (codecIdToMime.size > 0) {
+        codec = codecIdToMime.values().next().value ?? '';
+    }
+
+    return {
+        codec,
+        rtt: currRtt,
+        timestamp: inbound.timestamp,
+        bytesReceived: inbound.bytesReceived,
+        packetsReceived: inbound.packetsReceived,
+        packetsLost: inbound.packetsLost,
+        framesDropped: inbound.framesDropped,
+        framesDecoded: inbound.framesDecoded,
+        jitter: inbound.jitter,
+        jitterBufferDelay: inbound.jitterBufferDelay,
+        jitterBufferEmittedCount: inbound.jitterBufferEmittedCount,
+        avgJitterDelayInInterval: inbound.jitterBufferDelay / inbound.jitterBufferEmittedCount,
+        frameWidth: inbound.frameWidth,
+        frameHeight: inbound.frameHeight,
+        framesPerSecond: inbound.framesPerSecond,
+        freezeCount: inbound.freezeCount,
+        freezeDuration: (inbound as { totalFreezesDuration: number }).totalFreezesDuration,
+    } as SlimRTCStatsReport;
 }
 
 export function createVideoStatsReport(

--- a/src/services/streaming-manager/stats/report.ts
+++ b/src/services/streaming-manager/stats/report.ts
@@ -89,12 +89,12 @@ export function formatStats(stats: RTCStatsReport): SlimRTCStatsReport {
         if (report.type === 'codec' && report.mimeType?.startsWith('video')) {
             codecIdToMime.set(report.id, report.mimeType.split('/')[1]);
         } else if (report.type === 'candidate-pair') {
-            const rtt = report.currentRoundTripTime;
-            const isNominated = (report as any).nominated === true;
+            const pair = report as RTCIceCandidatePairStats;
+            const rtt = pair.currentRoundTripTime ?? 0;
             // Prefer RTT from the nominated candidate-pair (the active connection path).
             // Fall back to the first valid pair only until a nominated value arrives.
             if (rtt > 0) {
-                if (isNominated) {
+                if (pair.nominated === true) {
                     currRtt = rtt;
                 } else if (currRtt === 0) {
                     currRtt = rtt;
@@ -136,7 +136,7 @@ export function formatStats(stats: RTCStatsReport): SlimRTCStatsReport {
         frameHeight: inbound.frameHeight,
         framesPerSecond: inbound.framesPerSecond,
         freezeCount: inbound.freezeCount,
-        freezeDuration: (inbound as { totalFreezesDuration: number }).totalFreezesDuration,
+        freezeDuration: inbound.totalFreezesDuration,
     } as SlimRTCStatsReport;
 }
 


### PR DESCRIPTION
formatStats() previously returned at the first inbound-rtp video stat, which could leave codec=' ' when the browser's RTCStatsReport iteration order yielded inbound-rtp before the codec entry. This caused ~50% of stream-session events on Expressive to report codec=undefined in Mixpanel, breaking codec-based quality analysis.

The function now walks the full report once, links the codec via videoInboundRtp.codecId, and falls back to any video codec seen.

### Pull Request Type

🐛 BugFix

<leave only relevant line>

### Description
-

### Reference Links
-   [Asana](https://app.asana.com/1/856614567666442/project/1213796129611649/task/1214080561280821?focus=true) <add link inside brackets or delete line>
