### PR TITLE
feat(errors): capture network-failure context on NetworkError

### DIFF
--- a/src/api/apiClient.test.ts
+++ b/src/api/apiClient.test.ts
@@ -155,18 +155,22 @@ describe('createClient', () => {
             });
         });
 
-        it('should produce a NetworkError payload with the browser cause when fetch rejects', async () => {
+        it('should produce a NetworkError payload with the browser cause + captured signals when fetch rejects', async () => {
             fetchSpy.mockRejectedValue(new TypeError('Failed to fetch'));
             const client = createClient(auth, 'https://api.example.com');
 
             const rejection = await client.get('/agents/x').catch(e => e);
-            expect(toErrorAnalytics(rejection)).toEqual({
+            const payload = toErrorAnalytics(rejection);
+            expect(payload).toMatchObject({
                 kind: 'NetworkError',
                 message: 'Network request failed',
                 cause: 'Failed to fetch',
                 endpoint: '/agents/x',
                 method: 'GET',
+                online: true, // jsdom default
+                visibility: 'visible', // jsdom default
             });
+            expect(payload.durationMs).toEqual(expect.any(Number));
         });
     });
 

--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -24,6 +24,8 @@ export function createClient(
 ) {
     const client = async <T>(url: string, options?: RequestOptions) => {
         const { skipErrorHandler, ...fetchOptions } = options || {};
+        const method = fetchOptions.method ?? 'GET';
+        const start = performance.now();
 
         let request: Response;
         try {
@@ -44,7 +46,13 @@ export function createClient(
                 throw networkError;
             }
 
-            const error = new NetworkError(networkError, { url, method: fetchOptions.method ?? 'GET' });
+            const error = new NetworkError(networkError, {
+                url,
+                method,
+                durationMs: Math.round(performance.now() - start),
+                online: typeof navigator !== 'undefined' ? navigator.onLine : undefined,
+                visibility: typeof document !== 'undefined' ? document.visibilityState : undefined,
+            });
             if (!skipErrorHandler) {
                 onError?.(error, { url, options: fetchOptions });
             }
@@ -53,7 +61,7 @@ export function createClient(
 
         if (!request.ok) {
             const errorText = await request.text().catch(() => `Failed to fetch with status ${request.status}`);
-            const error = new HttpError(request.status, errorText, { url, method: fetchOptions.method ?? 'GET' });
+            const error = new HttpError(request.status, errorText, { url, method });
 
             if (!skipErrorHandler) {
                 onError?.(error, { url, options: fetchOptions, headers: request.headers });

--- a/src/errors/errors.test.ts
+++ b/src/errors/errors.test.ts
@@ -134,11 +134,31 @@ describe('SDK errors', () => {
             });
         });
 
-        it('should omit endpoint/method when the call context is absent', () => {
+        it('should omit endpoint/method/signals when the call context is absent', () => {
             expect(new NetworkError(new TypeError('Failed to fetch')).toJson()).toEqual({
                 kind: 'NetworkError',
                 message: 'Network request failed',
                 cause: 'Failed to fetch',
+            });
+        });
+
+        it('should serialize the captured context signals', () => {
+            const err = new NetworkError(new TypeError('Load failed'), {
+                url: '/streams',
+                method: 'POST',
+                durationMs: 1234,
+                online: false,
+                visibility: 'hidden',
+            });
+            expect(err.toJson()).toEqual({
+                kind: 'NetworkError',
+                message: 'Network request failed',
+                cause: 'Load failed',
+                endpoint: '/streams',
+                method: 'POST',
+                durationMs: 1234,
+                online: false,
+                visibility: 'hidden',
             });
         });
     });

--- a/src/errors/network-error.ts
+++ b/src/errors/network-error.ts
@@ -1,14 +1,28 @@
 import { BaseError, ErrorJson } from './base-error';
 
+export interface NetworkErrorMeta {
+    url?: string;
+    method?: string;
+    durationMs?: number;
+    online?: boolean;
+    visibility?: DocumentVisibilityState;
+}
+
 // Transport failure: fetch rejected with no response. Distinct from HttpError (server responded non-2xx).
 export class NetworkError extends BaseError {
     readonly endpoint?: string;
     readonly method?: string;
+    readonly durationMs?: number;
+    readonly online?: boolean;
+    readonly visibility?: DocumentVisibilityState;
 
-    constructor(originalError?: unknown, meta: { url?: string; method?: string } = {}) {
+    constructor(originalError?: unknown, meta: NetworkErrorMeta = {}) {
         super('Network request failed', 'NetworkError', originalError);
         this.endpoint = meta.url;
         this.method = meta.method;
+        this.durationMs = meta.durationMs;
+        this.online = meta.online;
+        this.visibility = meta.visibility;
     }
 
     toJson(): ErrorJson {
@@ -16,6 +30,9 @@ export class NetworkError extends BaseError {
             ...super.toJson(),
             ...(this.endpoint ? { endpoint: this.endpoint } : {}),
             ...(this.method ? { method: this.method } : {}),
+            ...(this.durationMs !== undefined ? { durationMs: this.durationMs } : {}),
+            ...(this.online !== undefined ? { online: this.online } : {}),
+            ...(this.visibility ? { visibility: this.visibility } : {}),
         };
     }
 }


### PR DESCRIPTION
## Why

`agent-error` events of kind `NetworkError` are currently an opaque bucket — the only client-side signal is the browser's generic `cause` (`Failed to fetch` / `Load failed` / `NetworkError when attempting to fetch resource.`), which can't distinguish a user being offline from a page-unload abort from a real connection failure or a hang. This adds the cheap, synchronous context we can read at the moment a `fetch` rejects, so these events become triageable in Mixpanel.

## What changed (observability only)

`NetworkError` now carries, and `toJson()` serializes (each omitted when absent):

- **`durationMs`** — time from request start to rejection (proxy for a timeout-like hang vs an instant fail)
- **`online`** — `navigator.onLine` at the failure
- **`visibility`** — `document.visibilityState` at the failure

`apiClient` captures these on the fetch-rejection path and passes them in. No interpretation is baked into the SDK — segmentation stays in the analytics layer:

- `online: false` → user connectivity
- `visibility: "hidden"` → likely navigation/unload noise (filter it)
- high `durationMs` → timeout-like hang
- else → generic connection failure

Resulting payload:
```json
{ "kind":"NetworkError", "message":"Network request failed", "cause":"Failed to fetch",
  "endpoint":"/v2_agt_x", "method":"GET", "durationMs":312, "online":true, "visibility":"visible" }
```

All values are safe scalars (no bodies/headers/auth) — the payload remains client-visible-safe.

## Explicitly NOT in this PR

No behavior changes. Deferred (discussed separately): a real client-side request timeout (`AbortSignal.timeout`, which would enable a definitive timeout signal) and not blindly retrying non-idempotent POSTs in stream-init.

## Tests

Updated `network-error` + `apiClient` unit tests for the new fields. Full suite green (460 tests), `tsc` and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)