### PR TITLE
fix(auth): send per-connection id in bearer/basic auth headers

### DIFF
--- a/src/auth/get-auth-header.test.ts
+++ b/src/auth/get-auth-header.test.ts
@@ -77,42 +77,67 @@ describe('getAuthHeader', () => {
     });
 
     describe('Bearer token auth', () => {
-        it('should return Bearer token header', () => {
+        beforeEach(() => {
+            mockGetRandom.mockReturnValue('mocked-random-id');
+            rotateConnectionId();
+        });
+
+        it('appends the connectionId so the authorizer can route the websocket per-connection', () => {
             const auth: Auth = { type: 'bearer', token: 'test-token-123' };
             const result = getAuthHeader(auth);
 
-            expect(result).toBe('Bearer test-token-123');
+            expect(result).toBe('Bearer test-token-123~mocked-random-id');
         });
 
-        it('should ignore externalId for bearer auth', () => {
+        it('appends the connectionId regardless of externalId for bearer auth', () => {
             const auth: Auth = { type: 'bearer', token: 'test-token-123' };
             const result = getAuthHeader(auth, 'user-123');
 
-            expect(result).toBe('Bearer test-token-123');
+            expect(result).toBe('Bearer test-token-123~mocked-random-id');
+        });
+
+        it('rotates the bearer connectionId on rotateConnectionId()', () => {
+            const auth: Auth = { type: 'bearer', token: 'tok' };
+
+            mockGetRandom.mockReturnValueOnce('session-A');
+            rotateConnectionId();
+            const first = getAuthHeader(auth);
+
+            mockGetRandom.mockReturnValueOnce('session-B');
+            rotateConnectionId();
+            const second = getAuthHeader(auth);
+
+            expect(first).toBe('Bearer tok~session-A');
+            expect(second).toBe('Bearer tok~session-B');
         });
     });
 
     describe('Basic auth', () => {
-        it('should return Basic auth header with base64 encoded credentials', () => {
+        beforeEach(() => {
+            mockGetRandom.mockReturnValue('mocked-random-id');
+            rotateConnectionId();
+        });
+
+        it('appends the connectionId to the base64 encoded credentials', () => {
             const auth: Auth = { type: 'basic', username: 'user', password: 'pass' };
             const result = getAuthHeader(auth);
 
-            expect(result).toBe('Basic ' + btoa('user:pass'));
+            expect(result).toBe('Basic ' + btoa('user:pass') + '~mocked-random-id');
         });
 
-        it('should ignore externalId for basic auth', () => {
+        it('appends the connectionId regardless of externalId for basic auth', () => {
             const auth: Auth = { type: 'basic', username: 'user', password: 'pass' };
             const result = getAuthHeader(auth, 'user-123');
 
-            expect(result).toBe('Basic ' + btoa('user:pass'));
+            expect(result).toBe('Basic ' + btoa('user:pass') + '~mocked-random-id');
         });
 
-        it('should return pre-encoded token without double-encoding', () => {
+        it('appends the connectionId to a pre-encoded token without double-encoding the credentials', () => {
             const preEncodedToken = btoa('user:pass');
             const auth: Auth = { type: 'basic', token: preEncodedToken };
             const result = getAuthHeader(auth);
 
-            expect(result).toBe(`Basic ${preEncodedToken}`);
+            expect(result).toBe(`Basic ${preEncodedToken}~mocked-random-id`);
         });
     });
 

--- a/src/auth/get-auth-header.ts
+++ b/src/auth/get-auth-header.ts
@@ -18,7 +18,11 @@ export function getExternalId(externalId?: string): string {
     return key;
 }
 
-// Trailing segment of the Client-Key auth header, shared by WS and HTTP. Rotated by rotateConnectionId().
+// Per-connection routing id, shared by WS and HTTP. Rotated by rotateConnectionId().
+// Carried in every auth header so the notifications WS adapter routes messages
+// per-connection instead of collapsing clients that share a bearer/basic credential.
+// Client-Key appends it after the external_id (`_<id>`); bearer/basic append it after
+// a `~` delimiter, which the authorizer strips before validating the token.
 let connectionId = getRandom();
 
 export function rotateConnectionId() {
@@ -27,9 +31,10 @@ export function rotateConnectionId() {
 
 export function getAuthHeader(auth: Auth, externalId?: string) {
     if (auth.type === 'bearer') {
-        return `Bearer ${auth.token}`;
+        return `Bearer ${auth.token}~${connectionId}`;
     } else if (auth.type === 'basic') {
-        return `Basic ${'token' in auth ? auth.token : btoa(`${auth.username}:${auth.password}`)}`;
+        const credentials = 'token' in auth ? auth.token : btoa(`${auth.username}:${auth.password}`);
+        return `Basic ${credentials}~${connectionId}`;
     } else if (auth.type === 'key') {
         return `Client-Key ${auth.clientKey}.${getExternalId(externalId)}_${connectionId}`;
     } else {


### PR DESCRIPTION
## Problem
Under bearer/basic auth, the SDK's WebSocket/HTTP requests carry no per-connection discriminator, so the serverless notifications adapter collapses clients that share a credential onto `owner_id` and mixes their messages. (Client-Key already carries one.) Regression from de-id/studio#6535.

## Fix
Append `~<connectionId>` — the existing per-connection `getRandom()` id already used for Client-Key — to the bearer token and basic credentials, in `getAuthHeader`. This covers **both** transports unchanged: the WS `?authorization=` value and the HTTP `Authorization` header. The serverless authorizer strips the suffix and exposes `external_id_connect_id` (companion PR in `de-id/serverless`).

## Tests
Updated/added `get-auth-header` cases for bearer & basic (suffix present, ignores `externalId`, rotation); 17 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

