### PR TITLE
Revert PR #377: restore Client-Key random suffix for per-tab WS routing

### DIFF
--- a/src/auth/get-auth-header.test.ts
+++ b/src/auth/get-auth-header.test.ts
@@ -128,7 +128,7 @@ describe('getAuthHeader', () => {
             const auth: Auth = { type: 'key', clientKey: 'test-client-key' };
             const result = getAuthHeader(auth);
 
-            expect(result).toBe('Client-Key test-client-key.generated-external-id');
+            expect(result).toBe('Client-Key test-client-key.generated-external-id_mocked-random-id');
         });
 
         it('should use provided externalId in Client-Key header', () => {
@@ -136,7 +136,8 @@ describe('getAuthHeader', () => {
             const externalId = 'user-123';
             const result = getAuthHeader(auth, externalId);
 
-            expect(result).toBe('Client-Key test-client-key.user-123');
+            expect(result).toBe('Client-Key test-client-key.user-123_mocked-random-id');
+            expect(result).toContain('user-123');
         });
 
         it('should use externalId from localStorage when not provided', () => {
@@ -146,7 +147,8 @@ describe('getAuthHeader', () => {
             const auth: Auth = { type: 'key', clientKey: 'test-client-key' };
             const result = getAuthHeader(auth);
 
-            expect(result).toBe('Client-Key test-client-key.stored-user-id');
+            expect(result).toBe('Client-Key test-client-key.stored-user-id_mocked-random-id');
+            expect(result).toContain('stored-user-id');
         });
 
         it('should generate new externalId and store it when localStorage is empty', () => {
@@ -156,7 +158,8 @@ describe('getAuthHeader', () => {
             const auth: Auth = { type: 'key', clientKey: 'test-client-key' };
             const result = getAuthHeader(auth);
 
-            expect(result).toBe('Client-Key test-client-key.new-generated-id');
+            expect(result).toBe('Client-Key test-client-key.new-generated-id_mocked-random-id');
+            expect(result).toContain('new-generated-id');
             expect(window.localStorage.getItem('did_external_key_id')).toBe(mockRandomId);
         });
 

--- a/src/auth/get-auth-header.ts
+++ b/src/auth/get-auth-header.ts
@@ -18,13 +18,14 @@ export function getExternalId(externalId?: string): string {
     return key;
 }
 
+let sessionKey = getRandom();
 export function getAuthHeader(auth: Auth, externalId?: string) {
     if (auth.type === 'bearer') {
         return `Bearer ${auth.token}`;
     } else if (auth.type === 'basic') {
         return `Basic ${'token' in auth ? auth.token : btoa(`${auth.username}:${auth.password}`)}`;
     } else if (auth.type === 'key') {
-        return `Client-Key ${auth.clientKey}.${getExternalId(externalId)}`;
+        return `Client-Key ${auth.clientKey}.${getExternalId(externalId)}_${sessionKey}`;
     } else {
         throw new Error(`Unknown auth type: ${auth}`);
     }


### PR DESCRIPTION
## Summary

Reverts commit 7c678d4 (PR #377). The Client-Key auth header again carries a per-page-load `_${sessionKey}` suffix, which the backend now splits into a clean `external_id` (analytics, memory_id) and `external_id_connect_id` (notifications WS per-tab routing).

## Why

PR #377 fixed an analytics regression where the per-page-load random made `external_id` non-stable per user. But the same random was load-bearing for the notifications WebSocket adapter, which uses it as the connections-table partition key. Removing it caused cross-tab message leakage: tab A's responses were delivered to tab B's socket whenever both tabs of the same browser were connected.

The backend PR (de-id/serverless#6754) splits the suffix at the authorizer boundary so analytics consumers see clean external_ids while the WS adapter routes per-tab. With that landed, this revert restores correct WS behavior without re-breaking analytics.

## Sequencing

**Do not merge or release this PR until de-id/serverless#6754 is deployed to prod.** Without the backend split, the suffix would once again bleed into analytics and memory_id keys.

## Test plan

- [ ] Backend split deployed to prod (verify de-id/serverless#6754 status)
- [ ] Manual two-tab test against prod: tab A and tab B, send chat from A, only A receives
- [ ] Manual analytics check: per-user identifier in analytics is stable across reloads
- [ ] Memory_id keys remain stable across reloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)