### PR TITLE
feat(analytics): track SDK errors to Mixpanel

### DIFF
--- a/src/services/agent-manager/index.test.ts
+++ b/src/services/agent-manager/index.test.ts
@@ -34,6 +34,7 @@ jest.mock('../../utils/chat', () => ({
 jest.mock('../../utils/analytics', () => ({
     getAgentInfo: jest.fn(() => ({ agentType: 'talk' })),
     getAnalyticsInfo: jest.fn(() => ({ agentType: 'talk' })),
+    getErrorMessage: jest.requireActual('../../utils/analytics').getErrorMessage,
 }));
 jest.mock('../../utils/defer', () => ({
     defer: jest.fn(fn => fn()),

--- a/src/services/agent-manager/index.test.ts
+++ b/src/services/agent-manager/index.test.ts
@@ -379,10 +379,10 @@ describe('createAgentManager', () => {
                 mockAgentsApi.chat.mockRejectedValueOnce(apiError);
 
                 await expect(manager.chat('Hello')).rejects.toThrow('API Error');
-                expect(mockAnalytics.track).toHaveBeenCalledWith('agent-message-send', {
-                    event: 'error',
-                    messages: expect.any(Number),
-                });
+                expect(mockAnalytics.track).toHaveBeenCalledWith(
+                    'agent-message-send',
+                    expect.objectContaining({ event: 'error', error: 'API Error' })
+                );
             });
 
             it('should handle retry logic for invalid session', async () => {

--- a/src/services/agent-manager/index.ts
+++ b/src/services/agent-manager/index.ts
@@ -23,7 +23,7 @@ import { isStreamsV2Agent } from '@sdk/utils/agent';
 import { isChatModeWithoutChat, isTextualChat } from '@sdk/utils/chat';
 import { parseMessagePartsMemo } from '@sdk/utils/content-parser';
 import { createAgentsApi } from '../../api/agents';
-import { getAgentInfo, getAnalyticsInfo } from '../../utils/analytics';
+import { getAgentInfo, getAnalyticsInfo, getErrorMessage } from '../../utils/analytics';
 import { defer } from '../../utils/defer';
 import { retryOperation } from '../../utils/retry-operation';
 import { initializeAnalytics } from '../analytics/mixpanel';
@@ -80,6 +80,12 @@ export async function createAgentManager(agent: string, options: AgentManagerOpt
     defer(() => {
         analytics.track('agent-sdk', { event: 'init' }, initTimestamp);
     });
+
+    const originalOnError = options.callbacks.onError;
+    options.callbacks.onError = (error: Error, errorData?: object) => {
+        analytics.track('agent-error', { error: getErrorMessage(error) });
+        originalOnError?.(error, errorData);
+    };
 
     const agentsApi = createAgentsApi(options.auth, baseURL, options.callbacks.onError, options.externalId);
 
@@ -489,6 +495,7 @@ export async function createAgentManager(agent: string, options: AgentManagerOpt
                 analytics.track('agent-message-send', {
                     event: 'error',
                     messages: items.messages.length,
+                    error: getErrorMessage(e),
                 });
 
                 throw e;

--- a/src/utils/analytics.test.ts
+++ b/src/utils/analytics.test.ts
@@ -1,0 +1,25 @@
+import { getErrorMessage } from './analytics';
+
+describe('getErrorMessage', () => {
+    it('returns the message of an Error', () => {
+        expect(getErrorMessage(new Error('boom'))).toBe('boom');
+    });
+
+    it('stringifies non-Error values', () => {
+        expect(getErrorMessage('plain string')).toBe('plain string');
+        expect(getErrorMessage(42)).toBe('42');
+    });
+
+    it('returns empty string for null/undefined', () => {
+        expect(getErrorMessage(null)).toBe('');
+        expect(getErrorMessage(undefined)).toBe('');
+    });
+
+    it('truncates messages to 256 characters', () => {
+        expect(getErrorMessage(new Error('x'.repeat(500)))).toHaveLength(256);
+    });
+
+    it('does not throw on values that cannot be stringified', () => {
+        expect(getErrorMessage(Object.create(null))).toBe('Unknown error');
+    });
+});

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -58,6 +58,8 @@ export function getAgentInfo(agent: Agent) {
         ...(agent.access === 'public' ? { from: 'agent-template' } : {}),
     };
 }
+export const getErrorMessage = (error: unknown) => String((error as Error)?.message ?? error ?? '').slice(0, 256);
+
 export const sumFunc = (numbers: number[]) => numbers.reduce((total, aNumber) => total + aNumber, 0);
 export const average = (numbers: number[]) => sumFunc(numbers) / numbers.length;
 

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -58,7 +58,13 @@ export function getAgentInfo(agent: Agent) {
         ...(agent.access === 'public' ? { from: 'agent-template' } : {}),
     };
 }
-export const getErrorMessage = (error: unknown) => String((error as Error)?.message ?? error ?? '').slice(0, 256);
+export const getErrorMessage = (error: unknown): string => {
+    try {
+        return String((error as Error)?.message ?? error ?? '').slice(0, 256);
+    } catch {
+        return 'Unknown error';
+    }
+};
 
 export const sumFunc = (numbers: number[]) => numbers.reduce((total, aNumber) => total + aNumber, 0);
 export const average = (numbers: number[]) => sumFunc(numbers) / numbers.length;


### PR DESCRIPTION
## What

- New `agent-error` Mixpanel event, tracked centrally by wrapping `options.callbacks.onError` in `createAgentManager` — every error surfaced by the SDK (api clients, socket manager, streaming managers, retry paths) is now tracked with its message. The consumer callback contract is unchanged.
- The existing `agent-message-send {event: 'error'}` now carries the error message too.
- `getErrorMessage(error)` util: error message as string, truncated to 256 chars (API error messages contain the raw response body).

## Why

Error events carried no detail, so production incidents couldn't be attributed from analytics. Investigating a real session today (LLM stalled 60s → chat POST timed out at the gateway's 29s cap → UI error handler switched to Maintenance and tore down a healthy WebRTC session) required a cross-system log dig; with this change the root cause is readable from the Mixpanel event (`error: '{"message":"Endpoint request timed out"}'`).

## Test plan

- `npx tsc --noEmit` clean
- Updated the chat-error assertion in `agent-manager/index.test.ts` (suite currently can't run due to a pre-existing `import.meta` jest config issue on main; `src/utils` suites pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)