### PR TITLE
feat(errors): include endpoint + method on NetworkError

### DIFF
--- a/src/api/apiClient.test.ts
+++ b/src/api/apiClient.test.ts
@@ -164,6 +164,8 @@ describe('createClient', () => {
                 kind: 'NetworkError',
                 message: 'Network request failed',
                 cause: 'Failed to fetch',
+                endpoint: '/agents/x',
+                method: 'GET',
             });
         });
     });

--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -44,7 +44,7 @@ export function createClient(
                 throw networkError;
             }
 
-            const error = new NetworkError(networkError);
+            const error = new NetworkError(networkError, { url, method: fetchOptions.method ?? 'GET' });
             if (!skipErrorHandler) {
                 onError?.(error, { url, options: fetchOptions });
             }

--- a/src/errors/errors.test.ts
+++ b/src/errors/errors.test.ts
@@ -1,5 +1,13 @@
 import { ChatMode } from '@sdk/types';
-import { BaseError, ChatCreationFailed, ChatModeDowngraded, HttpError, ValidationError, WsError } from './index';
+import {
+    BaseError,
+    ChatCreationFailed,
+    ChatModeDowngraded,
+    HttpError,
+    NetworkError,
+    ValidationError,
+    WsError,
+} from './index';
 
 describe('SDK errors', () => {
     // The key invariant under an ES5 target: every error must remain catchable by type.
@@ -8,6 +16,7 @@ describe('SDK errors', () => {
             { name: 'BaseError', error: new BaseError('boom'), kind: 'Error' },
             { name: 'BaseError(custom)', error: new BaseError('boom', 'CustomKind'), kind: 'CustomKind' },
             { name: 'HttpError', error: new HttpError(500, 'boom'), kind: 'HttpError' },
+            { name: 'NetworkError', error: new NetworkError(new TypeError('Failed to fetch')), kind: 'NetworkError' },
             { name: 'ValidationError', error: new ValidationError('bad'), kind: 'ValidationError' },
             { name: 'WsError', error: new WsError('socket'), kind: 'WSError' },
             {
@@ -107,6 +116,29 @@ describe('SDK errors', () => {
                 kind: 'HttpError',
                 message: 'boom',
                 httpStatus: 500,
+            });
+        });
+    });
+
+    describe('NetworkError', () => {
+        it('should record the failing call (endpoint + method) and the underlying cause', () => {
+            const err = new NetworkError(new TypeError('Failed to fetch'), { url: '/agents/x/chat', method: 'POST' });
+
+            expect(err.kind).toBe('NetworkError');
+            expect(err.toJson()).toEqual({
+                kind: 'NetworkError',
+                message: 'Network request failed',
+                cause: 'Failed to fetch',
+                endpoint: '/agents/x/chat',
+                method: 'POST',
+            });
+        });
+
+        it('should omit endpoint/method when the call context is absent', () => {
+            expect(new NetworkError(new TypeError('Failed to fetch')).toJson()).toEqual({
+                kind: 'NetworkError',
+                message: 'Network request failed',
+                cause: 'Failed to fetch',
             });
         });
     });

--- a/src/errors/network-error.ts
+++ b/src/errors/network-error.ts
@@ -1,8 +1,21 @@
-import { BaseError } from './base-error';
+import { BaseError, ErrorJson } from './base-error';
 
 // Transport failure: fetch rejected with no response. Distinct from HttpError (server responded non-2xx).
 export class NetworkError extends BaseError {
-    constructor(originalError?: unknown) {
+    readonly endpoint?: string;
+    readonly method?: string;
+
+    constructor(originalError?: unknown, meta: { url?: string; method?: string } = {}) {
         super('Network request failed', 'NetworkError', originalError);
+        this.endpoint = meta.url;
+        this.method = meta.method;
+    }
+
+    toJson(): ErrorJson {
+        return {
+            ...super.toJson(),
+            ...(this.endpoint ? { endpoint: this.endpoint } : {}),
+            ...(this.method ? { method: this.method } : {}),
+        };
     }
 }


### PR DESCRIPTION
## What

`NetworkError` now carries the **endpoint** and **method** of the request that failed.

A `NetworkError` (fetch rejected with **no** response — offline / DNS / refused / TLS / CORS) previously serialized only `{kind, message, cause}`, so on prod you couldn't tell *which* request failed. `HttpError` already recorded `endpoint`/`method`; this brings `NetworkError` to the same shape.

The url/method are already known at the throw site (`apiClient` passes them to `onError`) — they just weren't baked into the error. Now `toJson()` emits them.

## Before / after

```diff
- { "kind": "NetworkError", "message": "Network request failed", "cause": "Failed to fetch" }
+ { "kind": "NetworkError", "message": "Network request failed", "cause": "Failed to fetch",
+   "endpoint": "/agents/x/chat", "method": "POST" }
```

So in Mixpanel you can break `NetworkError` down by `endpoint` — chat POST vs stream-create vs agent fetch — which tells you whether one specific route is failing (→ CORS/config) or all of them (→ connectivity).

## Test plan

- `yarn type-check` clean; full suite **459/459** passing.
- Added `NetworkError.toJson()` coverage (with and without call context) + an end-to-end `apiClient` assertion that endpoint/method propagate through the real client path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)