### PR TITLE
feat(analytics): stream disconnect/reconnect telemetry + offline retry buffer

### DIFF
--- a/src/services/agent-manager/index.test.ts
+++ b/src/services/agent-manager/index.test.ts
@@ -207,6 +207,7 @@ describe('createAgentManager', () => {
                 expect(mockAnalytics.track).toHaveBeenCalledWith('agent-chat', {
                     event: 'reconnect',
                     mode: ChatMode.Functional,
+                    success: true,
                 });
 
                 // Verify that the streaming manager and socket manager have disconnect methods
@@ -222,10 +223,10 @@ describe('createAgentManager', () => {
                 mockStreamingManager.disconnect.mockRejectedValueOnce(new Error('Disconnect failed'));
 
                 await expect(manager.reconnect()).rejects.toThrow('Disconnect failed');
-                expect(mockAnalytics.track).not.toHaveBeenCalledWith('agent-chat', {
-                    event: 'reconnect',
-                    mode: ChatMode.Functional,
-                });
+                expect(mockAnalytics.track).not.toHaveBeenCalledWith(
+                    'agent-chat',
+                    expect.objectContaining({ event: 'reconnect' })
+                );
             });
 
             it('should handle reconnect failure during connect', async () => {
@@ -236,10 +237,10 @@ describe('createAgentManager', () => {
                 (initializeStreamAndChat as jest.Mock).mockRejectedValueOnce(new Error('Connect failed'));
 
                 await expect(manager.reconnect()).rejects.toThrow('Connect failed');
-                expect(mockAnalytics.track).not.toHaveBeenCalledWith('agent-chat', {
-                    event: 'reconnect',
-                    mode: ChatMode.Functional,
-                });
+                expect(mockAnalytics.track).not.toHaveBeenCalledWith(
+                    'agent-chat',
+                    expect.objectContaining({ event: 'reconnect' })
+                );
             });
         });
 

--- a/src/services/agent-manager/index.ts
+++ b/src/services/agent-manager/index.ts
@@ -109,6 +109,7 @@ export async function createAgentManager(agent: string, options: AgentManagerOpt
 
     const updateVideoId = (newVideoId: string | null) => {
         videoId = newVideoId;
+        analytics.enrich({ videoId: newVideoId });
     };
 
     const interrupt = ({ type }: Interrupt) => {
@@ -293,27 +294,26 @@ export async function createAgentManager(agent: string, options: AgentManagerOpt
         },
         async reconnect() {
             const streamingManager = items.streamingManager as { reconnect?: () => Promise<void> } | undefined;
+            let fallbackReason: string | undefined;
+
             if (isStreamsV2 && streamingManager?.reconnect) {
                 try {
                     await streamingManager.reconnect();
-
-                    analytics.track('agent-chat', {
-                        event: 'reconnect',
-                        mode: items.chatMode,
-                    });
                 } catch (error) {
+                    fallbackReason = toErrorAnalytics(error).kind;
                     await disconnect();
                     await connect(false);
                 }
-                return;
+            } else {
+                await disconnect();
+                await connect(false);
             }
-
-            await disconnect();
-            await connect(false);
 
             analytics.track('agent-chat', {
                 event: 'reconnect',
                 mode: items.chatMode,
+                success: true,
+                ...(fallbackReason && { fallbackReason }),
             });
         },
         async disconnect() {

--- a/src/services/analytics/mixpanel.test.ts
+++ b/src/services/analytics/mixpanel.test.ts
@@ -1,0 +1,69 @@
+import { _resetOfflineBufferForTests, initializeAnalytics } from './mixpanel';
+
+const tick = () => new Promise(resolve => setTimeout(resolve, 0));
+
+describe('initializeAnalytics offline buffer', () => {
+    const originalFetch = globalThis.fetch;
+    let fetchSpy: jest.Mock;
+
+    beforeEach(() => {
+        _resetOfflineBufferForTests();
+        fetchSpy = jest.fn();
+        (globalThis as unknown as { fetch: jest.Mock }).fetch = fetchSpy;
+    });
+
+    afterEach(() => {
+        (globalThis as unknown as { fetch: typeof originalFetch }).fetch = originalFetch;
+        jest.restoreAllMocks();
+    });
+
+    it('re-sends an event that failed to send once connectivity returns', async () => {
+        const analytics = initializeAnalytics({ token: 't', agentId: 'a', isEnabled: true });
+
+        // The network is down — the fire-and-forget POST rejects and the event is buffered.
+        fetchSpy.mockRejectedValueOnce(new Error('Failed to fetch'));
+        await analytics.track('agent-connection-state-change', {
+            state: 'disconnected',
+            reason: 'webrtc:ice-disconnected',
+        });
+        await tick();
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+        // Connectivity returns -> the buffered event is flushed, preserving its reason.
+        fetchSpy.mockResolvedValueOnce({ ok: true });
+        window.dispatchEvent(new Event('online'));
+        await tick();
+
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+        const flushedBody = String((fetchSpy.mock.calls[1][1] as { body: URLSearchParams }).body);
+        expect(flushedBody).toContain('webrtc%3Aice-disconnected');
+    });
+
+    it('buffers and retries on an HTTP error status, not only on network rejections', async () => {
+        const analytics = initializeAnalytics({ token: 't', agentId: 'a', isEnabled: true });
+
+        // fetch resolves, but Mixpanel returns 5xx — must still be treated as a failure and buffered.
+        fetchSpy.mockResolvedValueOnce({ ok: false, status: 503 });
+        await analytics.track('agent-error', { error: { kind: 'X' } });
+        await tick();
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+        fetchSpy.mockResolvedValueOnce({ ok: true });
+        window.dispatchEvent(new Event('online'));
+        await tick();
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not re-send when the original event sent successfully', async () => {
+        const analytics = initializeAnalytics({ token: 't', agentId: 'a', isEnabled: true });
+
+        fetchSpy.mockResolvedValue({ ok: true });
+        await analytics.track('agent-chat', { event: 'connect' });
+        await tick();
+
+        window.dispatchEvent(new Event('online'));
+        await tick();
+
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/services/analytics/mixpanel.ts
+++ b/src/services/analytics/mixpanel.ts
@@ -37,6 +37,59 @@ interface MixpanelEvents {
 
 const mixpanelUrl = 'https://api-js.mixpanel.com/track/?verbose=1&ip=1';
 
+// Re-send analytics that failed to POST (e.g. a network drop) once connectivity returns.
+const MAX_QUEUE = 50;
+const failedQueue: Array<Record<string, any>> = [];
+let flushInFlight = false;
+
+async function postEvents(events: Array<Record<string, any>>): Promise<void> {
+    const response = await fetch(mixpanelUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({ data: JSON.stringify(events) }),
+    });
+    if (!response.ok) {
+        throw new Error(`Mixpanel responded with ${response.status}`);
+    }
+}
+
+function enqueueFailed(event: Record<string, any>): void {
+    failedQueue.push(event);
+    failedQueue.splice(MAX_QUEUE);
+}
+
+function flushQueue(): void {
+    if (flushInFlight || !failedQueue.length) {
+        return;
+    }
+    flushInFlight = true;
+    const batch = failedQueue.splice(0, failedQueue.length);
+    postEvents(batch)
+        .catch(() => {
+            failedQueue.unshift(...batch);
+            failedQueue.splice(MAX_QUEUE);
+        })
+        .finally(() => {
+            flushInFlight = false;
+        });
+}
+
+if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
+    window.addEventListener('online', flushQueue);
+    if (typeof document !== 'undefined') {
+        document.addEventListener('visibilitychange', () => {
+            if (document.visibilityState === 'visible') {
+                flushQueue();
+            }
+        });
+    }
+}
+
+export function _resetOfflineBufferForTests(): void {
+    failedQueue.length = 0;
+    flushInFlight = false;
+}
+
 export function initializeAnalytics(config: AnalyticsOptions): Analytics {
     const source = window?.hasOwnProperty('DID_AGENTS_API') ? 'agents-ui' : 'agents-sdk';
     const mixpanelEvents: MixpanelEvents = {};
@@ -64,36 +117,27 @@ export function initializeAnalytics(config: AnalyticsOptions): Analytics {
 
             const eventTime = eventTimestamp || Date.now();
 
-            const options = {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/x-www-form-urlencoded',
+            const eventData = {
+                event,
+                properties: {
+                    ...this.additionalProperties,
+                    ...sendProps,
+                    agentId: this.agentId,
+                    source,
+                    emittedBy: 'agents-sdk',
+                    sdkVersion: SDK_VERSION,
+                    token: this.token,
+                    time: eventTime,
+                    $insert_id: this.getRandom(),
+                    origin: window.location.href,
+                    'Screen Height': window.screen.height || window.innerHeight,
+                    'Screen Width': window.screen.width || window.innerWidth,
+                    'User Agent': navigator.userAgent,
                 },
-                body: new URLSearchParams({
-                    data: JSON.stringify([
-                        {
-                            event,
-                            properties: {
-                                ...this.additionalProperties,
-                                ...sendProps,
-                                agentId: this.agentId,
-                                source,
-                                emittedBy: 'agents-sdk',
-                                sdkVersion: SDK_VERSION,
-                                token: this.token,
-                                time: eventTime,
-                                $insert_id: this.getRandom(),
-                                origin: window.location.href,
-                                'Screen Height': window.screen.height || window.innerWidth,
-                                'Screen Width': window.screen.width || window.innerHeight,
-                                'User Agent': navigator.userAgent,
-                            },
-                        },
-                    ]),
-                }),
             };
 
-            fetch(mixpanelUrl, options).catch(err => console.error('Analytics tracking error:', err));
+            flushQueue();
+            postEvents([eventData]).catch(() => enqueueFailed(eventData));
 
             return Promise.resolve();
         },

--- a/src/services/streaming-manager/webrtc-core.test.ts
+++ b/src/services/streaming-manager/webrtc-core.test.ts
@@ -94,7 +94,10 @@ describe('Streaming Manager Core', () => {
             const mockPC = (window.RTCPeerConnection as any).mock.results[0].value;
             mockPC.iceConnectionState = 'disconnected';
             mockPC.oniceconnectionstatechange();
-            expect(options.callbacks.onConnectionStateChange).toHaveBeenCalledWith(ConnectionState.Disconnected);
+            expect(options.callbacks.onConnectionStateChange).toHaveBeenCalledWith(
+                ConnectionState.Disconnected,
+                'webrtc:ice-disconnected'
+            );
         });
 
         it('should add ICE candidates', async () => {

--- a/src/services/streaming-manager/webrtc-manager.ts
+++ b/src/services/streaming-manager/webrtc-manager.ts
@@ -303,7 +303,7 @@ export async function createWebRTCStreamingManager<T extends CreateStreamOptions
         const newState = mapConnectionState(peerConnection.iceConnectionState);
 
         if (newState !== ConnectionState.Connected) {
-            callbacks.onConnectionStateChange?.(newState);
+            callbacks.onConnectionStateChange?.(newState, `webrtc:ice-${peerConnection.iceConnectionState}`);
         }
     };
 


### PR DESCRIPTION
### Pull Request Type

🔮 Feature

### Description

- `agent-connection-state-change` now carries an ICE disconnect **reason** (`webrtc:ice-disconnected` / `…-failed` / `…-closed`) — the drop was previously logged with no reason, and silent on explicit teardown.
- `agent-chat` reconnect records `success` + `fallbackReason`, derived once from the actual outcome (V2 no longer mis-reports a recovered reconnect as failed).
- Enrich `videoId` (`tlk_…`) onto events, cleared on `StreamDone`, so events map to the active render.
- Offline retry buffer: analytics POSTs that fail (network **or** HTTP error) are queued and re-sent on recovery — so disconnect/error events emitted during an outage aren't lost.

Motivated by a prod incident where a brief client network blip dropped a turn and the client-side telemetry couldn't explain why.

### Reference Links

-   [DataDog](https://us3.datadoghq.com/logs?query=1-6a3e8c62-05e2b25a57dcf6cd44211e1c)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

