### PR TITLE
chore: bump version to 1.1.70 to unblock prod publish (#406)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@d-id/client-sdk",
     "private": false,
-    "version": "1.1.69",
+    "version": "1.1.70",
     "type": "module",
     "description": "d-id client sdk",
     "repository": {


### PR DESCRIPTION
The repo's package.json (1.1.69) had drifted behind npm's published latest (1.1.70), so the prod publish workflow's `npm version patch` produced 1.1.70 and failed with "cannot publish over previously published versions". Aligning package.json with npm latest so the next prod publish patches to 1.1.71 (free).

### Pull Request Type

🔮 Feature
🐛 BugFix
⚒️ Refactor
🧹 Chore
🔥 HotFix
🚀 Release
<leave only relevant line>

### Description
-

### Reference Links
-   [Asana]() <add link inside brackets or delete line>
-   [DataDog]() <add link inside brackets or delete line>
