### PR TITLE
feat(verbose): thread verbose through create-session

### DIFF
--- a/src/services/streaming-manager/common.ts
+++ b/src/services/streaming-manager/common.ts
@@ -97,6 +97,12 @@ export type StreamingManager<T extends CreateStreamOptions | CreateSessionV2Opti
     isInterruptible: boolean;
 
     /**
+     * Returns the server-granted verbose flag for this session.
+     * supported only for livekit manager
+     */
+    getVerbose?(): boolean;
+
+    /**
      * Send an interrupt for the current stream segment.
      * Each implementation owns the validation/transport details (e.g. V1
      * sends a `stream/interrupt` payload over the data channel; V2 sends

--- a/src/services/streaming-manager/common.ts
+++ b/src/services/streaming-manager/common.ts
@@ -97,12 +97,6 @@ export type StreamingManager<T extends CreateStreamOptions | CreateSessionV2Opti
     isInterruptible: boolean;
 
     /**
-     * Returns the server-granted verbose flag for this session.
-     * supported only for livekit manager
-     */
-    getVerbose?(): boolean;
-
-    /**
      * Send an interrupt for the current stream segment.
      * Each implementation owns the validation/transport details (e.g. V1
      * sends a `stream/interrupt` payload over the data channel; V2 sends

--- a/src/services/streaming-manager/livekit-manager.test.ts
+++ b/src/services/streaming-manager/livekit-manager.test.ts
@@ -1291,7 +1291,7 @@ describe('LiveKit Streaming Manager - Verbose Mode', () => {
         });
         const manager = await createLiveKitStreamingManager(agentId, sessionOptions, { ...options, verbose: true });
 
-        expect(manager.getVerbose()).toBe(true);
+        expect(manager.getVerbose?.()).toBe(true);
     });
 
     it('getVerbose() is false when the server does not grant verbose', async () => {
@@ -1303,7 +1303,7 @@ describe('LiveKit Streaming Manager - Verbose Mode', () => {
         });
         const manager = await createLiveKitStreamingManager(agentId, sessionOptions, options);
 
-        expect(manager.getVerbose()).toBe(false);
+        expect(manager.getVerbose?.()).toBe(false);
     });
 });
 

--- a/src/services/streaming-manager/livekit-manager.test.ts
+++ b/src/services/streaming-manager/livekit-manager.test.ts
@@ -1268,19 +1268,14 @@ describe('LiveKit Streaming Manager - Verbose Mode', () => {
         const optionsWithVerbose = { ...options, verbose: true };
         await createLiveKitStreamingManager(agentId, sessionOptions, optionsWithVerbose);
 
-        expect(mockCreateStream).toHaveBeenCalledWith(
-            expect.objectContaining({ verbose: true })
-        );
+        expect(mockCreateStream).toHaveBeenCalledWith(expect.objectContaining({ verbose: true }));
     });
 
     it('defaults verbose to false in the createStream request', async () => {
         await createLiveKitStreamingManager(agentId, sessionOptions, options);
 
-        expect(mockCreateStream).toHaveBeenCalledWith(
-            expect.objectContaining({ verbose: false })
-        );
+        expect(mockCreateStream).toHaveBeenCalledWith(expect.objectContaining({ verbose: false }));
     });
-
 });
 
 describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {

--- a/src/services/streaming-manager/livekit-manager.test.ts
+++ b/src/services/streaming-manager/livekit-manager.test.ts
@@ -1235,6 +1235,78 @@ describe('LiveKit Streaming Manager - Disconnect Behavior', () => {
     });
 });
 
+describe('LiveKit Streaming Manager - Verbose Mode', () => {
+    let agentId: string;
+    let sessionOptions: CreateSessionV2Options;
+    let options: StreamingManagerOptions;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockRoom.connect.mockResolvedValue(undefined);
+        mockRoom.prepareConnection.mockResolvedValue(undefined);
+        mockRoom.disconnect.mockResolvedValue(undefined);
+        mockRoom.on.mockReturnThis();
+        mockLocalParticipant.audioTrackPublications = new Map();
+        mockLocalParticipant.videoTrackPublications = new Map();
+        agentId = TEST_AGENT_ID;
+        sessionOptions = {
+            chat_persist: true,
+            transport: {
+                provider: TransportProvider.Livekit,
+            },
+        };
+        options = StreamingManagerOptionsFactory.build();
+        mockCreateStream.mockResolvedValue({
+            id: 'session-123',
+            session_token: 'token-123',
+            session_url: 'wss://test.livekit.cloud',
+            interrupt_enabled: true,
+        });
+    });
+
+    it('sends verbose in the createStream request when options.verbose is true', async () => {
+        const optionsWithVerbose = { ...options, verbose: true };
+        await createLiveKitStreamingManager(agentId, sessionOptions, optionsWithVerbose);
+
+        expect(mockCreateStream).toHaveBeenCalledWith(
+            expect.objectContaining({ verbose: true })
+        );
+    });
+
+    it('defaults verbose to false in the createStream request', async () => {
+        await createLiveKitStreamingManager(agentId, sessionOptions, options);
+
+        expect(mockCreateStream).toHaveBeenCalledWith(
+            expect.objectContaining({ verbose: false })
+        );
+    });
+
+    it('exposes the server-granted verbose via getVerbose()', async () => {
+        mockCreateStream.mockResolvedValueOnce({
+            id: 'session-123',
+            session_token: 'token-123',
+            session_url: 'wss://test.livekit.cloud',
+            interrupt_enabled: true,
+            verbose: true,
+        });
+        const manager = await createLiveKitStreamingManager(agentId, sessionOptions, { ...options, verbose: true });
+
+        expect(manager.getVerbose()).toBe(true);
+    });
+
+    it('getVerbose() is false when the server does not grant verbose', async () => {
+        mockCreateStream.mockResolvedValueOnce({
+            id: 'session-123',
+            session_token: 'token-123',
+            session_url: 'wss://test.livekit.cloud',
+            interrupt_enabled: true,
+        });
+        const manager = await createLiveKitStreamingManager(agentId, sessionOptions, options);
+
+        expect(manager.getVerbose()).toBe(false);
+    });
+});
+
 describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
     let agentId: string;
     let sessionOptions: CreateSessionV2Options;

--- a/src/services/streaming-manager/livekit-manager.test.ts
+++ b/src/services/streaming-manager/livekit-manager.test.ts
@@ -1281,30 +1281,6 @@ describe('LiveKit Streaming Manager - Verbose Mode', () => {
         );
     });
 
-    it('exposes the server-granted verbose via getVerbose()', async () => {
-        mockCreateStream.mockResolvedValueOnce({
-            id: 'session-123',
-            session_token: 'token-123',
-            session_url: 'wss://test.livekit.cloud',
-            interrupt_enabled: true,
-            verbose: true,
-        });
-        const manager = await createLiveKitStreamingManager(agentId, sessionOptions, { ...options, verbose: true });
-
-        expect(manager.getVerbose?.()).toBe(true);
-    });
-
-    it('getVerbose() is false when the server does not grant verbose', async () => {
-        mockCreateStream.mockResolvedValueOnce({
-            id: 'session-123',
-            session_token: 'token-123',
-            session_url: 'wss://test.livekit.cloud',
-            interrupt_enabled: true,
-        });
-        const manager = await createLiveKitStreamingManager(agentId, sessionOptions, options);
-
-        expect(manager.getVerbose?.()).toBe(false);
-    });
 });
 
 describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {

--- a/src/services/streaming-manager/livekit-manager.ts
+++ b/src/services/streaming-manager/livekit-manager.ts
@@ -131,7 +131,6 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
     let token: string | undefined;
     let url: string | undefined;
     let interruptEnabled = true;
-    let grantedVerbose = false;
 
     try {
         const streamResponse = await streamApi.createStream({
@@ -140,13 +139,12 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
             verbose: options.verbose ?? false,
         });
 
-        const { id, session_token, session_url, interrupt_enabled, verbose } = streamResponse;
+        const { id, session_token, session_url, interrupt_enabled } = streamResponse;
         callbacks.onStreamCreated?.({ session_id: id, stream_id: id, agent_id: agentId });
         sessionId = id;
         token = session_token;
         url = session_url;
         interruptEnabled = interrupt_enabled ?? true;
-        grantedVerbose = verbose ?? false;
 
         await room.prepareConnection(url, token);
     } catch (error) {
@@ -786,7 +784,6 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
         streamType,
         interruptAvailable: interruptEnabled,
         isInterruptible: currentInterruptible,
-        getVerbose: () => grantedVerbose,
     };
 }
 

--- a/src/services/streaming-manager/livekit-manager.ts
+++ b/src/services/streaming-manager/livekit-manager.ts
@@ -131,19 +131,22 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
     let token: string | undefined;
     let url: string | undefined;
     let interruptEnabled = true;
+    let grantedVerbose = false;
 
     try {
         const streamResponse = await streamApi.createStream({
             transport: sessionOptions.transport,
             chat_persist: sessionOptions.chat_persist ?? true,
+            verbose: options.verbose ?? false,
         });
 
-        const { id, session_token, session_url, interrupt_enabled } = streamResponse;
+        const { id, session_token, session_url, interrupt_enabled, verbose } = streamResponse;
         callbacks.onStreamCreated?.({ session_id: id, stream_id: id, agent_id: agentId });
         sessionId = id;
         token = session_token;
         url = session_url;
         interruptEnabled = interrupt_enabled ?? true;
+        grantedVerbose = verbose ?? false;
 
         await room.prepareConnection(url, token);
     } catch (error) {
@@ -783,6 +786,7 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
         streamType,
         interruptAvailable: interruptEnabled,
         isInterruptible: currentInterruptible,
+        getVerbose: () => grantedVerbose,
     };
 }
 

--- a/src/types/entities/agents/manager.ts
+++ b/src/types/entities/agents/manager.ts
@@ -164,6 +164,7 @@ export interface AgentManagerOptions {
     baseURL?: string;
     wsURL?: string;
     debug?: boolean;
+    verbose?: boolean;
     enableAnalitics?: boolean;
     mixpanelKey?: string;
     mixpanelAdditionalProperties?: Record<string, any>;

--- a/src/types/stream/stream.ts
+++ b/src/types/stream/stream.ts
@@ -131,6 +131,7 @@ export interface StreamingManagerOptions {
     callbacks: ManagerCallbacks;
     baseURL?: string;
     debug?: boolean;
+    verbose?: boolean;
     auth: Auth;
     analytics: Analytics;
     /**

--- a/src/types/stream/streams-v2.ts
+++ b/src/types/stream/streams-v2.ts
@@ -7,6 +7,7 @@ export interface CreateSessionV2Options {
         provider: TransportProvider.Livekit;
     };
     chat_persist?: boolean;
+    verbose?: boolean;
 }
 
 export interface CreateSessionV2Response {
@@ -14,4 +15,5 @@ export interface CreateSessionV2Response {
     session_url: string;
     session_token: string;
     interrupt_enabled: boolean;
+    verbose?: boolean;
 }

--- a/src/types/stream/streams-v2.ts
+++ b/src/types/stream/streams-v2.ts
@@ -15,5 +15,4 @@ export interface CreateSessionV2Response {
     session_url: string;
     session_token: string;
     interrupt_enabled: boolean;
-    verbose?: boolean;
 }


### PR DESCRIPTION
### Pull Request Type

🔮 Feature

### Description

- Part of **Owner Verbose Mode (v1: tool calls)**. Threads an optional `verbose?: boolean` through the SDK: added to `AgentManagerOptions` / `StreamingManagerOptions` and the create-session request type (`CreateSessionV2Options`), and sent in the `createStream` request body so the backend can gate on it.
- The tool-event data path is unchanged — `ToolCall*` payloads already carry `input`/`output`, so they flow through `onToolEvent` untouched once the backend stops stripping them.
- **No response echo / `getVerbose()`** — nothing consumes a server-granted value (the client gates its UI on the config flag, and the backend 403s ineligible verbose requests). Streaming-manager tests pass; `tsc` clean.

### Reference Links
-   [Asana](https://app.asana.com/1/856614567666442/project/1215527970149880/task/1215581785596753?focus=true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
