### PR TITLE
feat: attach user timezone and device on LiveKit connect

### DIFF
--- a/src/services/streaming-manager/livekit-manager.ts
+++ b/src/services/streaming-manager/livekit-manager.ts
@@ -182,7 +182,6 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
         }
         try {
             await room.localParticipant.setAttributes(attributes);
-            log('User context attributes set', attributes);
         } catch (error) {
             log('Failed to set user context attributes', error);
         }

--- a/src/services/streaming-manager/livekit-manager.ts
+++ b/src/services/streaming-manager/livekit-manager.ts
@@ -18,6 +18,7 @@ import {
 } from '@sdk/types';
 import { ChatProgress } from '@sdk/types/entities/agents/manager';
 import { noop } from '@sdk/utils';
+import { getUserContextAttributes } from '@sdk/utils/user-context';
 import { createStreamApiV2 } from '../../api/streams/streamsApiV2';
 import { didApiUrl } from '../../config/environment';
 import { toErrorAnalytics } from '../../utils/error-analytics';
@@ -174,9 +175,24 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
             }
         }
     }
+    async function setUserContextAttributes(): Promise<void> {
+        const attributes = getUserContextAttributes();
+        if (!room || Object.keys(attributes).length === 0) {
+            return;
+        }
+        try {
+            await room.localParticipant.setAttributes(attributes);
+            log('User context attributes set', attributes);
+        } catch (error) {
+            log('Failed to set user context attributes', error);
+        }
+    }
+
     try {
         await room.connect(url, token);
         log('LiveKit room joined successfully');
+
+        void setUserContextAttributes();
 
         trackSubscriptionTimeoutId = setTimeout(() => {
             log(

--- a/src/utils/user-context.test.ts
+++ b/src/utils/user-context.test.ts
@@ -1,0 +1,61 @@
+import { getUserContextAttributes } from './user-context';
+
+function mockNavigator(userAgent: string, platform: string): void {
+    Object.defineProperty(window.navigator, 'userAgent', { value: userAgent, configurable: true });
+    Object.defineProperty(window.navigator, 'platform', { value: platform, configurable: true });
+}
+
+function mockTimezone(timeZone: string | undefined): void {
+    jest.spyOn(Intl, 'DateTimeFormat').mockReturnValue({
+        resolvedOptions: () => ({ timeZone }) as Intl.ResolvedDateTimeFormatOptions,
+    } as Intl.DateTimeFormat);
+}
+
+describe('getUserContextAttributes', () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('resolves the IANA timezone', () => {
+        mockTimezone('America/New_York');
+        mockNavigator('Mozilla/5.0 (Macintosh)', 'MacIntel');
+
+        expect(getUserContextAttributes().timezone).toBe('America/New_York');
+    });
+
+    it('describes a desktop Mac', () => {
+        mockTimezone('Europe/Berlin');
+        mockNavigator('Mozilla/5.0 (Macintosh; Intel Mac OS X)', 'MacIntel');
+
+        expect(getUserContextAttributes().device).toBe('Mac OS X, Desktop');
+    });
+
+    it('detects a mobile Android device from the user agent', () => {
+        mockTimezone('Asia/Tokyo');
+        mockNavigator('Mozilla/5.0 (Linux; Android 14; Pixel)', 'Linux armv8l');
+
+        expect(getUserContextAttributes().device).toBe('Android, Mobile');
+    });
+
+    it('detects iOS', () => {
+        mockTimezone('Asia/Tokyo');
+        mockNavigator('Mozilla/5.0 (iPhone; CPU iPhone OS 17_0)', 'iPhone');
+
+        expect(getUserContextAttributes().device).toBe('iOS, Mobile');
+    });
+
+    it('detects Windows desktop', () => {
+        mockTimezone('America/Chicago');
+        mockNavigator('Mozilla/5.0 (Windows NT 10.0)', 'Win32');
+
+        expect(getUserContextAttributes().device).toBe('Windows, Desktop');
+    });
+
+    it('omits timezone when it is unavailable', () => {
+        mockTimezone(undefined);
+        mockNavigator('Mozilla/5.0 (Windows NT 10.0)', 'Win32');
+
+        expect(getUserContextAttributes()).not.toHaveProperty('timezone');
+        expect(getUserContextAttributes().device).toBe('Windows, Desktop');
+    });
+});

--- a/src/utils/user-context.ts
+++ b/src/utils/user-context.ts
@@ -1,0 +1,64 @@
+/**
+ * Best-effort user context (location + device) resolved entirely on the client
+ * and attached to the LiveKit participant as attributes on connect. The agent
+ * backend reads these to enrich the LLM context (see `get_user_context`).
+ *
+ * `location` is the IANA timezone (e.g. `America/New_York`) — a coarse but
+ * network-free location proxy. `device` is a short human-readable descriptor.
+ */
+
+function getTimezone(): string {
+    try {
+        return Intl.DateTimeFormat().resolvedOptions().timeZone ?? '';
+    } catch {
+        return '';
+    }
+}
+
+function getDevice(): string {
+    if (typeof navigator === 'undefined') {
+        return '';
+    }
+
+    const userAgent = navigator.userAgent ?? '';
+    const platform = (navigator.platform ?? '').toLowerCase();
+
+    let os = 'Unknown';
+    if (/android/i.test(userAgent)) {
+        os = 'Android';
+    } else if (/iphone|ipad|ipod/i.test(userAgent)) {
+        os = 'iOS';
+    } else if (platform.includes('win')) {
+        os = 'Windows';
+    } else if (platform.includes('mac')) {
+        os = 'Mac OS X';
+    } else if (platform.includes('linux')) {
+        os = 'Linux';
+    }
+
+    const isMobile = os === 'Android' || os === 'iOS' || /Mobi/i.test(userAgent);
+
+    return `${os}, ${isMobile ? 'Mobile' : 'Desktop'}`;
+}
+
+/**
+ * Non-empty `{ timezone, device }` attributes to attach to the participant.
+ * Keys with no resolvable value are omitted. The backend infers the user's
+ * country from the timezone (a timezone identifies a country reliably, but its
+ * reference city is not the user's actual city).
+ */
+export function getUserContextAttributes(): Record<string, string> {
+    const attributes: Record<string, string> = {};
+
+    const timezone = getTimezone();
+    if (timezone) {
+        attributes.timezone = timezone;
+    }
+
+    const device = getDevice();
+    if (device) {
+        attributes.device = device;
+    }
+
+    return attributes;
+}


### PR DESCRIPTION
### Pull Request Type

🔮 Feature

### Description
-   Resolve the user's timezone (`Intl.DateTimeFormat().resolvedOptions().timeZone`) and device (from `navigator`) on the client, and set them as LiveKit participant attributes (`timezone`, `device`) right after joining the room.
-   The agent backend reads these to enrich the LLM context — approximate location is inferred from the timezone (country, not the reference city), plus the device — and reports them on `chat/end`. The raw timezone also feeds the `get_timestamp` tool for accurate local time.
-   New `getUserContextAttributes()` helper + unit tests; best-effort (`setAttributes` failures are logged, never block the session).

### Reference Links
-   [Asana](https://app.asana.com/1/856614567666442/project/1215792551506854/task/1215886842369861?focus=true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)