### PR TITLE
feat(stats): A/V-sync observability + anomalies in the WebRTC stats report

### DIFF
--- a/src/services/streaming-manager/stats/av-sync.ts
+++ b/src/services/streaming-manager/stats/av-sync.ts
@@ -1,0 +1,135 @@
+import { AvSyncAnomaly, AvSyncReport, AvSyncSample, SlimRTCStatsReport } from '@sdk/types';
+
+const CONVERGED_THRESHOLD_MS = 100;
+
+const round = (value: number) => Math.round(value);
+const round2 = (value: number) => Math.round(value * 100) / 100;
+const percentile = (sorted: number[], p: number) =>
+    sorted[Math.min(sorted.length - 1, Math.floor(p * (sorted.length - 1)))];
+
+function detectAvSyncAnomalies(report: Omit<AvSyncReport, 'anomalies'>): AvSyncAnomaly[] {
+    const anomalies: AvSyncAnomaly[] = [];
+    const add = (condition: boolean, type: string, severity: AvSyncAnomaly['severity'], detail: string) => {
+        if (condition) {
+            anomalies.push({ type, severity, detail });
+        }
+    };
+    const srBroken = (ratio: number | null) =>
+        ratio !== null && (ratio === 0 || !isFinite(ratio) || Math.abs(ratio - 1) > 0.5);
+
+    add(
+        srBroken(report.srClockRatioAudio) || srBroken(report.srClockRatioVideo),
+        'broken-sr-clock',
+        'high',
+        `SR clock ratio audio ${report.srClockRatioAudio} / video ${report.srClockRatioVideo} (expected ~1.0)`
+    );
+    add(
+        report.maxAbsDriftMs > 5000,
+        'unbounded-drift',
+        'high',
+        `max drift ${report.maxAbsDriftMs}ms (broken sync metadata)`
+    );
+    add(
+        report.timeToSyncMs === null,
+        'never-converged',
+        'high',
+        `offset never reached <${CONVERGED_THRESHOLD_MS}ms in ${report.durationMs}ms`
+    );
+    add(
+        report.timeToSyncMs !== null && report.timeToSyncMs > 2000,
+        'slow-start-convergence',
+        'medium',
+        `took ${report.timeToSyncMs}ms to reach <${CONVERGED_THRESHOLD_MS}ms`
+    );
+    add(
+        report.residualOffsetMs > 120,
+        'residual-drift',
+        'medium',
+        `steady-state |offset| ${report.residualOffsetMs}ms`
+    );
+    add(
+        report.srSkewMs !== null && Math.abs(report.srSkewMs) > 200,
+        'sr-clock-skew',
+        'medium',
+        `audio/video SR skew ${report.srSkewMs}ms`
+    );
+    add(
+        report.syncSlackMs > 80,
+        'excess-sync-buffering',
+        'medium',
+        `sync buffering ${report.syncSlackMs}ms (player padding to align)`
+    );
+    return anomalies;
+}
+
+export function buildAvSyncReport(stats: SlimRTCStatsReport[]): AvSyncReport | null {
+    const samples = stats
+        .map(stat => stat.av)
+        .filter((sample): sample is AvSyncSample => !!sample && sample.audioPlayout > 0 && sample.videoPlayout > 0);
+
+    if (samples.length < 2) {
+        return null;
+    }
+
+    const first = samples[0];
+    const last = samples[samples.length - 1];
+    const start = first.localTs;
+    const durationMs = last.localTs - start;
+
+    const drifts = samples.map(sample => sample.audioPlayout - sample.videoPlayout);
+    const absSorted = drifts.map(Math.abs).sort((a, b) => a - b);
+    const signedSorted = [...drifts].sort((a, b) => a - b);
+
+    const convergedSample = samples.find(
+        sample => Math.abs(sample.audioPlayout - sample.videoPlayout) < CONVERGED_THRESHOLD_MS
+    );
+    const timeToSyncMs = convergedSample ? round(convergedSample.localTs - start) : null;
+
+    const steady = samples.filter(sample => sample.localTs - start >= Math.min(5000, durationMs / 2));
+    const steadyAbs = (steady.length ? steady : samples)
+        .map(sample => Math.abs(sample.audioPlayout - sample.videoPlayout))
+        .sort((a, b) => a - b);
+    const residualOffsetMs = round(steadyAbs[Math.floor(steadyAbs.length / 2)]);
+
+    const avg = (deltaDelay: number, deltaCount: number) => (deltaCount > 0 ? (deltaDelay / deltaCount) * 1000 : 0);
+    const audioJb = avg(last.audioJbDelay - first.audioJbDelay, last.audioJbCount - first.audioJbCount);
+    const videoJb = avg(last.videoJbDelay - first.videoJbDelay, last.videoJbCount - first.videoJbCount);
+    const audioTarget = avg(last.audioJbTarget - first.audioJbTarget, last.audioJbCount - first.audioJbCount);
+    const audioMin = avg(last.audioJbMin - first.audioJbMin, last.audioJbCount - first.audioJbCount);
+
+    const deltaLocal = last.localTs - first.localTs;
+    const ratio = (deltaRemote: number) => (deltaLocal > 0 ? round2(deltaRemote / deltaLocal) : 0);
+    const hasAudioSr = first.srAudioRemoteTs > 0 && last.srAudioRemoteTs > 0;
+    const hasVideoSr = first.srVideoRemoteTs > 0 && last.srVideoRemoteTs > 0;
+
+    const lossPct = (deltaLost: number, deltaReceived: number) =>
+        deltaLost + deltaReceived > 0 ? (100 * deltaLost) / (deltaLost + deltaReceived) : 0;
+
+    const summary = {
+        sampleCount: samples.length,
+        durationMs: round(durationMs),
+        offsetMedianMs: round(percentile(signedSorted, 0.5)),
+        offsetP95Ms: round(percentile(absSorted, 0.95)),
+        residualOffsetMs,
+        maxAbsDriftMs: round(percentile(absSorted, 1)),
+        startOffsetMs: round(drifts[0]),
+        timeToSyncMs,
+        audioLeadPct: round((100 * drifts.filter(drift => drift > 0).length) / drifts.length),
+        syncSlackMs: round(audioTarget - audioMin),
+        jbGapMs: round(audioJb - videoJb),
+        audioRetimeMs: round((last.audioAccel - first.audioAccel - (last.audioDecel - first.audioDecel)) / 48),
+        srClockRatioAudio: hasAudioSr ? ratio(last.srAudioRemoteTs - first.srAudioRemoteTs) : null,
+        srClockRatioVideo: hasVideoSr ? ratio(last.srVideoRemoteTs - first.srVideoRemoteTs) : null,
+        srSkewMs: hasAudioSr && hasVideoSr ? round(last.srAudioRemoteTs - last.srVideoRemoteTs) : null,
+        concealMs: round((last.audioConcealed - first.audioConcealed) / 48),
+        audioLossPct: round2(
+            lossPct(
+                last.audioPacketsLost - first.audioPacketsLost,
+                last.audioPacketsReceived - first.audioPacketsReceived
+            )
+        ),
+        audioJitterMs: round(last.audioJitter * 1000),
+    };
+
+    return { ...summary, anomalies: detectAvSyncAnomalies(summary) };
+}

