### PR TITLE
fix(message-queue): voice interrupt detection via answer-vs-partials length

### DIFF
--- a/src/services/socket-manager/message-queue.ts
+++ b/src/services/socket-manager/message-queue.ts
@@ -34,12 +34,6 @@ function handleAudioTranscribedMessage(
         return;
     }
 
-    // Mark the last assistant message as interrupted when new user input arrives via server-side STT
-    const lastMessage = items.messages[items.messages.length - 1];
-    if (lastMessage?.role === 'assistant' && !lastMessage.interrupted) {
-        lastMessage.interrupted = true;
-    }
-
     const userMessage: Message = {
         id: data.id || `user-${Date.now()}`,
         role: data.role,
@@ -103,6 +97,13 @@ function processChatEvent(
     if (event === ChatProgress.Partial) {
         chatEventQueue[sequence] = content;
     } else {
+        // Answer shorter than accumulated partials means the orchestrator cut the segment
+        // short — i.e. the user interrupted mid-utterance.
+        const partialsContent = getMessageContent(chatEventQueue);
+        const isInterrupted = !!(content && content.length < partialsContent.length);
+        if (isInterrupted) {
+            currentMessage.interrupted = true;
+        }
         chatEventQueue['answer'] = content;
     }
 


### PR DESCRIPTION
## Summary

- Voice mode previously set `Message.interrupted = true` unconditionally on every `chat/audio-transcribed`, producing a trailing `…` on every assistant message after the first voice turn.
- Replaced with deterministic detection in `processChatEvent`: when `chat/answer.content` is shorter than the accumulated partials, the orchestrator cut the segment short → mark as interrupted.
- Text mode keeps existing behaviour (flag only via explicit `agent.interrupt()`).

## Asana
https://app.asana.com/1/856614567666442/project/1214294021916533/task/1214130455597264

## Test plan
- [x] `yarn jest` — 414/414 passing
- [x] Voice: greeting → "what's the weather in Madrid?" → "what's your name?" — no `…` on completed messages
- [x] Voice: "tell me a story" → interrupt with "stop, stop, stop" mid-utterance — `…` appears on the cut story
- [x] Text: unchanged, `…` only on explicit Stop button