### PR TITLE
feat(stats): per-utterance A/V-sync lip-sync detector + unit tests

### DIFF
--- a/src/services/streaming-manager/stats/av-sync.test.ts
+++ b/src/services/streaming-manager/stats/av-sync.test.ts
@@ -1,0 +1,71 @@
+import { SlimRTCStatsReport } from '@sdk/types';
+import { buildAvSyncReport } from './av-sync';
+
+const VIDEO_PLAYOUT = 3_800_000_000_000;
+
+// A measurable sample: audio leads video by `offsetMs` (positive = audio ahead), at local time `localTs`.
+const sample = (localTs: number, offsetMs: number): SlimRTCStatsReport =>
+    ({
+        av: { audioPlayout: VIDEO_PLAYOUT + offsetMs, videoPlayout: VIDEO_PLAYOUT, localTs },
+    }) as unknown as SlimRTCStatsReport;
+
+// A sample with no usable playout — should be filtered out.
+const unpaired = (localTs: number): SlimRTCStatsReport =>
+    ({ av: { audioPlayout: 0, videoPlayout: VIDEO_PLAYOUT, localTs } }) as unknown as SlimRTCStatsReport;
+
+const noAv = (): SlimRTCStatsReport => ({}) as SlimRTCStatsReport;
+
+const series = (offsets: number[], stepMs = 100): SlimRTCStatsReport[] =>
+    offsets.map((offset, index) => sample(index * stepMs, offset));
+
+describe('buildAvSyncReport', () => {
+    it('returns null when there are fewer than two measurable samples', () => {
+        expect(buildAvSyncReport([])).toBeNull();
+        expect(buildAvSyncReport([sample(0, 10)])).toBeNull();
+        expect(buildAvSyncReport([noAv(), noAv()])).toBeNull();
+        expect(buildAvSyncReport([sample(0, 10), unpaired(100)])).toBeNull();
+    });
+
+    it('counts only paired samples and measures the window from their local timestamps', () => {
+        const report = buildAvSyncReport([sample(0, 10), unpaired(100), sample(200, 10)]);
+        expect(report).not.toBeNull();
+        expect(report!.sampleCount).toBe(2);
+        expect(report!.durationMs).toBe(200);
+    });
+
+    it('reports zero desync when every offset is within perceptibility (incl. audio slightly behind)', () => {
+        // +10 (well under +45) and -80 (within the -100 audio-behind tolerance)
+        const report = buildAvSyncReport(series([10, -80, 10, -80]));
+        expect(report!.desyncDurationMs).toBe(0);
+    });
+
+    it('reports desync across the whole window when every offset is perceptible', () => {
+        const report = buildAvSyncReport(series([1000, 1000, 1000])); // duration 200
+        expect(report!.durationMs).toBe(200);
+        expect(report!.desyncDurationMs).toBe(200);
+    });
+
+    it('weights audio-lead more strictly than audio-lag (asymmetric thresholds)', () => {
+        // +50 perceptible (>45); -50 NOT (within -100); -150 perceptible (<-100); +10 NOT
+        const report = buildAvSyncReport(series([50, -50, -150, 10])); // 4 samples, duration 300
+        expect(report!.desyncDurationMs).toBe(150); // 2 of 4 perceptible -> 300 * 0.5
+    });
+
+    it('maxOffsetMs is the largest-magnitude offset, kept signed', () => {
+        const report = buildAvSyncReport(series([30, -200, 50]));
+        expect(report!.maxOffsetMs).toBe(-200);
+    });
+
+    it('residualOffsetMs reflects a persistent offset', () => {
+        const report = buildAvSyncReport(series([1786, 1786, 1786, 1786]));
+        expect(report!.residualOffsetMs).toBe(1786);
+    });
+
+    it('residualOffsetMs is ~0 when a large startup offset recovers, but desync was still flagged', () => {
+        // first half ~ +2000, second half 0; steady window = back half
+        const report = buildAvSyncReport(series([2000, 2000, 2000, 2000, 2000, 0, 0, 0, 0, 0]));
+        expect(report!.residualOffsetMs).toBe(0);
+        expect(report!.desyncDurationMs).toBeGreaterThan(0);
+        expect(report!.maxOffsetMs).toBe(2000);
+    });
+});

