### PR TITLE
feat(content-parser): classify naked markdown ![alt](url.mp4) as video

### DIFF
--- a/src/utils/content-parser.test.ts
+++ b/src/utils/content-parser.test.ts
@@ -53,6 +53,43 @@ describe('parseMessageParts', () => {
         });
     });
 
+    describe('markdown video (naked image syntax with video URL)', () => {
+        it('should classify ![alt](url.mp4) as video, not image', () => {
+            const result = parseMessageParts(
+                '![A video about dinosaurs for kids](https://agents-results-dev.d-id.com/auth0%7C123/v2_agt_x/assets/abc.mp4)'
+            );
+            expect(result).toEqual([
+                {
+                    type: 'video',
+                    src: 'https://agents-results-dev.d-id.com/auth0%7C123/v2_agt_x/assets/abc.mp4',
+                    alt: 'A video about dinosaurs for kids',
+                },
+            ]);
+        });
+
+        it.each(['.mp4', '.webm', '.mkv', '.mov', '.m4v', '.ogv'])('should classify %s extensions as video', ext => {
+            const result = parseMessageParts(`![v](https://example.com/file${ext})`);
+            expect(result).toEqual([{ type: 'video', src: `https://example.com/file${ext}`, alt: 'v' }]);
+        });
+
+        it('should classify video URL with query string as video', () => {
+            const result = parseMessageParts('![v](https://example.com/file.mp4?token=abc&exp=123)');
+            expect(result).toEqual([
+                { type: 'video', src: 'https://example.com/file.mp4?token=abc&exp=123', alt: 'v' },
+            ]);
+        });
+
+        it('should classify video URL with hash fragment as video', () => {
+            const result = parseMessageParts('![v](https://example.com/file.mp4#t=10)');
+            expect(result).toEqual([{ type: 'video', src: 'https://example.com/file.mp4#t=10', alt: 'v' }]);
+        });
+
+        it('should not misclassify image URLs containing video extension in path', () => {
+            const result = parseMessageParts('![pic](https://example.com/mp4-archive/photo.png)');
+            expect(result).toEqual([{ type: 'image', src: 'https://example.com/mp4-archive/photo.png', alt: 'pic' }]);
+        });
+    });
+
     describe('markdown links', () => {
         it('should parse a markdown link', () => {
             const result = parseMessageParts('[click here](https://example.com)');

--- a/src/utils/content-parser.ts
+++ b/src/utils/content-parser.ts
@@ -6,6 +6,13 @@ const VIDEO_THUMBNAIL_RE = /\[!\[([^\[\]]*)\]\(([^)\s]+)\)\]\(([^)\s]+)\)/g;
 // Standard markdown image: ![alt](url)
 const IMAGE_RE = /!\[([^\[\]]*)\]\(([^)\s]+)\)/g;
 
+const VIDEO_EXTENSIONS = ['.mp4', '.webm', '.mkv', '.mov', '.m4v', '.ogv'];
+
+function isVideoUrl(url: string): boolean {
+    const path = url.split('?')[0].split('#')[0].toLowerCase();
+    return VIDEO_EXTENSIONS.some(ext => path.endsWith(ext));
+}
+
 // Standard markdown link: [label](url) — but NOT images (no leading !)
 const MD_LINK_RE = /(?<!!)\[([^\[\]]+)\]\(([^)\s]+)\)/g;
 
@@ -37,15 +44,23 @@ export function parseMessageParts(content: string): MessagePart[] {
         });
     }
 
-    // 2. Markdown images: ![alt](url) — skip those already consumed by video thumbnails
+    // 2. Markdown images: ![alt](url) — skip those already consumed by video thumbnails.
+    // A URL with a video extension is classified as video even without thumbnail syntax,
+    // since backends frequently emit naked `![alt](video.mp4)` for video assets.
     IMAGE_RE.lastIndex = 0;
     while ((m = IMAGE_RE.exec(content)) !== null) {
         const overlaps = matches.some(entry => m!.index >= entry.index && m!.index < entry.index + entry.length);
         if (!overlaps) {
             const src = m[2];
-            const part: MessagePart = { type: 'image', src, alt: m[1] };
-            if (src.toLowerCase().endsWith('.gif')) {
-                (part as Extract<MessagePart, { type: 'image' }>).mimeType = 'image/gif';
+            const alt = m[1];
+            let part: MessagePart;
+            if (isVideoUrl(src)) {
+                part = { type: 'video', src, alt };
+            } else {
+                part = { type: 'image', src, alt };
+                if (src.toLowerCase().endsWith('.gif')) {
+                    (part as Extract<MessagePart, { type: 'image' }>).mimeType = 'image/gif';
+                }
             }
             matches.push({ index: m.index, length: m[0].length, part });
         }


### PR DESCRIPTION
## Summary
- Detect known video extensions (`.mp4`, `.webm`, `.mkv`, `.mov`, `.m4v`, `.ogv`) in the URL path of standard markdown image syntax `![alt](url)` and emit a `video` `MessagePart` instead of `image`.
- Backends frequently emit videos as naked `![alt](video.mp4)` rather than the thumbnail-wrapped `[![alt](thumb)](video.mp4)`, which previously surfaced as a broken `<img>` in the UI.
- Extension matching is performed on the URL path (query string and hash stripped, lowercased) so signed URLs and fragments still classify correctly, and the `mp4` substring in folder names won't cause false positives.

## Test plan
- [x] `jest src/utils/content-parser.test.ts` — 27/27 pass, including the new `markdown video (naked image syntax with video URL)` block (extension matrix, query string, hash, false-positive guard).
- [ ] Manual verification with paired UI change in `agents-ui` — confirm a chat message containing `![title](https://.../asset.mp4)` renders as a `<video>` element.

## Asana
https://app.asana.com/1/856614567666442/project/1205271704969303/task/1214524866086809