### PR TITLE
fix(message-queue): drop late chat/answer from interrupted previous stream

### DIFF
--- a/src/services/socket-manager/message-queue.ts
+++ b/src/services/socket-manager/message-queue.ts
@@ -69,9 +69,7 @@ function processChatEvent(
     // User sent a new message mid-stream: the orchestrator's shortened closing `answer` for the
     // abandoned reply would otherwise land as a truncated duplicate after the new user message.
     const isLateAnswerFromInterruptedStream =
-        event === ChatProgress.Answer &&
-        lastMessage?.role === 'user' &&
-        lastAssistantMessageType === 'partial';
+        event === ChatProgress.Answer && lastMessage?.role === 'user' && lastAssistantMessageType === 'partial';
 
     if (isLateAnswerFromInterruptedStream) {
         return;

--- a/src/services/socket-manager/message-queue.ts
+++ b/src/services/socket-manager/message-queue.ts
@@ -66,6 +66,17 @@ function processChatEvent(
 
     const lastMessage = items.messages[items.messages.length - 1];
 
+    // User sent a new message mid-stream: the orchestrator's shortened closing `answer` for the
+    // abandoned reply would otherwise land as a truncated duplicate after the new user message.
+    const isLateAnswerFromInterruptedStream =
+        event === ChatProgress.Answer &&
+        lastMessage?.role === 'user' &&
+        lastAssistantMessageType === 'partial';
+
+    if (isLateAnswerFromInterruptedStream) {
+        return;
+    }
+
     // `chat/answer` closes a logical assistant message: the next chat event (Partial or Answer)
     // starts a new one. This covers post-tool replies that follow a pre-tool ack within the same
     // turn, and consecutive answers in clips/talks flows. The orchestrator does not send a


### PR DESCRIPTION
## Summary

When the user sends a new message while a previous assistant stream is still emitting `partial` events, the orchestrator follows up with a shortened closing `chat/answer` for the abandoned reply. With the user message already pushed, that late answer was hitting branch 2 of `processChatEvent` and opening a truncated duplicate assistant entry between the new user message and the genuine reply.

This PR detects the condition and drops the event.

## Reproduction (before fix)

In agents-ui:
1. Click "Tell me about your red wines"
2. ~2s into streaming, click "Tell me about your white wines"

Result: 7 articles in the chat — a truncated duplicate red-wines bubble appears between the white-wines user message and the actual white-wines reply.

## After fix

5 articles: `greeting, user(red), agent(red full), user(white), agent(white full)` — no duplicate.

## Detection signal

- `event === ChatProgress.Answer`
- `lastMessage?.role === 'user'`
- `lastAssistantMessageType === 'partial'`

The third condition is what makes it specific to the interrupt case: under normal (non-streaming) flows `lastAssistantMessageType` is `'answer'` or `null`, so the guard stays inactive.