--- a/src/services/streaming-manager/stats/av-sync.ts
+++ b/src/services/streaming-manager/stats/av-sync.ts
@@ -1,0 +1,34 @@
+import { AvSyncReport, AvSyncSample, SlimRTCStatsReport } from '@sdk/types';
+import { median, round } from '@sdk/utils/analytics';
+
+// Perceptibility thresholds (ITU/EBU): audio ahead of video is less tolerable than audio behind.
+const AUDIO_LEAD_PERCEPTIBLE_MS = 45;
+const AUDIO_LAG_PERCEPTIBLE_MS = 100;
+
+export function buildAvSyncReport(stats: SlimRTCStatsReport[]): AvSyncReport | null {
+    const samples = stats
+        .map(stat => stat.av)
+        .filter((sample): sample is AvSyncSample => !!sample && sample.audioPlayout > 0 && sample.videoPlayout > 0);
+
+    if (samples.length < 2) {
+        return null;
+    }
+
+    const start = samples[0].localTs;
+    const durationMs = samples[samples.length - 1].localTs - start;
+    const offsets = samples.map(sample => sample.audioPlayout - sample.videoPlayout);
+
+    const perceptible = offsets.filter(
+        offset => offset > AUDIO_LEAD_PERCEPTIBLE_MS || offset < -AUDIO_LAG_PERCEPTIBLE_MS
+    );
+    const steady = samples.filter(sample => sample.localTs - start >= Math.min(5000, durationMs / 2));
+    const steadyOffsets = (steady.length ? steady : samples).map(sample => sample.audioPlayout - sample.videoPlayout);
+
+    return {
+        sampleCount: samples.length,
+        durationMs: round(durationMs),
+        desyncDurationMs: round(durationMs * (perceptible.length / offsets.length)),
+        maxOffsetMs: round(offsets.reduce((worst, offset) => (Math.abs(offset) > Math.abs(worst) ? offset : worst))),
+        residualOffsetMs: round(median(steadyOffsets)),
+    };
+}

