### PR TITLE
feat: optional sentiment param in speak

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,13 +115,23 @@ The `agentManager` object created during initialization has several built-in met
     });
     ```
 
+    Text scripts also accept an optional `sentiment` (expressive avatars only). If the requested sentiment is not supported by the agent, the default sentiment is used.
+
+    ```javascript Text with sentiment - JavaScript
+    let speak = agentManager.speak({
+        type: 'text',
+        input: "Hi! I'm Alice!",
+        sentiment: 'friendly',
+    });
+    ```
+
     ```javascript Audio File - JavaScript
     let speak = agentManager.speak(
         {
           type: "audio",
-          audio_url: "http://www.yourwebsite.com/audio.mp3";
+          audio_url: "http://www.yourwebsite.com/audio.mp3"
         }
-    )
+    );
     ```
 
 - **`agentManager.chat(string)`**

--- a/src/services/agent-manager/index.test.ts
+++ b/src/services/agent-manager/index.test.ts
@@ -487,6 +487,44 @@ describe('createAgentManager', () => {
                 });
             });
 
+            it('should preserve sentiment in the speak script', async () => {
+                const script = {
+                    type: 'text' as const,
+                    input: 'Hello world',
+                    ssml: false,
+                    sentiment: 'friendly',
+                };
+
+                await manager.speak(script);
+
+                expect(mockStreamingManager.speak).toHaveBeenCalledWith({
+                    script: {
+                        type: 'text',
+                        provider: mockAgent.presenter.voice,
+                        input: 'Hello world',
+                        ssml: false,
+                        sentiment: 'friendly',
+                    },
+                    metadata: { chat_id: 'chat-123', agent_id: 'agent-123' },
+                });
+            });
+
+            it('should preserve sentiment when the script has a provider', async () => {
+                const script = {
+                    type: 'text' as const,
+                    provider: mockAgent.presenter.voice,
+                    input: 'Hello world',
+                    sentiment: 'excited',
+                };
+
+                await manager.speak(script);
+
+                expect(mockStreamingManager.speak).toHaveBeenCalledWith({
+                    script,
+                    metadata: { chat_id: 'chat-123', agent_id: 'agent-123' },
+                });
+            });
+
             it('should trigger onNewMessage callback when speak is called with text', async () => {
                 const textInput = 'Hello from speak method';
                 const mockCallback = mockOptions.callbacks.onNewMessage as jest.Mock;

--- a/src/services/agent-manager/index.ts
+++ b/src/services/agent-manager/index.ts
@@ -583,6 +583,7 @@ export async function createAgentManager(agent: string, options: AgentManagerOpt
                         input: payload.input,
                         ssml: payload.ssml,
                         should_queue_speaks: payload.should_queue_speaks,
+                        sentiment: payload.sentiment,
                     };
                 }
 

--- a/src/types/stream-script.ts
+++ b/src/types/stream-script.ts
@@ -33,7 +33,7 @@ export interface Stream_Text_Script extends BaseStreamScript {
     ssml?: boolean;
 
     /**
-     * Queue this speak behind the current speech instead of interrupting it.
+     * Queue this speak behind the current speech instead of interrupting it (expressive avatars only).
      * @default false
      */
     should_queue_speaks?: boolean;

--- a/src/types/stream-script.ts
+++ b/src/types/stream-script.ts
@@ -37,6 +37,13 @@ export interface Stream_Text_Script extends BaseStreamScript {
      * @default false
      */
     should_queue_speaks?: boolean;
+
+    /**
+     * Sentiment name to speak with (expressive avatars only).
+     * If the sentiment is not supported by the agent, the default sentiment is used.
+     * @example "friendly"
+     */
+    sentiment?: string;
 }
 
 export interface Stream_Audio_Script extends BaseStreamScript {


### PR DESCRIPTION
### Pull Request Type

🔮 Feature

### General Description

- `speak` now accepts an optional `sentiment` name on text scripts (expressive avatars)
- Unsupported sentiments fall back to the agent's default sentiment on the server side

### Technical Description

- Added optional `sentiment` field to `Stream_Text_Script`
- `speak()` preserves `sentiment` when it fills in the default voice provider; scripts with an explicit provider already pass through unchanged
- README documents the param with an example; two unit tests cover sentiment passthrough