### PR TITLE
chore!: bump @d-id/client-sdk to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@d-id/client-sdk",
   "private": false,
-  "version": "1.2.10",
+  "version": "2.0.0",
   "type": "module",
   "description": "d-id client sdk",
   "repository": {


### PR DESCRIPTION
## Bump `@d-id/client-sdk` to `2.0.0`

The runtime-`Agent` change ([#442](https://github.com/de-id/agents-sdk/pull/442)) is a **breaking** release — `Agent` is now the minimized runtime shape and the full agent-management API (`create`/`update`/`getAgents`/`getById`/`delete`) was removed. CI/CD only auto-bumps the minor, so this sets the major version manually.

See `MIGRATION.md` for the v1 → v2 guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
