### PR TITLE
chore: migrate CI runners from aws-* to azure-*

### DIFF
--- a/.github/workflows/manual-e2e.yml
+++ b/.github/workflows/manual-e2e.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   e2e-validation:
-    runs-on: ${{ github.event.inputs.ui_branch == 'prod' && 'ubuntu-latest' || 'aws-medium' }}
+    runs-on: ${{ github.event.inputs.ui_branch == 'prod' && 'ubuntu-latest' || 'azure-medium' }}
     timeout-minutes: 30
     environment:
       name: ${{ github.event.inputs.ui_branch == 'prod' && 'prod' || 'staging' }}


### PR DESCRIPTION
Part of decommissioning the AWS `eks-main-dev` cluster — its only remaining workload is the self-hosted GitHub runners (confirmed via live cluster inspection + Datadog over the past week; all app namespaces are scaled to zero).

This flips CI from the `aws-*` runner sets to the `azure-*` equivalents, which **already exist** on `aks-main-dev` and are already used by many other de-id repos.

- **No functional change beyond the runner:** AWS access in these workflows is via static `AWS_*` secrets, not runner IAM, so it keeps working from Azure runners.
- Azure `buildkit` is already running on `aks-main-dev`.

Once the `aws-*` runners are unused across all repos, they can be scaled to zero and the EKS cluster decommissioned (the VPC is preserved — it hosts the load-bearing cross-cloud DNS resolver).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Asana task:** https://app.asana.com/1/856614567666442/project/1207071459536641/task/1215961488159083