### PR TITLE
feat: add correctly-spelled enableAnalytics option

### DIFF
--- a/src/services/agent-manager/index.ts
+++ b/src/services/agent-manager/index.ts
@@ -72,7 +72,7 @@ export async function createAgentManager(agent: string, options: AgentManagerOpt
     const analytics = initializeAnalytics({
         token: mxKey,
         agentId: agent,
-        isEnabled: options.enableAnalitics,
+        isEnabled: options.enableAnalytics ?? options.enableAnalitics,
         externalId: options.externalId,
         mixpanelAdditionalProperties: options.mixpanelAdditionalProperties,
     });

--- a/src/types/entities/agents/manager.ts
+++ b/src/types/entities/agents/manager.ts
@@ -165,7 +165,18 @@ export interface AgentManagerOptions {
     wsURL?: string;
     debug?: boolean;
     verbose?: boolean;
+    /**
+     * Whether to enable analytics (Mixpanel) tracking.
+     * @default true
+     * @deprecated Use `enableAnalytics` instead. This misspelled prop is kept for backwards compatibility.
+     */
     enableAnalitics?: boolean;
+    /**
+     * Whether to enable analytics (Mixpanel) tracking.
+     * Takes precedence over the deprecated `enableAnalitics` prop when both are set.
+     * @default true
+     */
+    enableAnalytics?: boolean;
     mixpanelKey?: string;
     mixpanelAdditionalProperties?: Record<string, any>;
     externalId?: string;


### PR DESCRIPTION
### Pull Request Type

🔮 Feature

### Description
- Adds a correctly-spelled `enableAnalytics` option to `AgentManagerOptions` to toggle Mixpanel analytics.
- Keeps the existing misspelled `enableAnalitics` (now marked `@deprecated`) so the public API is not broken.
- `enableAnalytics` takes precedence when both are provided; when neither is set the existing default (analytics enabled) is preserved — zero behavior change for current consumers.

### Reference Links

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015JGkJbz6wSXF8t1SY2gVoR