### PR TITLE
feat(errors): typed, self-classifying errors (consumer contract + analytics)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@d-id/client-sdk",
     "private": false,
-    "version": "1.1.70",
+    "version": "1.2.0",
     "type": "module",
     "description": "d-id client sdk",
     "repository": {

--- a/src/api/apiClient.test.ts
+++ b/src/api/apiClient.test.ts
@@ -2,7 +2,7 @@ import { Auth } from '@sdk/types/auth';
 
 jest.mock('../config/environment', () => ({ didApiUrl: 'http://test-api.com' }));
 
-import { BaseError, HttpError } from '../errors';
+import { HttpError, NetworkError, isDIDError } from '../errors';
 import { toErrorAnalytics } from '../utils/error-analytics';
 import { createClient } from './apiClient';
 
@@ -93,7 +93,7 @@ describe('createClient', () => {
         const client = createClient(auth, 'https://api.example.com', onError);
 
         const rejection = await client.get('/agents/x').catch(e => e);
-        expect(rejection).toBeInstanceOf(BaseError);
+        expect(rejection).toBeInstanceOf(NetworkError);
         expect(rejection.kind).toBe('NetworkError');
         expect(rejection.originalError).toBe(networkError);
 
@@ -135,7 +135,7 @@ describe('createClient', () => {
         fetchSpy.mockRejectedValue(new TypeError('Failed to fetch'));
         const client = createClient(auth, 'https://api.example.com');
         const rejection = await client.get('/agents/x').catch(e => e);
-        expect(rejection).toBeInstanceOf(BaseError);
+        expect(rejection).toBeInstanceOf(NetworkError);
         expect(rejection.kind).toBe('NetworkError');
     });
 
@@ -165,6 +165,34 @@ describe('createClient', () => {
                 error: 'Network request failed',
                 cause: 'Failed to fetch',
             });
+        });
+    });
+
+    // The typed contract consumers (agents-ui, agents-ui-2) branch on: a stable `kind`,
+    // an HTTP `status`, and a dedicated NetworkError for transport failures — read via
+    // isDIDError(e) + e.kind, NOT JSON.parse(error.message) or `instanceof TypeError`.
+    describe('typed error contract for consumers', () => {
+        it('should expose an HTTP error with the server kind, status, and a human message', async () => {
+            const body = JSON.stringify({ kind: 'InsufficientCreditsError', description: 'no credits' });
+            fetchSpy.mockResolvedValue(fakeResponse({ status: 402, bodyText: body }));
+            const client = createClient(auth, 'https://api.example.com');
+
+            const error = await client.get('/agents/x').catch(e => e);
+            expect(isDIDError(error)).toBe(true);
+            expect(error).toBeInstanceOf(HttpError);
+            expect(error.kind).toBe('InsufficientCreditsError');
+            expect(error.status).toBe(402);
+            expect(error.message).toBe('no credits');
+        });
+
+        it('should expose a transport failure as a NetworkError', async () => {
+            fetchSpy.mockRejectedValue(new TypeError('Failed to fetch'));
+            const client = createClient(auth, 'https://api.example.com');
+
+            const error = await client.get('/agents/x').catch(e => e);
+            expect(isDIDError(error)).toBe(true);
+            expect(error).toBeInstanceOf(NetworkError);
+            expect(error.kind).toBe('NetworkError');
         });
     });
 });

--- a/src/api/apiClient.test.ts
+++ b/src/api/apiClient.test.ts
@@ -168,9 +168,6 @@ describe('createClient', () => {
         });
     });
 