--- a/src/services/streaming-manager/stats/report.ts
+++ b/src/services/streaming-manager/stats/report.ts
@@ -1,9 +1,11 @@
-import { AnalyticsRTCStatsReport, SlimRTCStatsReport } from '@sdk/types';
+import { AnalyticsRTCStatsReport, AvSyncReport, SlimRTCStatsReport } from '@sdk/types';
 import { average } from '@sdk/utils/analytics';
+import { buildAvSyncReport } from './av-sync';
 
 export interface VideoRTCStatsReport {
     webRTCStats: {
         anomalies: AnalyticsRTCStatsReport[];
+        avSync: AvSyncReport | null;
         aggregateReport: AnalyticsRTCStatsReport;
         minRtt: number;
         maxRtt: number;
@@ -78,6 +80,9 @@ export function formatStats(stats: RTCStatsReport): SlimRTCStatsReport {
     let codec = '';
     let currRtt: number = 0;
     let videoInboundRtp: RTCInboundRtpStreamStats | null = null;
+    let audioInboundRtp: any = null;
+    let remoteOutboundAudio: any = null;
+    let remoteOutboundVideo: any = null;
     const codecIdToMime = new Map<string, string>();
 
     // RTCStatsReport iteration order is not guaranteed across browsers.
@@ -102,6 +107,12 @@ export function formatStats(stats: RTCStatsReport): SlimRTCStatsReport {
             }
         } else if (report.type === 'inbound-rtp' && report.kind === 'video') {
             videoInboundRtp = report as RTCInboundRtpStreamStats;
+        } else if (report.type === 'inbound-rtp' && (report as any).kind === 'audio') {
+            audioInboundRtp = report;
+        } else if (report.type === 'remote-outbound-rtp' && (report as any).kind === 'audio') {
+            remoteOutboundAudio = report;
+        } else if (report.type === 'remote-outbound-rtp' && (report as any).kind === 'video') {
+            remoteOutboundVideo = report;
         }
     }
 
@@ -119,7 +130,7 @@ export function formatStats(stats: RTCStatsReport): SlimRTCStatsReport {
         codec = codecIdToMime.values().next().value ?? '';
     }
 
-    return {
+    const slim = {
         codec,
         rtt: currRtt,
         timestamp: inbound.timestamp,
@@ -138,6 +149,32 @@ export function formatStats(stats: RTCStatsReport): SlimRTCStatsReport {
         freezeCount: inbound.freezeCount,
         freezeDuration: inbound.totalFreezesDuration,
     } as SlimRTCStatsReport;
+
+    if (audioInboundRtp) {
+        const audio = audioInboundRtp as any;
+        const video = inbound as any;
+        slim.av = {
+            audioPlayout: audio.estimatedPlayoutTimestamp ?? 0,
+            videoPlayout: video.estimatedPlayoutTimestamp ?? 0,
+            audioJbDelay: audio.jitterBufferDelay ?? 0,
+            audioJbCount: audio.jitterBufferEmittedCount ?? 0,
+            audioJbTarget: audio.jitterBufferTargetDelay ?? 0,
+            audioJbMin: audio.jitterBufferMinimumDelay ?? 0,
+            audioAccel: audio.removedSamplesForAcceleration ?? 0,
+            audioDecel: audio.insertedSamplesForDeceleration ?? 0,
+            audioConcealed: audio.concealedSamples ?? 0,
+            audioPacketsLost: audio.packetsLost ?? 0,
+            audioPacketsReceived: audio.packetsReceived ?? 0,
+            audioJitter: audio.jitter ?? 0,
+            videoJbDelay: video.jitterBufferDelay ?? 0,
+            videoJbCount: video.jitterBufferEmittedCount ?? 0,
+            srAudioRemoteTs: remoteOutboundAudio?.remoteTimestamp ?? 0,
+            srVideoRemoteTs: remoteOutboundVideo?.remoteTimestamp ?? 0,
+            localTs: video.timestamp,
+        };
+    }
+
+    return slim;
 }
 
 export function createVideoStatsReport(
@@ -224,6 +261,7 @@ export function createVideoStatsReport(
     return {
         webRTCStats: {
             anomalies: anomalies,
+            avSync: buildAvSyncReport(stats),
             minRtt: Math.min(...avgRttSamples),
             avgRtt: average(avgRttSamples),
             maxRtt: Math.max(...avgRttSamples),

--- a/src/types/stream/stream.ts
+++ b/src/types/stream/stream.ts
@@ -162,6 +162,55 @@ export interface SlimRTCStatsReport {
     framesPerSecond: any;
     freezeCount: number;
     freezeDuration: number;
+    av?: AvSyncSample;
+}
+
+export interface AvSyncSample {
+    audioPlayout: number;
+    videoPlayout: number;
+    audioJbDelay: number;
+    audioJbCount: number;
+    audioJbTarget: number;
+    audioJbMin: number;
+    audioAccel: number;
+    audioDecel: number;
+    audioConcealed: number;
+    audioPacketsLost: number;
+    audioPacketsReceived: number;
+    audioJitter: number;
+    videoJbDelay: number;
+    videoJbCount: number;
+    srAudioRemoteTs: number;
+    srVideoRemoteTs: number;
+    localTs: number;
+}
+
+export interface AvSyncAnomaly {
+    type: string;
+    severity: 'low' | 'medium' | 'high';
+    detail: string;
+}
+
+export interface AvSyncReport {
+    sampleCount: number;
+    durationMs: number;
+    offsetMedianMs: number;
+    offsetP95Ms: number;
+    residualOffsetMs: number;
+    maxAbsDriftMs: number;
+    startOffsetMs: number;
+    timeToSyncMs: number | null;
+    audioLeadPct: number;
+    syncSlackMs: number;
+    jbGapMs: number;
+    audioRetimeMs: number;
+    srClockRatioAudio: number | null;
+    srClockRatioVideo: number | null;
+    srSkewMs: number | null;
+    concealMs: number;
+    audioLossPct: number;
+    audioJitterMs: number;
+    anomalies: AvSyncAnomaly[];
 }
 
 export interface AnalyticsRTCStatsReport {


### PR DESCRIPTION
## What
Adds audio/video lip-sync observability to the WebRTC stats pipeline, folded into the existing `VideoRTCStatsReport` so it rides the current `stream-session`/`agent-video` analytics — **no new event, no second `getStats()` loop**.

## Why
The SDK already tracks per-session video stats (rtt, jitter, freezes, packet loss) but has **no audio or A/V-sync visibility** — it can't see lip-sync drift, the user-facing "audio ahead of video at session start" problem. This surfaces it as structured metrics + named anomalies.

## How
- **`formatStats`** now also reads the audio `inbound-rtp` and `remote-outbound-rtp` (RTCP Sender Report) entries per tick, stored on `SlimRTCStatsReport.av` — reusing the existing 100 ms video-stats loop.
- **`stats/av-sync.ts`** (new):
  - `buildAvSyncReport(stats)` derives the per-session summary: rendered A/V offset (median / p95 / steady-state residual), time-to-sync, start offset, sync buffering (audio JB target−min), audio↔video JB gap, audio retiming, SR clock ratio + skew, conceal, audio loss/jitter.
  - `detectAvSyncAnomalies()` classifies named, severity-tagged anomalies: `broken-sr-clock`, `unbounded-drift`, `never-converged`, `slow-start-convergence`, `residual-drift`, `sr-clock-skew`, `excess-sync-buffering`.
- **`createVideoStatsReport`** attaches `webRTCStats.avSync: AvSyncReport | null`.

Because `connect-to-manager` already spreads `...statsReport` into `stream-session`/`agent-video`, `avSync` (incl. its `anomalies`) reaches Mixpanel automatically.

## Behaviour / graceful degradation
- `avSync` is `null` when there aren't ≥2 paired audio+video playout samples (audio-only / pre-roll).
- SR-based fields (`srClockRatio*`, `srSkewMs`) are `null` on browsers that don't expose `remote-outbound-rtp` (non-Chromium); `broken-sr-clock` is skipped in that case (no false positives).

## Validation
Dev-vs-prod A/B against the media-gateway A/V-sync fix:
- **prod (unfixed):** A/V offset 19k–48k ms, never converges → trips `unbounded-drift` + `never-converged` (+ `broken-sr-clock` when SRs present).
- **dev (fixed):** converges to ~95 ms in ~3.5 s → at most `slow-start-convergence`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)