### PR TITLE
feat(agents): submitFeedback + end_of_call_feedback config

### DIFF
--- a/src/api/agents.ts
+++ b/src/api/agents.ts
@@ -8,6 +8,7 @@ import {
     RatingEntity,
     RatingPayload,
     STTTokenResponse,
+    SubmitFeedbackResponse,
 } from '@sdk/types/index';
 import { didApiUrl } from '../config/environment';
 import { RequestOptions, createClient } from './apiClient';
@@ -56,6 +57,14 @@ export function createAgentsApi(
         },
         deleteRating(agentId: string, chatId: string, ratingId: string, options?: RequestOptions) {
             return client.delete<RatingEntity>(`/${agentId}/chat/${chatId}/ratings/${ratingId}`, options);
+        },
+        submitFeedback(
+            agentId: string,
+            chatId: string,
+            payload: { rating: number; answer?: string },
+            options?: RequestOptions
+        ) {
+            return client.post<SubmitFeedbackResponse>(`/${agentId}/chat/${chatId}/feedback`, payload, options);
         },
         getSTTToken(agentId: string, options?: RequestOptions) {
             return client.get<STTTokenResponse>(`/${agentId}/stt-token`, options);

--- a/src/services/agent-manager/index.test.ts
+++ b/src/services/agent-manager/index.test.ts
@@ -686,6 +686,37 @@ describe('createAgentManager', () => {
             });
         });
 
