### PR TITLE
fix(livekit): keep ToolActive while tool calls are pending

### DIFF
--- a/src/services/streaming-manager/livekit-manager.test.ts
+++ b/src/services/streaming-manager/livekit-manager.test.ts
@@ -614,6 +614,32 @@ describe('LiveKit Streaming Manager - Microphone Stream', () => {
             expect(mockOnAgentActivityStateChange).toHaveBeenNthCalledWith(1, AgentActivityState.Talking);
             expect(mockOnAgentActivityStateChange).toHaveBeenNthCalledWith(2, AgentActivityState.Idle);
         });
+
+        it('should return to ToolActive when video ends while a tool call is pending', () => {
+            sendDataEvent(StreamEvents.ToolCallStarted, { call_id: 'tc1', name: 'form' });
+            sendDataEvent(StreamEvents.StreamVideoCreated);
+            sendDataEvent(StreamEvents.StreamVideoDone);
+
+            expect(mockOnAgentActivityStateChange).toHaveBeenNthCalledWith(1, AgentActivityState.ToolActive);
+            expect(mockOnAgentActivityStateChange).toHaveBeenNthCalledWith(2, AgentActivityState.Talking);
+            expect(mockOnAgentActivityStateChange).toHaveBeenNthCalledWith(3, AgentActivityState.ToolActive);
+        });
+
+        it('should set Idle when the last pending tool call resolves', () => {
+            sendDataEvent(StreamEvents.ToolCallStarted, { call_id: 'tc1', name: 'form' });
+            sendDataEvent(StreamEvents.ToolCallDone, { call_id: 'tc1', name: 'form' });
+
+            expect(mockOnAgentActivityStateChange).toHaveBeenLastCalledWith(AgentActivityState.Idle);
+        });
+
+        it('should set Idle when video ends after all tool calls resolved', () => {
+            sendDataEvent(StreamEvents.ToolCallStarted, { call_id: 'tc1', name: 'form' });
+            sendDataEvent(StreamEvents.ToolCallDone, { call_id: 'tc1', name: 'form' });
+            sendDataEvent(StreamEvents.StreamVideoCreated);
+            sendDataEvent(StreamEvents.StreamVideoDone);
+
+            expect(mockOnAgentActivityStateChange).toHaveBeenLastCalledWith(AgentActivityState.Idle);
+        });
     });
 
     describe('Transcription Interrupt Detection', () => {
@@ -1441,7 +1467,7 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
     });
 
     describe('handleDataReceived - tool-call/done', () => {
-        it('should forward payload via onToolEvent without changing activity state', async () => {
+        it('should forward payload via onToolEvent and release the last pending tool to Idle', async () => {
             // ARRANGE:
             const onAgentActivityStateChange = jest.fn();
             const onToolEvent = jest.fn();
@@ -1481,7 +1507,7 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
             dataHandler(donePayload);
 
             // ASSERT:
-            expect(onAgentActivityStateChange).not.toHaveBeenCalled();
+            expect(onAgentActivityStateChange).toHaveBeenCalledWith(AgentActivityState.Idle);
             expect(onToolEvent).toHaveBeenCalledWith(
                 StreamEvents.ToolCallDone,
                 expect.objectContaining({
@@ -1494,7 +1520,7 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
     });
 
     describe('handleDataReceived - tool-call/error', () => {
-        it('should forward payload via onToolEvent without changing activity state', async () => {
+        it('should forward payload via onToolEvent and release the last pending tool to Idle', async () => {
             // ARRANGE:
             const onAgentActivityStateChange = jest.fn();
             const onToolEvent = jest.fn();
@@ -1533,7 +1559,7 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
             dataHandler(errorPayload);
 
             // ASSERT:
-            expect(onAgentActivityStateChange).not.toHaveBeenCalled();
+            expect(onAgentActivityStateChange).toHaveBeenCalledWith(AgentActivityState.Idle);
             expect(onToolEvent).toHaveBeenCalledWith(
                 StreamEvents.ToolCallError,
                 expect.objectContaining({
@@ -1545,7 +1571,7 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
     });
 
     describe('handleDataReceived - stream-video/done with interruptible', () => {
-        it('should transition to Idle on stream-video/done when interruptible is true', async () => {
+        it('should stay ToolActive on stream-video/done while a tool call is pending (interruptible true)', async () => {
             // ARRANGE:
             const onAgentActivityStateChange = jest.fn();
             options.callbacks.onAgentActivityStateChange = onAgentActivityStateChange;
@@ -1577,10 +1603,10 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
             dataHandler(streamVideoDonePayload);
 
             // ASSERT:
-            expect(onAgentActivityStateChange).toHaveBeenCalledWith(AgentActivityState.Idle);
+            expect(onAgentActivityStateChange).not.toHaveBeenCalled();
         });
 
-        it('should transition to Idle on stream-video/done when interruptible is absent (default true)', async () => {
+        it('should stay ToolActive on stream-video/done while a tool call is pending (interruptible absent)', async () => {
             // ARRANGE:
             const onAgentActivityStateChange = jest.fn();
             options.callbacks.onAgentActivityStateChange = onAgentActivityStateChange;
@@ -1611,7 +1637,7 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
             dataHandler(streamVideoDonePayload);
 
             // ASSERT:
-            expect(onAgentActivityStateChange).toHaveBeenCalledWith(AgentActivityState.Idle);
+            expect(onAgentActivityStateChange).not.toHaveBeenCalled();
         });
 
         it('should stay in ToolActive on stream-video/done when interruptible is false', async () => {
@@ -1651,7 +1677,7 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
     });
 
     describe('Chained tools', () => {
-        it('should stay ToolActive across multiple tool calls until final stream-video/done', async () => {
+        it('should stay ToolActive until all pending tool calls resolve', async () => {
             // ARRANGE:
             const onAgentActivityStateChange = jest.fn();
             options.callbacks.onAgentActivityStateChange = onAgentActivityStateChange;
@@ -1660,49 +1686,26 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
             await simulateConnection();
             const dataHandler = getDataReceivedHandler();
 
-            // ACT:
-            // First tool cycle
-            dataHandler(
+            const toolEvent = (subject: StreamEvents, callId: string) =>
                 createDataChannelPayload({
-                    subject: StreamEvents.ToolCallStarted,
-                    call_id: 'call-1',
-                    name: 'tool1',
+                    subject,
+                    call_id: callId,
+                    name: 'tool',
                     input: {},
                     output: {},
                     timestamp: new Date().toISOString(),
-                })
-            );
+                });
 
-            // interruptible: false = more tools coming
-            dataHandler(
-                createDataChannelPayload({
-                    subject: StreamEvents.StreamVideoDone,
-                    metadata: { interruptible: false },
-                })
-            );
+            // ACT: two parallel tool calls; the first resolves while the second is still pending
+            dataHandler(toolEvent(StreamEvents.ToolCallStarted, 'call-1'));
+            dataHandler(toolEvent(StreamEvents.ToolCallStarted, 'call-2'));
+            dataHandler(toolEvent(StreamEvents.ToolCallDone, 'call-1'));
 
-            // Second tool cycle
-            dataHandler(
-                createDataChannelPayload({
-                    subject: StreamEvents.ToolCallStarted,
-                    call_id: 'call-2',
-                    name: 'tool2',
-                    input: {},
-                    output: {},
-                    timestamp: new Date().toISOString(),
-                })
-            );
+            // ASSERT: still ToolActive — no Idle until the last tool resolves
+            expect(onAgentActivityStateChange).not.toHaveBeenCalledWith(AgentActivityState.Idle);
 
-            // interruptible: true = tool chain complete
-            dataHandler(
-                createDataChannelPayload({
-                    subject: StreamEvents.StreamVideoDone,
-                    metadata: { interruptible: true },
-                })
-            );
+            dataHandler(toolEvent(StreamEvents.ToolCallDone, 'call-2'));
 
-            // ASSERT:
-            expect(onAgentActivityStateChange).toHaveBeenCalledWith(AgentActivityState.ToolActive);
             expect(onAgentActivityStateChange).toHaveBeenLastCalledWith(AgentActivityState.Idle);
         });
     });

--- a/src/services/streaming-manager/livekit-manager.ts
+++ b/src/services/streaming-manager/livekit-manager.ts
@@ -124,6 +124,7 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
     let trackSubscriptionTimeoutId: ReturnType<typeof setTimeout> | null = null;
     let currentActivityState: AgentActivityState = AgentActivityState.Idle;
     let currentInterruptible = true;
+    const pendingToolCalls = new Set<string>();
 
     const streamApi = createStreamApiV2(auth, baseURL || didApiUrl, agentId, callbacks.onError);
     let sessionId: string | undefined;
@@ -359,9 +360,10 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
 
     /**
      * ToolActive state transitions:
-     * - tool-call/started -> sets ToolActive
-     * - stream-video/done with interruptible: true -> sets Idle
-     * - stream-video/done with interruptible: false -> stays ToolActive (more tools coming)
+     * - tool-call/started -> ToolActive
+     * - stream-video/created -> Talking, then back to ToolActive on stream-video/done
+     *   while any tool call is still pending (e.g. a client tool waiting for user input)
+     * - last tool-call/done|error -> Idle
      */
     function handleToolEvents(subject: string, data: any): void {
         if (subject === StreamEvents.ToolCallStarted) {
@@ -372,6 +374,7 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
             // Future fix: track interruptible per toolId and derive the aggregate state.
             currentInterruptible = payload.interruptible !== false;
             callbacks.onInterruptibleChange?.(currentInterruptible);
+            pendingToolCalls.add(payload.call_id);
             currentActivityState = AgentActivityState.ToolActive;
             callbacks.onAgentActivityStateChange?.(AgentActivityState.ToolActive);
             callbacks.onToolEvent?.(StreamEvents.ToolCallStarted, payload);
@@ -379,12 +382,24 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
         }
 
         if (subject === StreamEvents.ToolCallDone) {
-            callbacks.onToolEvent?.(StreamEvents.ToolCallDone, data as ToolCallDonePayload);
+            const payload = data as ToolCallDonePayload;
+            resolvePendingToolCall(payload.call_id);
+            callbacks.onToolEvent?.(StreamEvents.ToolCallDone, payload);
             return;
         }
 
         if (subject === StreamEvents.ToolCallError) {
-            callbacks.onToolEvent?.(StreamEvents.ToolCallError, data as ToolCallErrorPayload);
+            const payload = data as ToolCallErrorPayload;
+            resolvePendingToolCall(payload.call_id);
+            callbacks.onToolEvent?.(StreamEvents.ToolCallError, payload);
+        }
+    }
+
+    function resolvePendingToolCall(callId: string): void {
+        pendingToolCalls.delete(callId);
+        if (pendingToolCalls.size === 0 && currentActivityState === AgentActivityState.ToolActive) {
+            currentActivityState = AgentActivityState.Idle;
+            callbacks.onAgentActivityStateChange?.(AgentActivityState.Idle);
         }
     }
 
@@ -399,6 +414,14 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
                 sttLatency: data?.stt?.latency,
                 serviceLatency: data?.serviceLatency,
             });
+            return;
+        }
+
+        if (pendingToolCalls.size > 0) {
+            if (currentActivityState !== AgentActivityState.ToolActive) {
+                currentActivityState = AgentActivityState.ToolActive;
+                callbacks.onAgentActivityStateChange?.(AgentActivityState.ToolActive);
+            }
             return;
         }
 
@@ -690,6 +713,7 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
         cleanMediaStream();
         isConnected = false;
         hasEmittedConnected = false;
+        pendingToolCalls.clear();
         callbacks.onAgentActivityStateChange?.(AgentActivityState.Idle);
         currentActivityState = AgentActivityState.Idle;
     }


### PR DESCRIPTION
### Pull Request Type

🐛 BugFix

### Description
- `AgentActivityState.ToolActive` was lost the moment the agent spoke alongside a tool call: `stream-video/created` unconditionally set `Talking`, and `stream-video/done` set `Idle` (interruptible) or left it stranded on `Talking` (non-interruptible). Nothing restored `ToolActive`, since `tool-call/done` only arrives when the tool resolves — for client tools (widgets awaiting user input) that's minutes. Consumers keying on `ToolActive` (running-tool indicator, input locking) broke whenever the tool call had spoken content around it.
- Fix: track pending `call_id`s. `stream-video/done`/`error` restores `ToolActive` while any call is pending (the doc comment always promised this); the last `tool-call/done|error` releases to `Idle`. No API surface changes — only more-correct emissions.
- Tests: video-done-while-pending restores ToolActive, last-tool-resolution releases to Idle, parallel calls release only after the last, and the old interruptible-heuristic tests updated to the pending-set contract.

### Reference Links
-   [Asana](https://app.asana.com/1/856614567666442/project/1215527970149880/task/1215120866285574?focus=true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)