-    // The typed contract consumers (agents-ui, agents-ui-2) branch on: a stable `kind`,
-    // an HTTP `status`, and a dedicated NetworkError for transport failures — read via
-    // isDIDError(e) + e.kind, NOT JSON.parse(error.message) or `instanceof TypeError`.
     describe('typed error contract for consumers', () => {
         it('should expose an HTTP error with the server kind, status, and a human message', async () => {
             const body = JSON.stringify({ kind: 'InsufficientCreditsError', description: 'no credits' });

--- a/src/api/apiClient.test.ts
+++ b/src/api/apiClient.test.ts
@@ -148,7 +148,7 @@ describe('createClient', () => {
             const rejection = await client.get('/agents/missing').catch(e => e);
             expect(toErrorAnalytics(rejection)).toEqual({
                 kind: 'NotFoundError',
-                error: 'agent not found',
+                message: 'agent not found',
                 httpStatus: 404,
                 endpoint: '/agents/missing',
                 method: 'GET',
@@ -162,7 +162,7 @@ describe('createClient', () => {
             const rejection = await client.get('/agents/x').catch(e => e);
             expect(toErrorAnalytics(rejection)).toEqual({
                 kind: 'NetworkError',
-                error: 'Network request failed',
+                message: 'Network request failed',
                 cause: 'Failed to fetch',
             });
         });

--- a/src/api/apiClient.test.ts
+++ b/src/api/apiClient.test.ts
@@ -2,13 +2,17 @@ import { Auth } from '@sdk/types/auth';
 
 jest.mock('../config/environment', () => ({ didApiUrl: 'http://test-api.com' }));
 
+import { BaseError, HttpError } from '../errors';
+import { toErrorAnalytics } from '../utils/error-analytics';
 import { createClient } from './apiClient';
 
 interface FakeResponseInit {
     status?: number;
+    statusText?: string;
     ok?: boolean;
     body?: unknown;
     bodyText?: string;
+    headers?: Record<string, string>;
 }
 
 function fakeResponse(init: FakeResponseInit = {}) {
@@ -16,7 +20,8 @@ function fakeResponse(init: FakeResponseInit = {}) {
     return {
         ok: init.ok ?? (status >= 200 && status < 300),
         status,
-        headers: new Map([['content-type', 'application/json']]),
+        statusText: init.statusText ?? '',
+        headers: new Map<string, string>([['content-type', 'application/json'], ...Object.entries(init.headers ?? {})]),
         json: jest.fn().mockResolvedValue(init.body ?? {}),
         text: jest.fn().mockResolvedValue(init.bodyText ?? JSON.stringify(init.body ?? '')),
     };
@@ -36,44 +41,69 @@ describe('createClient', () => {
         (globalThis as unknown as { fetch: typeof originalFetch }).fetch = originalFetch;
     });
 
-    it('resolves with parsed JSON on a 2xx response', async () => {
+    it('should resolve with parsed JSON when the response is 2xx', async () => {
         fetchSpy.mockResolvedValue(fakeResponse({ body: { id: 'x' } }));
         const client = createClient(auth, 'https://api.example.com');
         await expect(client.get('/agents/x')).resolves.toEqual({ id: 'x' });
     });
 
-    it('routes HTTP error responses through onError with url + options + headers', async () => {
-        fetchSpy.mockResolvedValue(fakeResponse({ status: 404, bodyText: 'NotFound' }));
+    it('should throw an HttpError with the server kind + status when the response is a non-2xx', async () => {
+        const body = JSON.stringify({ kind: 'NotFoundError', description: 'agent not found' });
+        fetchSpy.mockResolvedValue(fakeResponse({ status: 404, statusText: 'Not Found', bodyText: body }));
         const onError = jest.fn();
         const client = createClient(auth, 'https://api.example.com', onError);
 
-        await expect(client.get('/agents/missing')).rejects.toThrow('NotFound');
+        await expect(client.get('/agents/missing')).rejects.toBeInstanceOf(HttpError);
 
         expect(onError).toHaveBeenCalledTimes(1);
         const [err, data] = onError.mock.calls[0];
-        expect(err).toBeInstanceOf(Error);
-        expect(err.message).toBe('NotFound');
+        expect(err.kind).toBe('NotFoundError'); // parsed from server envelope
+        expect(err.message).toBe('agent not found');
+        expect(err.status).toBe(404);
+        expect(err.url).toBe('/agents/missing');
+        expect(err.method).toBe('GET');
         expect(data).toMatchObject({ url: '/agents/missing' });
-        expect(data.headers).toBeDefined();
     });
 
-    it('routes network-level fetch rejections through onError (TypeError)', async () => {
+    it('should throw an HttpError when the response is 5xx', async () => {
+        fetchSpy.mockResolvedValue(fakeResponse({ status: 504, bodyText: 'gateway timeout' }));
+        const onError = jest.fn();
+        const client = createClient(auth, 'https://api.example.com', onError);
+
+        const rejection = await client.post('/agents/x/chat', {}).catch(e => e);
+        expect(rejection).toBeInstanceOf(HttpError);
+        expect(rejection.status).toBe(504);
+        expect(onError.mock.calls[0][1]).toMatchObject({ url: '/agents/x/chat' });
+    });
+
+    it('should surface a 429 as an HttpError and not retry', async () => {
+        fetchSpy.mockResolvedValue(fakeResponse({ status: 429, bodyText: 'slow down' }));
+        const client = createClient(auth, 'https://api.example.com');
+
+        const rejection = await client.get('/agents/x').catch(e => e);
+        expect(rejection).toBeInstanceOf(HttpError);
+        expect(rejection.status).toBe(429);
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should wrap a network-level fetch rejection as a NetworkError', async () => {
         const networkError = new TypeError('Failed to fetch');
         fetchSpy.mockRejectedValue(networkError);
         const onError = jest.fn();
         const client = createClient(auth, 'https://api.example.com', onError);
 
-        await expect(client.get('/agents/x')).rejects.toBe(networkError);
+        const rejection = await client.get('/agents/x').catch(e => e);
+        expect(rejection).toBeInstanceOf(BaseError);
+        expect(rejection.kind).toBe('NetworkError');
+        expect(rejection.originalError).toBe(networkError);
 
         expect(onError).toHaveBeenCalledTimes(1);
         const [err, data] = onError.mock.calls[0];
-        expect(err).toBe(networkError);
+        expect(err.kind).toBe('NetworkError');
         expect(data).toMatchObject({ url: '/agents/x' });
-        // Network failures have no Response, so `headers` is intentionally absent.
-        expect(data).not.toHaveProperty('headers');
     });
 
-    it('does NOT route AbortError rejections through onError (cancellations are not errors)', async () => {
+    it('should not route AbortError through onError when the request is cancelled', async () => {
         const abortError = Object.assign(new Error('aborted'), { name: 'AbortError' });
         fetchSpy.mockRejectedValue(abortError);
         const onError = jest.fn();
@@ -83,7 +113,7 @@ describe('createClient', () => {
         expect(onError).not.toHaveBeenCalled();
     });
 
-    it('honors skipErrorHandler for network-level rejections', async () => {
+    it('should skip onError when skipErrorHandler is set on a network rejection', async () => {
         fetchSpy.mockRejectedValue(new TypeError('Failed to fetch'));
         const onError = jest.fn();
         const client = createClient(auth, 'https://api.example.com', onError);
@@ -92,7 +122,7 @@ describe('createClient', () => {
         expect(onError).not.toHaveBeenCalled();
     });
 
-    it('honors skipErrorHandler for HTTP error responses', async () => {
+    it('should skip onError when skipErrorHandler is set on an HTTP error', async () => {
         fetchSpy.mockResolvedValue(fakeResponse({ status: 500, bodyText: 'boom' }));
         const onError = jest.fn();
         const client = createClient(auth, 'https://api.example.com', onError);
@@ -101,9 +131,40 @@ describe('createClient', () => {
         expect(onError).not.toHaveBeenCalled();
     });
 
-    it('does not throw when no onError is supplied (network rejection still propagates)', async () => {
+    it('should still raise the wrapped error when no onError is supplied', async () => {
         fetchSpy.mockRejectedValue(new TypeError('Failed to fetch'));
         const client = createClient(auth, 'https://api.example.com');
-        await expect(client.get('/agents/x')).rejects.toThrow('Failed to fetch');
+        const rejection = await client.get('/agents/x').catch(e => e);
+        expect(rejection).toBeInstanceOf(BaseError);
+        expect(rejection.kind).toBe('NetworkError');
+    });
+
+    describe('end-to-end: thrown error → analytics payload', () => {
+        it('should produce a kind/status/endpoint/method payload when the request is an HTTP error', async () => {
+            const body = JSON.stringify({ kind: 'NotFoundError', description: 'agent not found' });
+            fetchSpy.mockResolvedValue(fakeResponse({ status: 404, bodyText: body }));
+            const client = createClient(auth, 'https://api.example.com');
+
+            const rejection = await client.get('/agents/missing').catch(e => e);
+            expect(toErrorAnalytics(rejection)).toEqual({
+                kind: 'NotFoundError',
+                error: 'agent not found',
+                httpStatus: 404,
+                endpoint: '/agents/missing',
+                method: 'GET',
+            });
+        });
+
+        it('should produce a NetworkError payload with the browser cause when fetch rejects', async () => {
+            fetchSpy.mockRejectedValue(new TypeError('Failed to fetch'));
+            const client = createClient(auth, 'https://api.example.com');
+
+            const rejection = await client.get('/agents/x').catch(e => e);
+            expect(toErrorAnalytics(rejection)).toEqual({
+                kind: 'NetworkError',
+                error: 'Network request failed',
+                cause: 'Failed to fetch',
+            });
+        });
     });
 });

--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -1,4 +1,4 @@
-import { BaseError, HttpError } from '@sdk/errors';
+import { HttpError, NetworkError } from '@sdk/errors';
 import { Auth } from '@sdk/types/auth';
 import { retryOperation } from '@sdk/utils/retry-operation';
 import { getAuthHeader } from '../auth/get-auth-header';
@@ -44,7 +44,7 @@ export function createClient(
                 throw networkError;
             }
 
-            const error = new BaseError('Network request failed', 'NetworkError', networkError);
+            const error = new NetworkError(networkError);
             if (!skipErrorHandler) {
                 onError?.(error, { url, options: fetchOptions });
             }

--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -1,3 +1,4 @@
+import { BaseError, HttpError } from '@sdk/errors';
 import { Auth } from '@sdk/types/auth';
 import { retryOperation } from '@sdk/utils/retry-operation';
 import { getAuthHeader } from '../auth/get-auth-header';
@@ -37,23 +38,25 @@ export function createClient(
                 })
             );
         } catch (networkError) {
-            // Network-level rejection — TypeError ("Failed to fetch"), DNS failure, offline,
-            // CORS preflight failure, etc. The HTTP-error branch below is unreachable in this
-            // case, so route the error through onError here so consumers learn about it.
-            // AbortError is excluded — those are intentional cancellations, not failures.
+            // no response reached us (offline / DNS / refused / TLS / CORS); AbortError is a cancellation
             const isAbort = (networkError as { name?: string })?.name === 'AbortError';
-            if (!isAbort && onError && !skipErrorHandler) {
-                onError(networkError as Error, { url, options: fetchOptions });
+            if (isAbort) {
+                throw networkError;
             }
-            throw networkError;
+
+            const error = new BaseError('Network request failed', 'NetworkError', networkError);
+            if (!skipErrorHandler) {
+                onError?.(error, { url, options: fetchOptions });
+            }
+            throw error;
         }
 
         if (!request.ok) {
-            let errorText: any = await request.text().catch(() => `Failed to fetch with status ${request.status}`);
-            const error = new Error(errorText);
+            const errorText = await request.text().catch(() => `Failed to fetch with status ${request.status}`);
+            const error = new HttpError(request.status, errorText, { url, method: fetchOptions.method ?? 'GET' });
 
-            if (onError && !skipErrorHandler) {
-                onError(error, { url, options: fetchOptions, headers: request.headers });
+            if (!skipErrorHandler) {
+                onError?.(error, { url, options: fetchOptions, headers: request.headers });
             }
 
             throw error;

--- a/src/errors/application-error.ts
+++ b/src/errors/application-error.ts
@@ -1,0 +1,7 @@
+import { BaseError } from './base-error';
+
+export class ApplicationError extends BaseError {
+    constructor(message: string, originalError?: unknown) {
+        super(message || 'UnknownError', 'ApplicationError', originalError);
+    }
+}

--- a/src/errors/application-error.ts
+++ b/src/errors/application-error.ts
@@ -1,7 +1,0 @@
-import { BaseError } from './base-error';
-
-export class ApplicationError extends BaseError {
-    constructor(message: string, originalError?: unknown) {
-        super(message || 'UnknownError', 'ApplicationError', originalError);
-    }
-}

--- a/src/errors/base-error.ts
+++ b/src/errors/base-error.ts
@@ -1,19 +1,27 @@
-interface BaseErrorParams {
+export interface ErrorJson {
     kind: string;
-    description?: string;
-    error?: Error;
+    error: string;
+    cause?: string;
+    [key: string]: any;
 }
 
 export class BaseError extends Error {
-    kind: string;
-    description?: string;
-    error?: Error;
+    constructor(
+        message: string,
+        public readonly kind: string = 'Error',
+        public readonly originalError?: unknown
+    ) {
+        super(message);
+        Object.setPrototypeOf(this, new.target.prototype);
+    }
 
-    constructor({ kind, description, error }: BaseErrorParams) {
-        super(JSON.stringify({ kind, description }));
-
-        this.kind = kind;
-        this.description = description;
-        this.error = error;
+    toJson(): ErrorJson {
+        // the cause's message — Error causes only, and only when it adds to ours (payload is public)
+        const cause = this.originalError instanceof Error ? this.originalError.message.slice(0, 256) : undefined;
+        return {
+            kind: this.kind,
+            error: this.message,
+            ...(cause && cause !== this.message ? { cause } : {}),
+        };
     }
 }

--- a/src/errors/base-error.ts
+++ b/src/errors/base-error.ts
@@ -1,6 +1,6 @@
 export interface ErrorJson {
     kind: string;
-    error: string;
+    message: string;
     cause?: string;
     [key: string]: any;
 }
@@ -20,7 +20,7 @@ export class BaseError extends Error {
         const cause = this.originalError instanceof Error ? this.originalError.message.slice(0, 256) : undefined;
         return {
             kind: this.kind,
-            error: this.message,
+            message: this.message,
             ...(cause && cause !== this.message ? { cause } : {}),
         };
     }

--- a/src/errors/base-error.ts
+++ b/src/errors/base-error.ts
@@ -25,3 +25,7 @@ export class BaseError extends Error {
         };
     }
 }
+
+export function isDIDError(error: unknown): error is BaseError {
+    return error instanceof Error && typeof (error as { kind?: unknown }).kind === 'string';
+}

--- a/src/errors/chat/chat-creation-failed.ts
+++ b/src/errors/chat/chat-creation-failed.ts
@@ -3,9 +3,6 @@ import { BaseError } from '../base-error';
 
 export class ChatCreationFailed extends BaseError {
     constructor(mode: ChatMode, persistent: boolean) {
-        super({
-            kind: 'ChatCreationFailed',
-            description: `Failed to create ${persistent ? 'persistent' : ''} chat, mode: ${mode}`,
-        });
+        super(`Failed to create ${persistent ? 'persistent' : ''} chat, mode: ${mode}`, 'ChatCreationFailed');
     }
 }

--- a/src/errors/chat/chat-mode-downgraded.ts
+++ b/src/errors/chat/chat-mode-downgraded.ts
@@ -3,6 +3,6 @@ import { BaseError } from '../base-error';
 
 export class ChatModeDowngraded extends BaseError {
     constructor(mode: ChatMode) {
-        super({ kind: 'ChatModeDowngraded', description: `Chat mode downgraded to ${mode}` });
+        super(`Chat mode downgraded to ${mode}`, 'ChatModeDowngraded');
     }
 }

--- a/src/errors/errors.test.ts
+++ b/src/errors/errors.test.ts
@@ -45,20 +45,20 @@ describe('SDK errors', () => {
             expect(err.message).toBe('boom');
             expect(err.kind).toBe('X');
             expect(err.originalError).toBe(cause);
-            expect(err.toJson()).toEqual({ kind: 'X', error: 'boom', cause: 'root' });
+            expect(err.toJson()).toEqual({ kind: 'X', message: 'boom', cause: 'root' });
         });
 
         it('should serialize the cause message only when it adds info, and never a non-Error cause', () => {
             // distinct wrapper message → the underlying browser message surfaces
             expect(
                 new BaseError('Network request failed', 'NetworkError', new TypeError('Failed to fetch')).toJson()
-            ).toEqual({ kind: 'NetworkError', error: 'Network request failed', cause: 'Failed to fetch' });
+            ).toEqual({ kind: 'NetworkError', message: 'Network request failed', cause: 'Failed to fetch' });
 
             // same message → no redundant cause
-            expect(new BaseError('boom', 'X', new Error('boom')).toJson()).toEqual({ kind: 'X', error: 'boom' });
+            expect(new BaseError('boom', 'X', new Error('boom')).toJson()).toEqual({ kind: 'X', message: 'boom' });
 
             // non-Error cause → omitted (never serialize arbitrary objects)
-            expect(new BaseError('boom', 'X', { token: 'SECRET' }).toJson()).toEqual({ kind: 'X', error: 'boom' });
+            expect(new BaseError('boom', 'X', { token: 'SECRET' }).toJson()).toEqual({ kind: 'X', message: 'boom' });
         });
     });
 
@@ -73,7 +73,7 @@ describe('SDK errors', () => {
             expect(err.status).toBe(402);
             expect(err.toJson()).toEqual({
                 kind: 'InsufficientCreditsError',
-                error: 'no credits',
+                message: 'no credits',
                 httpStatus: 402,
                 endpoint: '/agents/x/chat',
                 method: 'POST',
@@ -86,7 +86,7 @@ describe('SDK errors', () => {
             expect(err.message).toBe('<html>gateway timeout</html>');
             expect(err.toJson()).toEqual({
                 kind: 'HttpError',
-                error: '<html>gateway timeout</html>',
+                message: '<html>gateway timeout</html>',
                 httpStatus: 504,
             });
         });
@@ -97,7 +97,7 @@ describe('SDK errors', () => {
 
         it('should expose only mapped keys in toJson, never raw status/url/method', () => {
             const json = new HttpError(500, 'boom', { url: '/x', method: 'GET' }).toJson();
-            expect(Object.keys(json).sort()).toEqual(['endpoint', 'error', 'httpStatus', 'kind', 'method']);
+            expect(Object.keys(json).sort()).toEqual(['endpoint', 'httpStatus', 'kind', 'message', 'method']);
             expect(json).not.toHaveProperty('status');
             expect(json).not.toHaveProperty('url');
         });
@@ -105,7 +105,7 @@ describe('SDK errors', () => {
         it('should omit endpoint/method from toJson when the call context is absent', () => {
             expect(new HttpError(500, 'boom').toJson()).toEqual({
                 kind: 'HttpError',
-                error: 'boom',
+                message: 'boom',
                 httpStatus: 500,
             });
         });
@@ -116,14 +116,14 @@ describe('SDK errors', () => {
             const err = new ValidationError('Message cannot be empty', 'message');
             expect(err).toBeInstanceOf(ValidationError);
             expect(err.key).toBe('message');
-            expect(err.toJson()).toEqual({ kind: 'ValidationError', error: 'Message cannot be empty' });
+            expect(err.toJson()).toEqual({ kind: 'ValidationError', message: 'Message cannot be empty' });
             expect(err.toJson()).not.toHaveProperty('key');
         });
     });
 
     describe('WsError', () => {
         it('should use kind "WSError"', () => {
-            expect(new WsError('socket died').toJson()).toEqual({ kind: 'WSError', error: 'socket died' });
+            expect(new WsError('socket died').toJson()).toEqual({ kind: 'WSError', message: 'socket died' });
         });
     });
 

--- a/src/errors/errors.test.ts
+++ b/src/errors/errors.test.ts
@@ -1,13 +1,5 @@
 import { ChatMode } from '@sdk/types';
-import {
-    ApplicationError,
-    BaseError,
-    ChatCreationFailed,
-    ChatModeDowngraded,
-    HttpError,
-    ValidationError,
-    WsError,
-} from './index';
+import { BaseError, ChatCreationFailed, ChatModeDowngraded, HttpError, ValidationError, WsError } from './index';
 
 describe('SDK errors', () => {
     // The key invariant under an ES5 target: every error must remain catchable by type.
@@ -18,7 +10,6 @@ describe('SDK errors', () => {
             { name: 'HttpError', error: new HttpError(500, 'boom'), kind: 'HttpError' },
             { name: 'ValidationError', error: new ValidationError('bad'), kind: 'ValidationError' },
             { name: 'WsError', error: new WsError('socket'), kind: 'WSError' },
-            { name: 'ApplicationError', error: new ApplicationError('oops'), kind: 'ApplicationError' },
             {
                 name: 'ChatCreationFailed',
                 error: new ChatCreationFailed(ChatMode.Functional, true),
@@ -133,17 +124,6 @@ describe('SDK errors', () => {
     describe('WsError', () => {
         it('should use kind "WSError"', () => {
             expect(new WsError('socket died').toJson()).toEqual({ kind: 'WSError', error: 'socket died' });
-        });
-    });
-
-    describe('ApplicationError', () => {
-        it('should use kind "ApplicationError" and surface the cause message but never the cause object', () => {
-            const cause = new Error('root');
-            const err = new ApplicationError('wrapped', cause);
-            expect(err).toBeInstanceOf(ApplicationError);
-            expect(err.originalError).toBe(cause);
-            expect(err.toJson()).toEqual({ kind: 'ApplicationError', error: 'wrapped', cause: 'root' });
-            expect(err.toJson()).not.toHaveProperty('originalError');
         });
     });
 

--- a/src/errors/errors.test.ts
+++ b/src/errors/errors.test.ts
@@ -1,0 +1,161 @@
+import { ChatMode } from '@sdk/types';
+import {
+    ApplicationError,
+    BaseError,
+    ChatCreationFailed,
+    ChatModeDowngraded,
+    HttpError,
+    ValidationError,
+    WsError,
+} from './index';
+
+describe('SDK errors', () => {
+    // The key invariant under an ES5 target: every error must remain catchable by type.
+    describe('are catchable by type (instanceof survives throw + ES5 downleveling)', () => {
+        const cases: Array<{ name: string; error: BaseError; kind: string }> = [
+            { name: 'BaseError', error: new BaseError('boom'), kind: 'Error' },
+            { name: 'BaseError(custom)', error: new BaseError('boom', 'CustomKind'), kind: 'CustomKind' },
+            { name: 'HttpError', error: new HttpError(500, 'boom'), kind: 'HttpError' },
+            { name: 'ValidationError', error: new ValidationError('bad'), kind: 'ValidationError' },
+            { name: 'WsError', error: new WsError('socket'), kind: 'WSError' },
+            { name: 'ApplicationError', error: new ApplicationError('oops'), kind: 'ApplicationError' },
+            {
+                name: 'ChatCreationFailed',
+                error: new ChatCreationFailed(ChatMode.Functional, true),
+                kind: 'ChatCreationFailed',
+            },
+            {
+                name: 'ChatModeDowngraded',
+                error: new ChatModeDowngraded(ChatMode.TextOnly),
+                kind: 'ChatModeDowngraded',
+            },
+        ];
+
+        it.each(cases)('$name should be a catchable Error + BaseError with kind "$kind"', ({ error, kind }) => {
+            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(BaseError);
+            expect(error.kind).toBe(kind);
+
+            try {
+                throw error;
+            } catch (caught) {
+                expect(caught).toBeInstanceOf(BaseError);
+                expect((caught as BaseError).kind).toBe(kind);
+            }
+        });
+    });
+
+    describe('BaseError', () => {
+        it('should default kind to "Error" and carry message + cause', () => {
+            expect(new BaseError('boom').kind).toBe('Error');
+
+            const cause = new Error('root');
+            const err = new BaseError('boom', 'X', cause);
+            expect(err.message).toBe('boom');
+            expect(err.kind).toBe('X');
+            expect(err.originalError).toBe(cause);
+            expect(err.toJson()).toEqual({ kind: 'X', error: 'boom', cause: 'root' });
+        });
+
+        it('should serialize the cause message only when it adds info, and never a non-Error cause', () => {
+            // distinct wrapper message → the underlying browser message surfaces
+            expect(
+                new BaseError('Network request failed', 'NetworkError', new TypeError('Failed to fetch')).toJson()
+            ).toEqual({ kind: 'NetworkError', error: 'Network request failed', cause: 'Failed to fetch' });
+
+            // same message → no redundant cause
+            expect(new BaseError('boom', 'X', new Error('boom')).toJson()).toEqual({ kind: 'X', error: 'boom' });
+
+            // non-Error cause → omitted (never serialize arbitrary objects)
+            expect(new BaseError('boom', 'X', { token: 'SECRET' }).toJson()).toEqual({ kind: 'X', error: 'boom' });
+        });
+    });
+
+    describe('HttpError', () => {
+        it('should parse the server { kind, description } envelope and record the call', () => {
+            const body = JSON.stringify({ kind: 'InsufficientCreditsError', description: 'no credits' });
+            const err = new HttpError(402, body, { url: '/agents/x/chat', method: 'POST' });
+
+            expect(err).toBeInstanceOf(HttpError);
+            expect(err.kind).toBe('InsufficientCreditsError');
+            expect(err.message).toBe('no credits');
+            expect(err.status).toBe(402);
+            expect(err.toJson()).toEqual({
+                kind: 'InsufficientCreditsError',
+                error: 'no credits',
+                httpStatus: 402,
+                endpoint: '/agents/x/chat',
+                method: 'POST',
+            });
+        });
+
+        it('should fall back to kind "HttpError" + raw body when the body is not the envelope', () => {
+            const err = new HttpError(504, '<html>gateway timeout</html>');
+            expect(err.kind).toBe('HttpError');
+            expect(err.message).toBe('<html>gateway timeout</html>');
+            expect(err.toJson()).toEqual({
+                kind: 'HttpError',
+                error: '<html>gateway timeout</html>',
+                httpStatus: 504,
+            });
+        });
+
+        it('should cap the message at 256 chars when the body is huge', () => {
+            expect(new HttpError(500, 'x'.repeat(1000)).message).toHaveLength(256);
+        });
+
+        it('should expose only mapped keys in toJson, never raw status/url/method', () => {
+            const json = new HttpError(500, 'boom', { url: '/x', method: 'GET' }).toJson();
+            expect(Object.keys(json).sort()).toEqual(['endpoint', 'error', 'httpStatus', 'kind', 'method']);
+            expect(json).not.toHaveProperty('status');
+            expect(json).not.toHaveProperty('url');
+        });
+
+        it('should omit endpoint/method from toJson when the call context is absent', () => {
+            expect(new HttpError(500, 'boom').toJson()).toEqual({
+                kind: 'HttpError',
+                error: 'boom',
+                httpStatus: 500,
+            });
+        });
+    });
+
+    describe('ValidationError', () => {
+        it('should carry an optional key that is never serialized', () => {
+            const err = new ValidationError('Message cannot be empty', 'message');
+            expect(err).toBeInstanceOf(ValidationError);
+            expect(err.key).toBe('message');
+            expect(err.toJson()).toEqual({ kind: 'ValidationError', error: 'Message cannot be empty' });
+            expect(err.toJson()).not.toHaveProperty('key');
+        });
+    });
+
+    describe('WsError', () => {
+        it('should use kind "WSError"', () => {
+            expect(new WsError('socket died').toJson()).toEqual({ kind: 'WSError', error: 'socket died' });
+        });
+    });
+
+    describe('ApplicationError', () => {
+        it('should use kind "ApplicationError" and surface the cause message but never the cause object', () => {
+            const cause = new Error('root');
+            const err = new ApplicationError('wrapped', cause);
+            expect(err).toBeInstanceOf(ApplicationError);
+            expect(err.originalError).toBe(cause);
+            expect(err.toJson()).toEqual({ kind: 'ApplicationError', error: 'wrapped', cause: 'root' });
+            expect(err.toJson()).not.toHaveProperty('originalError');
+        });
+    });
+
+    describe('chat errors build descriptive messages', () => {
+        it('should build a descriptive ChatCreationFailed message', () => {
+            expect(new ChatCreationFailed(ChatMode.Functional, true).message).toBe(
+                'Failed to create persistent chat, mode: Functional'
+            );
+        });
+
+        it('should build a descriptive ChatModeDowngraded message', () => {
+            expect(new ChatModeDowngraded(ChatMode.TextOnly).message).toBe('Chat mode downgraded to TextOnly');
+        });
+    });
+});

--- a/src/errors/http-error.ts
+++ b/src/errors/http-error.ts
@@ -1,0 +1,44 @@
+import { BaseError, ErrorJson } from './base-error';
+
+interface ServerErrorBody {
+    kind?: string;
+    description?: string;
+}
+
+// The backend serializes errors as `{ kind, description }`; parse it to reuse the server's classification.
+function parseServerError(body: string): ServerErrorBody | undefined {
+    try {
+        const parsed = JSON.parse(body);
+        if (parsed && typeof parsed === 'object' && typeof parsed.kind === 'string') {
+            return parsed as ServerErrorBody;
+        }
+    } catch {
+        // not a JSON envelope
+    }
+    return undefined;
+}
+
+export class HttpError extends BaseError {
+    readonly status: number;
+    readonly url?: string;
+    readonly method?: string;
+
+    constructor(status: number, body: string, meta: { url?: string; method?: string } = {}) {
+        const parsed = parseServerError(body);
+        // Cap the body — a non-JSON 5xx (e.g. a gateway's HTML page) is the only unbounded message source.
+        super((parsed?.description ?? body).slice(0, 256), parsed?.kind ?? 'HttpError');
+
+        this.status = status;
+        this.url = meta.url;
+        this.method = meta.method;
+    }
+
+    toJson(): ErrorJson {
+        return {
+            ...super.toJson(),
+            httpStatus: this.status,
+            ...(this.url ? { endpoint: this.url } : {}),
+            ...(this.method ? { method: this.method } : {}),
+        };
+    }
+}

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -3,5 +3,6 @@ export * from './base-error';
 export * from './chat/chat-creation-failed';
 export * from './chat/chat-mode-downgraded';
 export * from './http-error';
+export * from './network-error';
 export * from './validation-error';
 export * from './ws-error';

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,4 +1,3 @@
-export * from './application-error';
 export * from './base-error';
 export * from './chat/chat-creation-failed';
 export * from './chat/chat-mode-downgraded';

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,4 +1,7 @@
+export * from './application-error';
+export * from './base-error';
 export * from './chat/chat-creation-failed';
 export * from './chat/chat-mode-downgraded';
+export * from './http-error';
 export * from './validation-error';
 export * from './ws-error';

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -3,5 +3,6 @@ export * from './chat/chat-creation-failed';
 export * from './chat/chat-mode-downgraded';
 export * from './http-error';
 export * from './network-error';
+export * from './stream-error';
 export * from './validation-error';
 export * from './ws-error';

--- a/src/errors/network-error.ts
+++ b/src/errors/network-error.ts
@@ -1,7 +1,6 @@
 import { BaseError } from './base-error';
 
-// A transport-level failure: the request never got a response (offline / DNS / refused / TLS / CORS).
-// Distinct from HttpError, which means the server *did* respond with a non-2xx status.
+// Transport failure: fetch rejected with no response. Distinct from HttpError (server responded non-2xx).
 export class NetworkError extends BaseError {
     constructor(originalError?: unknown) {
         super('Network request failed', 'NetworkError', originalError);

--- a/src/errors/network-error.ts
+++ b/src/errors/network-error.ts
@@ -1,0 +1,9 @@
+import { BaseError } from './base-error';
+
+// A transport-level failure: the request never got a response (offline / DNS / refused / TLS / CORS).
+// Distinct from HttpError, which means the server *did* respond with a non-2xx status.
+export class NetworkError extends BaseError {
+    constructor(originalError?: unknown) {
+        super('Network request failed', 'NetworkError', originalError);
+    }
+}

--- a/src/errors/stream-error.ts
+++ b/src/errors/stream-error.ts
@@ -1,0 +1,7 @@
+import { BaseError } from './base-error';
+
+export class StreamError extends BaseError {
+    constructor(message: string, originalError?: unknown) {
+        super(message, 'StreamError', originalError);
+    }
+}

--- a/src/errors/validation-error.ts
+++ b/src/errors/validation-error.ts
@@ -1,11 +1,10 @@
 import { BaseError } from './base-error';
 
 export class ValidationError extends BaseError {
-    key?: string;
-
-    constructor(message: string, key?: string) {
-        super({ kind: 'ValidationError', description: message });
-
-        this.key = key;
+    constructor(
+        message: string,
+        public readonly key?: string
+    ) {
+        super(message, 'ValidationError');
     }
 }

--- a/src/errors/ws-error.ts
+++ b/src/errors/ws-error.ts
@@ -2,6 +2,6 @@ import { BaseError } from './base-error';
 
 export class WsError extends BaseError {
     constructor(message: string) {
-        super({ kind: 'WSError', description: message });
+        super(message, 'WSError');
     }
 }

--- a/src/services/agent-manager/index.test.ts
+++ b/src/services/agent-manager/index.test.ts
@@ -388,7 +388,7 @@ describe('createAgentManager', () => {
                 await expect(manager.chat('Hello')).rejects.toThrow('API Error');
                 expect(mockAnalytics.track).toHaveBeenCalledWith(
                     'agent-message-send',
-                    expect.objectContaining({ event: 'error', error: 'API Error' })
+                    expect.objectContaining({ event: 'error', error: { kind: 'UnknownError', message: 'API Error' } })
                 );
             });
 

--- a/src/services/agent-manager/index.ts
+++ b/src/services/agent-manager/index.ts
@@ -17,7 +17,7 @@ import {
 import { rotateConnectionId } from '@sdk/auth/get-auth-header';
 import { CONNECTION_RETRY_TIMEOUT_MS, MAX_CHAT_MESSAGE_LENGTH } from '@sdk/config/consts';
 import { didApiUrl, didSocketApiUrl, mixpanelKey } from '@sdk/config/environment';
-import { ChatCreationFailed, ValidationError } from '@sdk/errors';
+import { ChatCreationFailed, HttpError, ValidationError } from '@sdk/errors';
 import { getRandom } from '@sdk/utils';
 import { isStreamsV2Agent } from '@sdk/utils/agent';
 import { isChatModeWithoutChat, isTextualChat } from '@sdk/utils/chat';
@@ -217,8 +217,10 @@ export async function createAgentManager(agent: string, options: AgentManagerOpt
                 timeoutErrorMessage: 'Timeout initializing the stream',
                 shouldRetryFn: (error: any) =>
                     error?.message !== 'Could not connect' &&
-                    error.status !== 429 &&
-                    error?.message !== 'InsufficientCreditsError',
+                    !(
+                        error instanceof HttpError &&
+                        (error.status === 429 || error.kind === 'InsufficientCreditsError')
+                    ),
                 delayMs: 1000,
             }
         ).catch(e => {
@@ -506,9 +508,9 @@ export async function createAgentManager(agent: string, options: AgentManagerOpt
             const message = items.messages.find(message => message.id === messageId);
 
             if (!items.chat) {
-                throw new Error('Chat is not initialized');
+                throw new ValidationError('Chat is not initialized');
             } else if (!message) {
-                throw new Error('Message not found');
+                throw new ValidationError('Message not found');
             }
 
             const matches: [string, string][] = message.matches?.map(match => [match.document_id, match.id]) ?? [];
@@ -539,7 +541,7 @@ export async function createAgentManager(agent: string, options: AgentManagerOpt
         },
         deleteRate(id: string) {
             if (!items.chat) {
-                throw new Error('Chat is not initialized');
+                throw new ValidationError('Chat is not initialized');
             }
 
             analytics.track('agent-rate-delete', { type: 'text' });
@@ -550,7 +552,7 @@ export async function createAgentManager(agent: string, options: AgentManagerOpt
             function getScript(): StreamScript {
                 if (typeof payload === 'string') {
                     if (!agentEntity.presenter.voice) {
-                        throw new Error('Presenter voice is not initialized');
+                        throw new ValidationError('Presenter voice is not initialized');
                     }
 
                     return {
@@ -563,7 +565,7 @@ export async function createAgentManager(agent: string, options: AgentManagerOpt
 
                 if (payload.type === 'text' && !payload.provider) {
                     if (!agentEntity.presenter.voice) {
-                        throw new Error('Presenter voice is not initialized');
+                        throw new ValidationError('Presenter voice is not initialized');
                     }
 
                     return {
@@ -604,7 +606,7 @@ export async function createAgentManager(agent: string, options: AgentManagerOpt
             }
 
             if (!items.streamingManager) {
-                throw new Error('Please connect to the agent first');
+                throw new ValidationError('Please connect to the agent first');
             }
 
             return items.streamingManager.speak({

--- a/src/services/agent-manager/index.ts
+++ b/src/services/agent-manager/index.ts
@@ -84,7 +84,7 @@ export async function createAgentManager(agent: string, options: AgentManagerOpt
 
     const originalOnError = options.callbacks.onError;
     options.callbacks.onError = (error: Error, errorData?: object) => {
-        analytics.track('agent-error', toErrorAnalytics(error));
+        analytics.track('agent-error', { error: toErrorAnalytics(error) });
         originalOnError?.(error, errorData);
     };
 
@@ -498,7 +498,7 @@ export async function createAgentManager(agent: string, options: AgentManagerOpt
                 analytics.track('agent-message-send', {
                     event: 'error',
                     messages: items.messages.length,
-                    ...toErrorAnalytics(e),
+                    error: toErrorAnalytics(e),
                 });
 
                 throw e;

--- a/src/services/agent-manager/index.ts
+++ b/src/services/agent-manager/index.ts
@@ -23,8 +23,9 @@ import { isStreamsV2Agent } from '@sdk/utils/agent';
 import { isChatModeWithoutChat, isTextualChat } from '@sdk/utils/chat';
 import { parseMessagePartsMemo } from '@sdk/utils/content-parser';
 import { createAgentsApi } from '../../api/agents';
-import { getAgentInfo, getAnalyticsInfo, getErrorMessage } from '../../utils/analytics';
+import { getAgentInfo, getAnalyticsInfo } from '../../utils/analytics';
 import { defer } from '../../utils/defer';
+import { toErrorAnalytics } from '../../utils/error-analytics';
 import { retryOperation } from '../../utils/retry-operation';
 import { initializeAnalytics } from '../analytics/mixpanel';
 import { interruptTimestampTracker, latencyTimestampTracker } from '../analytics/timestamp-tracker';
@@ -83,7 +84,7 @@ export async function createAgentManager(agent: string, options: AgentManagerOpt
 
     const originalOnError = options.callbacks.onError;
     options.callbacks.onError = (error: Error, errorData?: object) => {
-        analytics.track('agent-error', { error: getErrorMessage(error) });
+        analytics.track('agent-error', toErrorAnalytics(error));
         originalOnError?.(error, errorData);
     };
 
@@ -495,7 +496,7 @@ export async function createAgentManager(agent: string, options: AgentManagerOpt
                 analytics.track('agent-message-send', {
                     event: 'error',
                     messages: items.messages.length,
-                    error: getErrorMessage(e),
+                    ...toErrorAnalytics(e),
                 });
 
                 throw e;

--- a/src/services/chat/index.test.ts
+++ b/src/services/chat/index.test.ts
@@ -1,0 +1,34 @@
+jest.mock('@sdk/config/environment', () => ({
+    didApiUrl: 'http://test-api.com',
+    didSocketApiUrl: 'ws://test-api.com',
+    mixpanelKey: 'k',
+}));
+jest.mock('@sdk/utils/chat', () => ({ isChatModeWithoutChat: () => false }));
+
+import { HttpError } from '../../errors';
+import { createChat } from './index';
+
+describe('createChat error mapping', () => {
+    const agent = { id: 'a1' } as any;
+    const analytics = { track: jest.fn() } as any;
+    const api = (error: unknown) => ({ newChat: jest.fn().mockRejectedValue(error) }) as any;
+
+    it('should rethrow the InsufficientCreditsError sentinel when the server reports insufficient credits', async () => {
+        const body = JSON.stringify({ kind: 'InsufficientCreditsError', description: 'no credits' });
+        await expect(createChat(agent, api(new HttpError(402, body)), analytics)).rejects.toThrow(
+            'InsufficientCreditsError'
+        );
+    });
+
+    it('should map other failures to "Cannot create new chat" and preserve the status when it is a 429', async () => {
+        const error = await createChat(agent, api(new HttpError(429, 'slow down')), analytics).catch(e => e);
+        expect(error.message).toBe('Cannot create new chat');
+        expect(error.status).toBe(429);
+    });
+
+    it('should not attach a status when the failure is not an HttpError', async () => {
+        const error = await createChat(agent, api(new Error('boom')), analytics).catch(e => e);
+        expect(error.message).toBe('Cannot create new chat');
+        expect(error.status).toBeUndefined();
+    });
+});

--- a/src/services/chat/index.test.ts
+++ b/src/services/chat/index.test.ts
@@ -8,27 +8,29 @@ jest.mock('@sdk/utils/chat', () => ({ isChatModeWithoutChat: () => false }));
 import { HttpError } from '../../errors';
 import { createChat } from './index';
 
-describe('createChat error mapping', () => {
+describe('createChat', () => {
     const agent = { id: 'a1' } as any;
     const analytics = { track: jest.fn() } as any;
     const api = (error: unknown) => ({ newChat: jest.fn().mockRejectedValue(error) }) as any;
 
-    it('should rethrow the InsufficientCreditsError sentinel when the server reports insufficient credits', async () => {
+    it('should propagate a typed HttpError untouched (kind + status intact for the connect guard)', async () => {
         const body = JSON.stringify({ kind: 'InsufficientCreditsError', description: 'no credits' });
-        await expect(createChat(agent, api(new HttpError(402, body)), analytics)).rejects.toThrow(
-            'InsufficientCreditsError'
-        );
+        const httpError = new HttpError(402, body);
+        const error = await createChat(agent, api(httpError), analytics).catch(e => e);
+        expect(error).toBe(httpError);
+        expect(error.kind).toBe('InsufficientCreditsError');
+        expect(error.status).toBe(402);
     });
 
-    it('should map other failures to "Cannot create new chat" and preserve the status when it is a 429', async () => {
-        const error = await createChat(agent, api(new HttpError(429, 'slow down')), analytics).catch(e => e);
-        expect(error.message).toBe('Cannot create new chat');
+    it('should propagate a 429 HttpError with its status', async () => {
+        const httpError = new HttpError(429, 'slow down');
+        const error = await createChat(agent, api(httpError), analytics).catch(e => e);
+        expect(error).toBe(httpError);
         expect(error.status).toBe(429);
     });
 
-    it('should not attach a status when the failure is not an HttpError', async () => {
-        const error = await createChat(agent, api(new Error('boom')), analytics).catch(e => e);
-        expect(error.message).toBe('Cannot create new chat');
-        expect(error.status).toBeUndefined();
+    it('should propagate a non-HttpError failure as-is', async () => {
+        const original = new Error('boom');
+        await expect(createChat(agent, api(original), analytics)).rejects.toBe(original);
     });
 });

--- a/src/services/chat/index.ts
+++ b/src/services/chat/index.ts
@@ -1,5 +1,4 @@
 import { PLAYGROUND_HEADER } from '@sdk/config/consts';
-import { HttpError } from '@sdk/errors';
 import type { Agent, AgentsAPI, Chat } from '@sdk/types';
 import { ChatMode } from '@sdk/types';
 import { isChatModeWithoutChat } from '@sdk/utils/chat';
@@ -17,28 +16,15 @@ export async function createChat(
     persist = false,
     chat?: Chat
 ) {
-    try {
-        if (!chat && !isChatModeWithoutChat(chatMode)) {
-            chat = await agentsApi.newChat(agent.id, { persist }, getRequestHeaders(chatMode));
+    if (!chat && !isChatModeWithoutChat(chatMode)) {
+        chat = await agentsApi.newChat(agent.id, { persist }, getRequestHeaders(chatMode));
 
-            analytics.track('agent-chat', {
-                event: 'created',
-                chatId: chat.id,
-                mode: chatMode,
-            });
-        }
-
-        return { chat, chatMode: chat?.chat_mode ?? chatMode };
-    } catch (error) {
-        const httpError = error instanceof HttpError ? error : undefined;
-
-        if (httpError?.kind === 'InsufficientCreditsError') {
-            throw new Error('InsufficientCreditsError');
-        }
-
-        // preserve the status so the connect-level retry guard can fail-fast on a 429
-        const failure = new Error('Cannot create new chat') as Error & { status?: number };
-        failure.status = httpError?.status;
-        throw failure;
+        analytics.track('agent-chat', {
+            event: 'created',
+            chatId: chat.id,
+            mode: chatMode,
+        });
     }
+
+    return { chat, chatMode: chat?.chat_mode ?? chatMode };
 }

--- a/src/services/chat/index.ts
+++ b/src/services/chat/index.ts
@@ -1,10 +1,11 @@
 import { PLAYGROUND_HEADER } from '@sdk/config/consts';
+import { HttpError } from '@sdk/errors';
 import type { Agent, AgentsAPI, Chat } from '@sdk/types';
 import { ChatMode } from '@sdk/types';
 import { isChatModeWithoutChat } from '@sdk/utils/chat';
 import { Analytics } from '../analytics/mixpanel';
 
-export function getRequestHeaders(chatMode?: ChatMode): Record<string, Record<string, string>> {
+export function getRequestHeaders(chatMode?: ChatMode): { headers?: Record<string, string> } {
     return chatMode === ChatMode.Playground ? { headers: { [PLAYGROUND_HEADER]: 'true' } } : {};
 }
 
@@ -28,20 +29,16 @@ export async function createChat(
         }
 
         return { chat, chatMode: chat?.chat_mode ?? chatMode };
-    } catch (error: any) {
-        const errorKind = getErrorKind(error);
-        if (errorKind === 'InsufficientCreditsError') {
+    } catch (error) {
+        const httpError = error instanceof HttpError ? error : undefined;
+
+        if (httpError?.kind === 'InsufficientCreditsError') {
             throw new Error('InsufficientCreditsError');
         }
-        throw new Error('Cannot create new chat');
+
+        // preserve the status so the connect-level retry guard can fail-fast on a 429
+        const failure = new Error('Cannot create new chat') as Error & { status?: number };
+        failure.status = httpError?.status;
+        throw failure;
     }
 }
-
-const getErrorKind = (error: Error) => {
-    try {
-        const parsedError = JSON.parse(error.message);
-        return parsedError?.kind;
-    } catch (e) {
-        return 'UnknownError';
-    }
-};

--- a/src/services/socket-manager/message-queue.ts
+++ b/src/services/socket-manager/message-queue.ts
@@ -1,3 +1,4 @@
+import { StreamError } from '@sdk/errors';
 import { Agent, AgentManagerOptions, ChatProgress, StreamEvents } from '@sdk/types';
 import { Message } from '@sdk/types/entities/agents/chat';
 import { getStreamAnalyticsProps } from '@sdk/utils/analytics';
@@ -228,7 +229,7 @@ export function createMessageEventQueue(
                 }
 
                 if (failedEvents.includes(event)) {
-                    options.callbacks.onError?.(new Error(`Stream failed with event ${event}`), { data });
+                    options.callbacks.onError?.(new StreamError(`Stream failed with event ${event}`), { data });
                 }
 
                 if (data.event === SEvent.StreamDone) {

--- a/src/services/streaming-manager/livekit-manager.ts
+++ b/src/services/streaming-manager/livekit-manager.ts
@@ -1,3 +1,4 @@
+import { StreamError } from '@sdk/errors';
 import {
     AgentActivityState,
     ConnectionState,
@@ -71,10 +72,7 @@ const connectivityQualityToState = {
     unknown: ConnectivityState.Unknown,
 };
 
-const internalErrorMassage = JSON.stringify({
-    kind: 'InternalServerError',
-    description: 'Stream Error',
-});
+const streamError = (message = 'Stream Error') => new StreamError(message);
 
 export enum DataChannelTopic {
     Chat = 'lk.chat',
@@ -188,7 +186,7 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
                 error: 'Track subscription timeout',
                 sessionId,
             });
-            callbacks.onError?.(new Error('Track subscription timeout'), { sessionId });
+            callbacks.onError?.(streamError('Track subscription timeout'), { sessionId });
             disconnect('internal:track-subscription-timeout');
         }, TRACK_SUBSCRIPTION_TIMEOUT_MS);
     } catch (error) {
@@ -469,12 +467,12 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
 
     function handleMediaDevicesError(error: Error): void {
         log('Media devices error:', error);
-        callbacks.onError?.(new Error(internalErrorMassage), { sessionId });
+        callbacks.onError?.(streamError(), { sessionId });
     }
 
     function handleEncryptionError(error: Error): void {
         log('Encryption error:', error);
-        callbacks.onError?.(new Error(internalErrorMassage), { sessionId });
+        callbacks.onError?.(streamError(), { sessionId });
     }
 
     function handleTrackSubscriptionFailed(
@@ -642,7 +640,7 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
     async function sendMessage(message: string, topic: DataChannelTopic) {
         if (!isConnected || !room) {
             log('Room is not connected for sending messages');
-            callbacks.onError?.(new Error(internalErrorMassage), {
+            callbacks.onError?.(streamError(), {
                 sessionId,
             });
             return;
@@ -653,7 +651,7 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
             log('Message sent successfully:', message);
         } catch (error) {
             log('Failed to send message:', error);
-            callbacks.onError?.(new Error(internalErrorMassage), { sessionId });
+            callbacks.onError?.(streamError(), { sessionId });
         }
     }
 
@@ -664,7 +662,7 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
             return sendMessage('', topic);
         } catch (error) {
             log('Failed to send data channel message:', error);
-            callbacks.onError?.(new Error(internalErrorMassage), { sessionId });
+            callbacks.onError?.(streamError(), { sessionId });
         }
     }
 

--- a/src/services/streaming-manager/livekit-manager.ts
+++ b/src/services/streaming-manager/livekit-manager.ts
@@ -20,6 +20,7 @@ import { ChatProgress } from '@sdk/types/entities/agents/manager';
 import { noop } from '@sdk/utils';
 import { createStreamApiV2 } from '../../api/streams/streamsApiV2';
 import { didApiUrl } from '../../config/environment';
+import { toErrorAnalytics } from '../../utils/error-analytics';
 import { latencyTimestampTracker } from '../analytics/timestamp-tracker';
 import { createStreamingLogger, StreamingManager } from './common';
 import { chatEventMap } from './data-channel-handlers';
@@ -182,11 +183,12 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
                 `Track subscription timeout - no track subscribed within ${TRACK_SUBSCRIPTION_TIMEOUT_MS / 1000} seconds after connect`
             );
             trackSubscriptionTimeoutId = null;
+            const error = streamError('Track subscription timeout');
             analytics.track('connectivity-error', {
-                error: 'Track subscription timeout',
+                error: toErrorAnalytics(error),
                 sessionId,
             });
-            callbacks.onError?.(streamError('Track subscription timeout'), { sessionId });
+            callbacks.onError?.(error, { sessionId });
             disconnect('internal:track-subscription-timeout');
         }, TRACK_SUBSCRIPTION_TIMEOUT_MS);
     } catch (error) {

--- a/src/services/streaming-manager/webrtc-manager.ts
+++ b/src/services/streaming-manager/webrtc-manager.ts
@@ -1,5 +1,6 @@
 import { createStreamApi } from '@sdk/api/streams';
 import { didApiUrl } from '@sdk/config/environment';
+import { StreamError } from '@sdk/errors';
 import {
     AgentActivityState,
     ConnectionState,
@@ -327,7 +328,7 @@ export async function createWebRTCStreamingManager<T extends CreateStreamOptions
     function sendDataChannelMessage(payload: string) {
         if (!isConnected || pcDataChannel.readyState !== 'open') {
             log('Data channel is not ready for sending messages');
-            callbacks.onError?.(new Error('Data channel is not ready for sending messages'), {
+            callbacks.onError?.(new StreamError('Data channel is not ready for sending messages'), {
                 streamId: streamIdFromServer,
             });
             return;

--- a/src/utils/error-analytics.test.ts
+++ b/src/utils/error-analytics.test.ts
@@ -1,0 +1,82 @@
+import { ApplicationError, BaseError, HttpError, ValidationError, WsError } from '../errors';
+import { toErrorAnalytics } from './error-analytics';
+
+const ALLOWED_KEYS = ['kind', 'error', 'cause', 'httpStatus', 'endpoint', 'method'];
+
+describe('toErrorAnalytics', () => {
+    it("should delegate to an SDK error's own toJson()", () => {
+        const err = new HttpError(
+            402,
+            JSON.stringify({ kind: 'InsufficientCreditsError', description: 'no credits' }),
+            { url: '/agents/x/chat', method: 'POST' }
+        );
+        expect(toErrorAnalytics(err)).toEqual(err.toJson());
+        expect(toErrorAnalytics(err)).toEqual({
+            kind: 'InsufficientCreditsError',
+            error: 'no credits',
+            httpStatus: 402,
+            endpoint: '/agents/x/chat',
+            method: 'POST',
+        });
+    });
+
+    it('should classify every SDK error by its kind', () => {
+        expect(toErrorAnalytics(new HttpError(500, 'boom'))).toMatchObject({
+            kind: 'HttpError',
+            httpStatus: 500,
+        });
+        expect(toErrorAnalytics(new ValidationError('bad'))).toMatchObject({ kind: 'ValidationError', error: 'bad' });
+        expect(toErrorAnalytics(new WsError('socket'))).toMatchObject({ kind: 'WSError' });
+        expect(toErrorAnalytics(new BaseError('Network request failed', 'NetworkError'))).toEqual({
+            kind: 'NetworkError',
+            error: 'Network request failed',
+        });
+        expect(toErrorAnalytics(new BaseError('downgraded', 'ChatModeDowngraded'))).toMatchObject({
+            kind: 'ChatModeDowngraded',
+        });
+    });
+
+    describe('unknown / non-SDK throwables are wrapped as ApplicationError', () => {
+        it.each([
+            ['an Error', new Error('something weird'), 'something weird'],
+            ['a string', 'plain string', 'plain string'],
+            ['a number', 42, '42'],
+            ['null', null, 'UnknownError'],
+            ['undefined', undefined, 'UnknownError'],
+        ])('should wrap %s as an ApplicationError', (_label, thrown, expectedError) => {
+            expect(toErrorAnalytics(thrown)).toEqual({ kind: 'ApplicationError', error: expectedError });
+        });
+
+        it('should default the message to "Unknown error" when the value cannot be stringified', () => {
+            expect(toErrorAnalytics(Object.create(null))).toEqual({ kind: 'ApplicationError', error: 'Unknown error' });
+        });
+
+        it('should pass an explicit ApplicationError straight through', () => {
+            expect(toErrorAnalytics(new ApplicationError('explicit'))).toEqual({
+                kind: 'ApplicationError',
+                error: 'explicit',
+            });
+        });
+    });
+
+    describe('payload safety (the Mixpanel payload is publicly visible)', () => {
+        it('should emit only allow-listed scalar keys', () => {
+            const payloads = [
+                toErrorAnalytics(new HttpError(500, JSON.stringify({ kind: 'X' }), { url: '/x', method: 'GET' })),
+                toErrorAnalytics(new ValidationError('bad', 'secretFieldName')),
+                toErrorAnalytics(new ApplicationError('boom', { token: 'SECRET' })),
+                toErrorAnalytics(new Error('boom')),
+            ];
+            for (const payload of payloads) {
+                for (const key of Object.keys(payload)) {
+                    expect(ALLOWED_KEYS).toContain(key);
+                }
+            }
+        });
+
+        it('should never leak the original cause or a ValidationError key', () => {
+            expect(toErrorAnalytics(new ValidationError('bad', 'fieldName'))).not.toHaveProperty('key');
+            expect(toErrorAnalytics(new ApplicationError('boom', { secret: 1 }))).not.toHaveProperty('originalError');
+        });
+    });
+});

--- a/src/utils/error-analytics.test.ts
+++ b/src/utils/error-analytics.test.ts
@@ -1,7 +1,7 @@
 import { BaseError, HttpError, ValidationError, WsError } from '../errors';
 import { toErrorAnalytics } from './error-analytics';
 
-const ALLOWED_KEYS = ['kind', 'error', 'cause', 'httpStatus', 'endpoint', 'method'];
+const ALLOWED_KEYS = ['kind', 'message', 'cause', 'httpStatus', 'endpoint', 'method'];
 
 describe('toErrorAnalytics', () => {
     it("should delegate to an SDK error's own toJson()", () => {
@@ -13,7 +13,7 @@ describe('toErrorAnalytics', () => {
         expect(toErrorAnalytics(err)).toEqual(err.toJson());
         expect(toErrorAnalytics(err)).toEqual({
             kind: 'InsufficientCreditsError',
-            error: 'no credits',
+            message: 'no credits',
             httpStatus: 402,
             endpoint: '/agents/x/chat',
             method: 'POST',
@@ -25,11 +25,11 @@ describe('toErrorAnalytics', () => {
             kind: 'HttpError',
             httpStatus: 500,
         });
-        expect(toErrorAnalytics(new ValidationError('bad'))).toMatchObject({ kind: 'ValidationError', error: 'bad' });
+        expect(toErrorAnalytics(new ValidationError('bad'))).toMatchObject({ kind: 'ValidationError', message: 'bad' });
         expect(toErrorAnalytics(new WsError('socket'))).toMatchObject({ kind: 'WSError' });
         expect(toErrorAnalytics(new BaseError('Network request failed', 'NetworkError'))).toEqual({
             kind: 'NetworkError',
-            error: 'Network request failed',
+            message: 'Network request failed',
         });
         expect(toErrorAnalytics(new BaseError('downgraded', 'ChatModeDowngraded'))).toMatchObject({
             kind: 'ChatModeDowngraded',
@@ -43,12 +43,12 @@ describe('toErrorAnalytics', () => {
             ['a number', 42, '42'],
             ['null', null, 'UnknownError'],
             ['undefined', undefined, 'UnknownError'],
-        ])('should classify %s as UnknownError', (_label, thrown, expectedError) => {
-            expect(toErrorAnalytics(thrown)).toEqual({ kind: 'UnknownError', error: expectedError });
+        ])('should classify %s as UnknownError', (_label, thrown, expectedMessage) => {
+            expect(toErrorAnalytics(thrown)).toEqual({ kind: 'UnknownError', message: expectedMessage });
         });
 
         it('should default the message to "Unknown error" when the value cannot be stringified', () => {
-            expect(toErrorAnalytics(Object.create(null))).toEqual({ kind: 'UnknownError', error: 'Unknown error' });
+            expect(toErrorAnalytics(Object.create(null))).toEqual({ kind: 'UnknownError', message: 'Unknown error' });
         });
     });
 

--- a/src/utils/error-analytics.test.ts
+++ b/src/utils/error-analytics.test.ts
@@ -1,4 +1,4 @@
-import { ApplicationError, BaseError, HttpError, ValidationError, WsError } from '../errors';
+import { BaseError, HttpError, ValidationError, WsError } from '../errors';
 import { toErrorAnalytics } from './error-analytics';
 
 const ALLOWED_KEYS = ['kind', 'error', 'cause', 'httpStatus', 'endpoint', 'method'];
@@ -36,26 +36,19 @@ describe('toErrorAnalytics', () => {
         });
     });
 
-    describe('unknown / non-SDK throwables are wrapped as ApplicationError', () => {
+    describe('unknown / non-SDK throwables map to kind "UnknownError"', () => {
         it.each([
             ['an Error', new Error('something weird'), 'something weird'],
             ['a string', 'plain string', 'plain string'],
             ['a number', 42, '42'],
             ['null', null, 'UnknownError'],
             ['undefined', undefined, 'UnknownError'],
-        ])('should wrap %s as an ApplicationError', (_label, thrown, expectedError) => {
-            expect(toErrorAnalytics(thrown)).toEqual({ kind: 'ApplicationError', error: expectedError });
+        ])('should classify %s as UnknownError', (_label, thrown, expectedError) => {
+            expect(toErrorAnalytics(thrown)).toEqual({ kind: 'UnknownError', error: expectedError });
         });
 
         it('should default the message to "Unknown error" when the value cannot be stringified', () => {
-            expect(toErrorAnalytics(Object.create(null))).toEqual({ kind: 'ApplicationError', error: 'Unknown error' });
-        });
-
-        it('should pass an explicit ApplicationError straight through', () => {
-            expect(toErrorAnalytics(new ApplicationError('explicit'))).toEqual({
-                kind: 'ApplicationError',
-                error: 'explicit',
-            });
+            expect(toErrorAnalytics(Object.create(null))).toEqual({ kind: 'UnknownError', error: 'Unknown error' });
         });
     });
 
@@ -64,7 +57,7 @@ describe('toErrorAnalytics', () => {
             const payloads = [
                 toErrorAnalytics(new HttpError(500, JSON.stringify({ kind: 'X' }), { url: '/x', method: 'GET' })),
                 toErrorAnalytics(new ValidationError('bad', 'secretFieldName')),
-                toErrorAnalytics(new ApplicationError('boom', { token: 'SECRET' })),
+                toErrorAnalytics(new BaseError('boom', 'X', { token: 'SECRET' })),
                 toErrorAnalytics(new Error('boom')),
             ];
             for (const payload of payloads) {
@@ -76,7 +69,7 @@ describe('toErrorAnalytics', () => {
 
         it('should never leak the original cause or a ValidationError key', () => {
             expect(toErrorAnalytics(new ValidationError('bad', 'fieldName'))).not.toHaveProperty('key');
-            expect(toErrorAnalytics(new ApplicationError('boom', { secret: 1 }))).not.toHaveProperty('originalError');
+            expect(toErrorAnalytics(new BaseError('boom', 'X', { secret: 1 }))).not.toHaveProperty('originalError');
         });
     });
 });

--- a/src/utils/error-analytics.ts
+++ b/src/utils/error-analytics.ts
@@ -1,0 +1,10 @@
+import { ApplicationError, BaseError, ErrorJson } from '@sdk/errors';
+import { getErrorMessage } from './analytics';
+
+export type ErrorAnalyticsProps = ErrorJson;
+
+export function toErrorAnalytics(error: unknown): ErrorAnalyticsProps {
+    const sdkError = error instanceof BaseError ? error : new ApplicationError(getErrorMessage(error), error);
+
+    return sdkError.toJson();
+}

--- a/src/utils/error-analytics.ts
+++ b/src/utils/error-analytics.ts
@@ -8,5 +8,5 @@ export function toErrorAnalytics(error: unknown): ErrorAnalyticsProps {
         return error.toJson();
     }
 
-    return { kind: 'UnknownError', error: getErrorMessage(error) || 'UnknownError' };
+    return { kind: 'UnknownError', message: getErrorMessage(error) || 'UnknownError' };
 }

--- a/src/utils/error-analytics.ts
+++ b/src/utils/error-analytics.ts
@@ -1,10 +1,12 @@
-import { ApplicationError, BaseError, ErrorJson } from '@sdk/errors';
+import { BaseError, ErrorJson } from '@sdk/errors';
 import { getErrorMessage } from './analytics';
 
 export type ErrorAnalyticsProps = ErrorJson;
 
 export function toErrorAnalytics(error: unknown): ErrorAnalyticsProps {
-    const sdkError = error instanceof BaseError ? error : new ApplicationError(getErrorMessage(error), error);
+    if (error instanceof BaseError) {
+        return error.toJson();
+    }
 
-    return sdkError.toJson();
+    return { kind: 'UnknownError', error: getErrorMessage(error) || 'UnknownError' };
 }


### PR DESCRIPTION
## Why

Errors reaching Mixpanel (`agent-error`, `agent-message-send`, `connectivity-error`) collapsed into a single opaque `"Failed to fetch"` string — a gateway timeout, a 402 insufficient-credits, an offline blip, a stream failure, and a 500 all looked identical. You couldn't tell what happened or which call failed. The same opacity hurt **consumers**: agents-ui recovered the kind via `JSON.parse(error.message)` / `instanceof TypeError` — fragile, message-coupled control flow.

## What

A small, self-classifying typed error model — both the **analytics** source *and* a **consumer-facing contract**. `message` is human-readable; machine logic branches on a stable `kind`.

- **`BaseError(message, kind?, originalError?)`** — concrete base; `kind` is the stable discriminant, `originalError` preserved as `cause`.
- **`HttpError(status, body, {url, method})`** — a non-2xx response; parses the server's `{ kind, description }` envelope, so it carries the server's own kind + `status`.
- **`NetworkError`** — transport failure: `fetch` rejected with no response (offline / DNS / refused / TLS / CORS). **Distinct from `HttpError`** — this is what finally makes "gateway timeout (504) vs Failed to fetch (no response)" distinguishable.
- **`StreamError`** — client-side stream/media failure (livekit / webrtc / socket). Previously plain `Error`s that analytics saw as `UnknownError`.
- **`ValidationError` / `WsError` / `ChatCreationFailed` / `ChatModeDowngraded`** — thin kinds on top of `BaseError`.
- **`isDIDError(e): e is BaseError`** — a field-based guard so consumers branch on `error.kind` robustly across bundlers / duplicated deps, where `instanceof` can silently fail (the `axios.isAxiosError` pattern).
- **`toErrorAnalytics(error)`** maps any thrown value to a lean, **allow-listed** payload: an SDK error's `toJson()` (`{ kind, message, cause?, httpStatus?, endpoint?, method? }`), or `{ kind: 'UnknownError', message }` for a non-SDK throwable.

**Invariant:** every error reaching analytics goes through `toErrorAnalytics`, nested under a single `error` property — `error.kind` for breakdowns, `error.message` for detail, namespaced away from event fields.

## Versioning: minor (`1.1.70` → `1.2.0`)

Additive to the *documented* public surface — new error classes + `isDIDError`. `error.message` was never a promised structure and "network rejects with `TypeError`" was incidental `fetch` behavior, so no documented contract is broken → **minor**, not major. (Registry is at `1.1.71`; `1.2.0` clears it.)

## Consumer note (behavioral change)

No *documented* contract changed, but code coupled to error internals needs a one-line migration. Both known consumers (agents-ui, agents-ui-2) are migrated + green (unit + a temporary integration test against the real SDK classes; type-checks clean against local `1.2.0`).

| Consumer read | Before | After |
|---|---|---|
| classify by | `JSON.parse(error.message).kind` | `isDIDError(e) ? e.kind : undefined` |
| network check | `e instanceof TypeError` | `isDIDError(e) && e.kind === 'NetworkError'` |
| `error.message` | raw `{kind,description}` JSON | the human description |
| `error.kind` / `error.status` | `undefined` | server kind / HTTP status |

Released in lockstep: SDK `1.2.0` + both UIs (they pin exact versions; the dep bump is the coordination point).

## Mixpanel payload — before → after

```jsonc
// before — one opaque string for everything
{ "error": "Failed to fetch" }

// after — HTTP error
{ "error": { "kind": "InsufficientCreditsError", "message": "no credits", "httpStatus": 402, "endpoint": "/agents/x/chat", "method": "POST" } }
// after — transport failure
{ "error": { "kind": "NetworkError", "message": "Network request failed", "cause": "Failed to fetch" } }
// after — stream/media failure
{ "error": { "kind": "StreamError", "message": "Track subscription timeout" } }
```

> ⚠️ The `error` property changes type **string → object** on these events. The old string values are the `"Failed to fetch"` noise this PR replaces — break down on **`error.kind`** going forward.

## Notes
- `apiClient` raises the typed errors; `createChat` propagates them untouched; the connect retry guard fail-fasts on `HttpError.status === 429` / `kind === 'InsufficientCreditsError'` (was message/status strings).
- The analytics payload is an explicit allow-list — `originalError`, request bodies, headers, and auth never leak.
- 456 tests (error classes, classifier, client incl. typed-contract, `createChat`, guard); `type-check` + prettier clean.

## Out of scope (pre-existing)
- The dead `retryHttpTooManyRequests` 429 retry (`fetch` resolves on 429, so it never fires).
- `NetworkError` doesn't carry `endpoint`/`method` yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)