+        describe('submitFeedback', () => {
+            beforeEach(async () => {
+                await manager.connect();
+            });
+
+            it('should submit feedback successfully', async () => {
+                await manager.submitFeedback(4, 'nice');
+
+                expect(mockAgentsApi.submitFeedback).toHaveBeenCalledWith('agent-123', 'chat-123', {
+                    rating: 4,
+                    answer: 'nice',
+                });
+                expect(mockAnalytics.track).toHaveBeenCalledWith('agent-feedback', {
+                    rating: 4,
+                    hasAnswer: true,
+                });
+            });
+
+            it('should throw error if chat not initialized when submitting feedback', async () => {
+                (initializeStreamAndChat as jest.Mock).mockResolvedValue({
+                    streamingManager: mockStreamingManager,
+                    chat: undefined,
+                });
+
+                const newManager = await createAgentManager('agent-123', mockOptions);
+                await newManager.connect();
+
+                expect(() => newManager.submitFeedback(4)).toThrow('Chat is not initialized');
+            });
+        });
+
         describe('changeMode', () => {
             it('should change mode successfully', async () => {
                 await manager.changeMode(ChatMode.TextOnly);

--- a/src/services/agent-manager/index.ts
+++ b/src/services/agent-manager/index.ts
@@ -548,6 +548,15 @@ export async function createAgentManager(agent: string, options: AgentManagerOpt
 
             return agentsApi.deleteRating(agentEntity.id, items.chat.id, id);
         },
+        submitFeedback(rating: number, answer?: string) {
+            if (!items.chat) {
+                throw new ValidationError('Chat is not initialized');
+            }
+
+            analytics.track('agent-feedback', { rating, hasAnswer: !!answer });
+
+            return agentsApi.submitFeedback(agentEntity.id, items.chat.id, { rating, answer });
+        },
         async speak(payload: string | SupportedStreamScript) {
             function getScript(): StreamScript {
                 if (typeof payload === 'string') {

--- a/src/test-utils/factories/agents-api.factory.ts
+++ b/src/test-utils/factories/agents-api.factory.ts
@@ -9,4 +9,5 @@ export const AgentsApiFactory = new Factory().attrs({
     createRating: () => jest.fn().mockResolvedValue({ id: 'rating-123' }),
     updateRating: () => jest.fn().mockResolvedValue({ id: 'rating-123' }),
     deleteRating: () => jest.fn().mockResolvedValue(undefined),
+    submitFeedback: () => jest.fn().mockResolvedValue({ chat_id: 'chat-123', rating: 4, submitted_at: 'now' }),
 });

--- a/src/types/entities/agents/agent.ts
+++ b/src/types/entities/agents/agent.ts
@@ -36,6 +36,17 @@ export interface Vision {
     enabled: boolean;
 }
 
+export interface EndOfCallFeedbackConfig {
+    enabled: boolean;
+    closing_message?: string;
+    follow_up_enabled?: boolean;
+    follow_up_messages?: {
+        low?: string;
+        four?: string;
+        five?: string;
+    };
+}
+
 export interface Agent {
     id: string;
     username?: string;
@@ -57,6 +68,7 @@ export interface Agent {
     preview_url?: string;
     owner_id?: string;
     status?: AgentStatus;
+    end_of_call_feedback?: EndOfCallFeedbackConfig;
 }
 
 export type AgentPayload = Omit<

--- a/src/types/entities/agents/chat.ts
+++ b/src/types/entities/agents/chat.ts
@@ -24,6 +24,13 @@ export type RatingPayload = Omit<
     'owner_id' | 'id' | 'created_at' | 'modified_at' | 'created_by' | 'external_id' | 'agent_id' | 'chat_id'
 >;
 
+export interface SubmitFeedbackResponse {
+    chat_id: string;
+    rating: number;
+    question_shown?: string;
+    submitted_at: string;
+}
+
 export type MessagePart =
     | { type: 'text'; text: string }
     | { type: 'image'; src: string; alt: string; mimeType?: string }

--- a/src/types/entities/agents/manager.ts
+++ b/src/types/entities/agents/manager.ts
@@ -14,7 +14,7 @@ import {
 import { SupportedStreamScript } from '@sdk/types/stream-script';
 import type { ManagerCallbacks as StreamManagerCallbacks } from '../../stream/stream';
 import { Agent } from './agent';
-import { ChatMode, ChatResponse, Interrupt, Message, RatingEntity } from './chat';
+import { ChatMode, ChatResponse, Interrupt, Message, RatingEntity, SubmitFeedbackResponse } from './chat';
 
 /**
  * Types of events provided in Chat Progress Callback
@@ -264,6 +264,12 @@ export interface AgentManager {
      * @param id - id of Rating entity.
      */
     deleteRate: (id: string) => Promise<RatingEntity>;
+    /**
+     * Method to submit end-of-call feedback for the chat
+     * @param rating - integer score from 1 to 5
+     * @param answer - optional free-text answer
+     */
+    submitFeedback: (rating: number, answer?: string) => Promise<SubmitFeedbackResponse>;
     /**
      * Method to make your agent read the text you provide or reproduce sound
      * @param payload


### PR DESCRIPTION
## Summary
SDK support for the end-of-call feedback feature so consumers don't hand-roll the request/auth:

- `AgentManager.submitFeedback(rating: number, answer?: string): Promise<SubmitFeedbackResponse>` — `POST /agents/{agentId}/chat/{chatId}/feedback`; chat-initialized guard (`ValidationError`, same idiom as `rate`), `agent-feedback` analytics with `{ rating, hasAnswer }`
- `Agent.end_of_call_feedback?: EndOfCallFeedbackConfig` — `{ enabled, closing_message?, follow_up_enabled?, follow_up_messages?: { low?, four?, five? } }`, matching the backend block (serverless #7168)
- `SubmitFeedbackResponse` — `{ chat_id, rating, question_shown?, submitted_at }`

Backend endpoint: serverless #7176 (+ #7207/#7208 fixes), deployed on dev. Consumer: agents-ui #1045 currently calls the endpoint via a local seam that this method replaces after release.

## Testing
`yarn ci:test` — 21 suites / 476 tests green; `describe('submitFeedback')` mirrors the `rate` block (success + uninitialized-chat guard). Prettier clean.

**Asana:** https://app.asana.com/1/856614567666442/project/1215792551506854/task/1216197180240376