--- a/src/services/streaming-manager/stats/report.ts
+++ b/src/services/streaming-manager/stats/report.ts
@@ -1,9 +1,11 @@
-import { AnalyticsRTCStatsReport, SlimRTCStatsReport } from '@sdk/types';
-import { average } from '@sdk/utils/analytics';
+import { AnalyticsRTCStatsReport, AvSyncReport, SlimRTCStatsReport } from '@sdk/types';
+import { average, max, min, safe } from '@sdk/utils/analytics';
+import { buildAvSyncReport } from './av-sync';
 
 export interface VideoRTCStatsReport {
     webRTCStats: {
         anomalies: AnalyticsRTCStatsReport[];
+        avSync: AvSyncReport | null;
         aggregateReport: AnalyticsRTCStatsReport;
         minRtt: number;
         maxRtt: number;
@@ -78,6 +80,7 @@ export function formatStats(stats: RTCStatsReport): SlimRTCStatsReport {
     let codec = '';
     let currRtt: number = 0;
     let videoInboundRtp: RTCInboundRtpStreamStats | null = null;
+    let audioInboundRtp: RTCInboundRtpStreamStats | null = null;
     const codecIdToMime = new Map<string, string>();
 
     // RTCStatsReport iteration order is not guaranteed across browsers.
@@ -102,6 +105,8 @@ export function formatStats(stats: RTCStatsReport): SlimRTCStatsReport {
             }
         } else if (report.type === 'inbound-rtp' && report.kind === 'video') {
             videoInboundRtp = report as RTCInboundRtpStreamStats;
+        } else if (report.type === 'inbound-rtp' && report.kind === 'audio') {
+            audioInboundRtp = report;
         }
     }
 
@@ -119,7 +124,7 @@ export function formatStats(stats: RTCStatsReport): SlimRTCStatsReport {
         codec = codecIdToMime.values().next().value ?? '';
     }
 
-    return {
+    const slim = {
         codec,
         rtt: currRtt,
         timestamp: inbound.timestamp,
@@ -138,6 +143,16 @@ export function formatStats(stats: RTCStatsReport): SlimRTCStatsReport {
         freezeCount: inbound.freezeCount,
         freezeDuration: inbound.totalFreezesDuration,
     } as SlimRTCStatsReport;
+
+    if (audioInboundRtp) {
+        slim.av = {
+            audioPlayout: audioInboundRtp.estimatedPlayoutTimestamp ?? 0,
+            videoPlayout: inbound.estimatedPlayoutTimestamp ?? 0,
+            localTs: inbound.timestamp,
+        };
+    }
+
+    return slim;
 }
 
 export function createVideoStatsReport(
@@ -224,12 +239,13 @@ export function createVideoStatsReport(
     return {
         webRTCStats: {
             anomalies: anomalies,
-            minRtt: Math.min(...avgRttSamples),
+            avSync: safe(() => buildAvSyncReport(stats), null),
+            minRtt: min(avgRttSamples),
             avgRtt: average(avgRttSamples),
-            maxRtt: Math.max(...avgRttSamples),
+            maxRtt: max(avgRttSamples),
             aggregateReport: createAggregateReport(stats[0], stats[stats.length - 1], lowFpsCount),
-            minJitterDelayInInterval: Math.min(...avgJittersSamples),
-            maxJitterDelayInInterval: Math.max(...avgJittersSamples),
+            minJitterDelayInInterval: min(avgJittersSamples),
+            maxJitterDelayInInterval: max(avgJittersSamples),
             avgJitterDelayInInterval: average(avgJittersSamples),
         },
         codec: stats[0].codec,

--- a/src/types/stream/stream.ts
+++ b/src/types/stream/stream.ts
@@ -162,6 +162,29 @@ export interface SlimRTCStatsReport {
     framesPerSecond: any;
     freezeCount: number;
     freezeDuration: number;
+    av?: AvSyncSample;
+}
+
+export interface AvSyncSample {
+    /** Audio estimatedPlayoutTimestamp (ms, NTP) — playout time of the audio sample currently being rendered. */
+    audioPlayout: number;
+    /** Video estimatedPlayoutTimestamp (ms, NTP) — playout time of the video frame currently being rendered. */
+    videoPlayout: number;
+    /** Local timestamp of this sample (ms) — the video inbound-rtp report timestamp; the utterance time axis. */
+    localTs: number;
+}
+
+export interface AvSyncReport {
+    /** Measurable samples in this utterance (both audio and video playout present). Report is null if fewer than 2. */
+    sampleCount: number;
+    /** Measurement window in milliseconds (first to last sample). */
+    durationMs: number;
+    /** How long the A/V offset was perceptibly off (audio ahead > 45ms or behind > 100ms) — the "was there a lip-sync issue, and for how long" signal. */
+    desyncDurationMs: number;
+    /** The single worst offset (largest magnitude), signed. Positive = audio ahead of video, negative = video ahead. */
+    maxOffsetMs: number;
+    /** Settled offset after startup (signed median over the back half). ~0 = recovered; non-zero = persistent lip-sync error. */
+    residualOffsetMs: number;
 }
 
 export interface AnalyticsRTCStatsReport {

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -68,6 +68,25 @@ export const getErrorMessage = (error: unknown): string => {
 
 export const sumFunc = (numbers: number[]) => numbers.reduce((total, aNumber) => total + aNumber, 0);
 export const average = (numbers: number[]) => sumFunc(numbers) / numbers.length;
+export const min = (numbers: number[]) => Math.min(...numbers);
+export const max = (numbers: number[]) => Math.max(...numbers);
+export const round = (value: number, decimals = 0) => {
+    const factor = 10 ** decimals;
+    return Math.round(value * factor) / factor;
+};
+export const percentile = (numbers: number[], p: number) => {
+    const sorted = [...numbers].sort((a, b) => a - b);
+    return sorted[Math.min(sorted.length - 1, Math.floor(p * (sorted.length - 1)))];
+};
+export const median = (numbers: number[]) => percentile(numbers, 0.5);
+/** Run fn, returning fallback instead of throwing — so a telemetry failure can never break the caller. */
+export const safe = <T>(fn: () => T, fallback: T): T => {
+    try {
+        return fn();
+    } catch {
+        return fallback;
+    }
+};
 
 export function getStreamAnalyticsProps(data: any, agent: Agent, additionalProps: Record<string, any>) {
     const { event, ...baseProps } = data;


### PR DESCRIPTION
## What
Adds a receiver-side **lip-sync detector** to the per-utterance WebRTC video stats report. It lets us say *"there was a lip-sync issue, and for how long"* from telemetry alone — without watching the video.

It folds into the existing `VideoRTCStatsReport`, so it rides the current `stream-session`/`agent-video` analytics — **no new event, no extra `getStats()` loop.**

## The metric (`webRTCStats.avSync`)
The proper A/V offset per the W3C spec is the difference of the two tracks' `estimatedPlayoutTimestamp` (both in the sender's NTP/capture clock), so the difference is the capture-aligned rendering misalignment. Summarized per utterance:

| field | meaning |
|---|---|
| `sampleCount` | measurable samples (both playouts present); report is `null` if < 2 |
| `durationMs` | measurement window |
| **`desyncDurationMs`** | **how long the offset was perceptibly off** — audio ahead > 45 ms or behind > 100 ms (audio-lead weighted, per ITU/EBU). The headline. |
| `maxOffsetMs` | single worst offset, signed (`+` = audio ahead) |
| `residualOffsetMs` | settled offset (signed median over the back half); `~0` = recovered, non-zero = persistent |

**Read:** `desyncDurationMs` → was there an issue & for how long; `residualOffsetMs` → did it recover or persist; `maxOffsetMs` → how bad & which way; cross-check the co-located `aggregateReport.freezeDuration` → was a freeze the cause.

## How
- **`formatStats`** captures audio `estimatedPlayoutTimestamp`, video playout, and the local timestamp onto `SlimRTCStatsReport.av` (reuses the existing 100 ms loop).
- **`stats/av-sync.ts`** — `buildAvSyncReport()` derives the summary above.
- **`createVideoStatsReport`** attaches `webRTCStats.avSync`, wrapped in **`safe()`** so a telemetry failure can never break the existing video/connectivity report.
- **`utils/analytics`** — shared `min`/`max`/`round`/`percentile`/`median` + `safe()`.

## Tests
`av-sync.test.ts` — 8 unit tests on the pure builder: null-guards, paired-only counting, window duration, zero-desync within tolerance, full-window desync, **asymmetric audio-lead weighting**, signed `maxOffsetMs`, persistent-vs-recovered `residualOffsetMs`. All green; `tsc` + prettier clean.

## Scope / notes
- **Best on Chromium + sustained utterances.** Non-Chromium lacks `estimatedPlayoutTimestamp` → `avSync` is `null` (graceful).
- It's **per-utterance** (resets at boundaries), so it measures within-utterance sync — not the cross-utterance gateway re-anchor (that's validated server-side).
- A big offset spike during a video freeze is real transient desync; attribute it via the co-located freeze fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)