### PR TITLE
feat(chat): raise max chat message length 800 → 2000

### DIFF
--- a/src/config/consts.ts
+++ b/src/config/consts.ts
@@ -1,2 +1,3 @@
 export const CONNECTION_RETRY_TIMEOUT_MS = 45 * 1000;
 export const PLAYGROUND_HEADER = 'X-Playground-Chat';
+export const MAX_CHAT_MESSAGE_LENGTH = 2000;

--- a/src/services/agent-manager/index.test.ts
+++ b/src/services/agent-manager/index.test.ts
@@ -1,3 +1,4 @@
+import { MAX_CHAT_MESSAGE_LENGTH } from '@sdk/config/consts';
 import { createAgentsApi } from '../../api/agents';
 import {
     AgentFactory,
@@ -48,7 +49,10 @@ jest.mock('../../config/environment', () => ({
     didSocketApiUrl: 'wss://api.d-id.com',
     mixpanelKey: 'test-mixpanel-key',
 }));
-jest.mock('../../config/consts', () => ({ CONNECTION_RETRY_TIMEOUT_MS: 5000 }));
+jest.mock('../../config/consts', () => ({
+    ...jest.requireActual('../../config/consts'),
+    CONNECTION_RETRY_TIMEOUT_MS: 5000,
+}));
 
 describe('createAgentManager', () => {
     let mockAgent: Agent;
@@ -323,8 +327,10 @@ describe('createAgentManager', () => {
             });
 
             it('should validate chat request - message too long', async () => {
-                const longMessage = 'a'.repeat(801);
-                await expect(manager.chat(longMessage)).rejects.toThrow('Message cannot be more than 800 characters');
+                const longMessage = 'a'.repeat(MAX_CHAT_MESSAGE_LENGTH + 1);
+                await expect(manager.chat(longMessage)).rejects.toThrow(
+                    `Message cannot be more than ${MAX_CHAT_MESSAGE_LENGTH} characters`
+                );
             });
 
             it('should validate chat request - maintenance mode', async () => {

--- a/src/services/agent-manager/index.ts
+++ b/src/services/agent-manager/index.ts
@@ -15,7 +15,7 @@ import {
 } from '../../types';
 
 import { rotateConnectionId } from '@sdk/auth/get-auth-header';
-import { CONNECTION_RETRY_TIMEOUT_MS } from '@sdk/config/consts';
+import { CONNECTION_RETRY_TIMEOUT_MS, MAX_CHAT_MESSAGE_LENGTH } from '@sdk/config/consts';
 import { didApiUrl, didSocketApiUrl, mixpanelKey } from '@sdk/config/environment';
 import { ChatCreationFailed, ValidationError } from '@sdk/errors';
 import { getRandom } from '@sdk/utils';
@@ -355,8 +355,8 @@ export async function createAgentManager(agent: string, options: AgentManagerOpt
             const validateChatRequest = () => {
                 if (isChatModeWithoutChat(mode)) {
                     throw new ValidationError(`${mode} is enabled, chat is disabled`);
-                } else if (userMessage.length >= 800) {
-                    throw new ValidationError('Message cannot be more than 800 characters');
+                } else if (userMessage.length >= MAX_CHAT_MESSAGE_LENGTH) {
+                    throw new ValidationError(`Message cannot be more than ${MAX_CHAT_MESSAGE_LENGTH} characters`);
                 } else if (userMessage.length === 0) {
                     throw new ValidationError('Message cannot be empty');
                 } else if (items.chatMode === ChatMode.Maintenance) {


### PR DESCRIPTION
### Pull Request Type

🔮 Feature

### Description
- Long-form mic STT (opt-in, up to ~60s of speech) can produce transcripts longer than the previous **800**-character chat cap, causing `chat()` to reject the message with `ValidationError: Message cannot be more than 800 characters`.
- Extracted the limit to a named `MAX_CHAT_MESSAGE_LENGTH` constant and raised it **800 → 2000** (headroom for ~60s of fast speech; not unbounded). Error message is now templated off the constant.
- Fixed a pre-existing partial mock in `agent-manager/index.test.ts` — `jest.mock('../../config/consts', …)` returned only `CONNECTION_RETRY_TIMEOUT_MS`, so any other export (incl. the new constant) resolved to `undefined`. Now spreads `jest.requireActual`.

### Reference Links
-
