### PR TITLE
chore: bump version to 1.1.70 (unblock prod publish)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@d-id/client-sdk",
     "private": false,
-    "version": "1.1.69",
+    "version": "1.1.70",
     "type": "module",
     "description": "d-id client sdk",
     "repository": {


### PR DESCRIPTION
### Pull Request Type

🧹 Chore

### Description
- Unblocks the failing prod `Auto Publish SDK` job. `package.json` (1.1.69) had drifted behind npm's published `latest` (1.1.70), so `npm version patch` produced 1.1.70 and hit `cannot publish over previously published versions: 1.1.70`.
- Aligns `package.json` with npm latest (1.1.70) so the next prod publish patches to **1.1.71** (free) and ships the chat-message-limit change (#404).
- NOTE: this is a one-time unblock. The underlying pipeline bug (commit-back step force-pushes protected `prod` → `GH006`, so the bump is never persisted) will recreate the drift on the next release and needs a separate fix.

### Reference Links
-