### PR TITLE
feat(turn-events): consume turn/started + turn/ended for agent activity state

### DIFF
--- a/src/services/streaming-manager/livekit-manager.test.ts
+++ b/src/services/streaming-manager/livekit-manager.test.ts
@@ -640,6 +640,42 @@ describe('LiveKit Streaming Manager - Microphone Stream', () => {
 
             expect(mockOnAgentActivityStateChange).toHaveBeenLastCalledWith(AgentActivityState.Idle);
         });
+
+        it('should set Loading on turn/started', () => {
+            sendDataEvent(StreamEvents.TurnStarted, { turn_id: 1 });
+
+            expect(mockOnAgentActivityStateChange).toHaveBeenLastCalledWith(AgentActivityState.Loading);
+        });
+
+        it('should return to Idle only on turn/ended, not on a mid-turn video done', () => {
+            sendDataEvent(StreamEvents.TurnStarted, { turn_id: 1 });
+            sendDataEvent(StreamEvents.StreamVideoCreated, { turn_id: 1 });
+            sendDataEvent(StreamEvents.StreamVideoDone, { turn_id: 1 });
+            sendDataEvent(StreamEvents.TurnEnded, { turn_id: 1 });
+
+            const states = mockOnAgentActivityStateChange.mock.calls.map(call => call[0]);
+            expect(states).toEqual([AgentActivityState.Loading, AgentActivityState.Talking, AgentActivityState.Idle]);
+        });
+
+        it('should stay ToolActive when the last tool call resolves inside a turn', () => {
+            sendDataEvent(StreamEvents.TurnStarted, { turn_id: 1 });
+            sendDataEvent(StreamEvents.ToolCallStarted, { call_id: 'tc1', name: 'form', turn_id: 1 });
+            sendDataEvent(StreamEvents.ToolCallDone, { call_id: 'tc1', name: 'form', turn_id: 1 });
+
+            expect(mockOnAgentActivityStateChange).not.toHaveBeenCalledWith(AgentActivityState.Idle);
+            expect(mockOnAgentActivityStateChange).toHaveBeenLastCalledWith(AgentActivityState.ToolActive);
+        });
+
+        it('should drop a stale turn/ended from an older turn', () => {
+            sendDataEvent(StreamEvents.TurnStarted, { turn_id: 1 });
+            sendDataEvent(StreamEvents.TurnEnded, { turn_id: 1 });
+            sendDataEvent(StreamEvents.TurnStarted, { turn_id: 2 });
+            mockOnAgentActivityStateChange.mockClear();
+
+            sendDataEvent(StreamEvents.TurnEnded, { turn_id: 1 });
+
+            expect(mockOnAgentActivityStateChange).not.toHaveBeenCalled();
+        });
     });
 
     describe('Transcription Interrupt Detection', () => {

--- a/src/services/streaming-manager/livekit-manager.ts
+++ b/src/services/streaming-manager/livekit-manager.ts
@@ -126,6 +126,8 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
     let currentActivityState: AgentActivityState = AgentActivityState.Idle;
     let currentInterruptible = true;
     const pendingToolCalls = new Set<string>();
+    let currentTurnId: number | null = null;
+    let usingTurnEvents = false;
 
     const streamApi = createStreamApiV2(auth, baseURL || didApiUrl, agentId, callbacks.onError);
     let sessionId: string | undefined;
@@ -172,7 +174,7 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
     function handleTranscriptionReceived(_segments: TranscriptionSegment[], participant?: Participant): void {
         if (participant?.isLocal) {
             latencyTimestampTracker.update();
-            if (currentActivityState === AgentActivityState.Talking) {
+            if (!usingTurnEvents && currentActivityState === AgentActivityState.Talking) {
                 currentActivityState = AgentActivityState.Idle;
             }
         }
@@ -412,7 +414,7 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
 
     function resolvePendingToolCall(callId: string): void {
         pendingToolCalls.delete(callId);
-        if (pendingToolCalls.size === 0 && currentActivityState === AgentActivityState.ToolActive) {
+        if (!usingTurnEvents && pendingToolCalls.size === 0 && currentActivityState === AgentActivityState.ToolActive) {
             currentActivityState = AgentActivityState.Idle;
             callbacks.onAgentActivityStateChange?.(AgentActivityState.Idle);
         }
@@ -440,7 +442,7 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
             return;
         }
 
-        if (currentInterruptible) {
+        if (!usingTurnEvents && currentInterruptible) {
             currentActivityState = AgentActivityState.Idle;
             callbacks.onAgentActivityStateChange?.(AgentActivityState.Idle);
         }
@@ -469,6 +471,20 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
         });
     }
 
+    function handleTurnStarted(_subject: string, data: any): void {
+        usingTurnEvents = true;
+        currentTurnId = data?.turn_id ?? null;
+        currentActivityState = AgentActivityState.Loading;
+        callbacks.onAgentActivityStateChange?.(AgentActivityState.Loading);
+    }
+
+    function handleTurnEnded(_subject: string, data: any): void {
+        const turnId: number | null = data?.turn_id ?? null;
+        if (currentTurnId !== null && turnId !== null && turnId < currentTurnId) return;
+        currentActivityState = AgentActivityState.Idle;
+        callbacks.onAgentActivityStateChange?.(AgentActivityState.Idle);
+    }
+
     type DataChannelHandler = (subject: string, data: any) => void;
     const dataChannelHandlers: Record<string, DataChannelHandler> = {
         [StreamEvents.ChatAnswer]: handleChatEvents,
@@ -481,6 +497,8 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
         [StreamEvents.StreamVideoError]: handleVideoEvents,
         [StreamEvents.StreamVideoRejected]: handleVideoEvents,
         [StreamEvents.ChatAudioTranscribed]: handleTranscriptionEvents,
+        [StreamEvents.TurnStarted]: handleTurnStarted,
+        [StreamEvents.TurnEnded]: handleTurnEnded,
     };
 
     function handleDataReceived(
@@ -729,6 +747,7 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
         isConnected = false;
         hasEmittedConnected = false;
         pendingToolCalls.clear();
+        currentTurnId = null;
         callbacks.onAgentActivityStateChange?.(AgentActivityState.Idle);
         currentActivityState = AgentActivityState.Idle;
     }

--- a/src/services/streaming-manager/livekit-manager.ts
+++ b/src/services/streaming-manager/livekit-manager.ts
@@ -15,6 +15,7 @@ import {
     ToolCallDonePayload,
     ToolCallErrorPayload,
     ToolCallStartedPayload,
+    TurnEventPayload,
 } from '@sdk/types';
 import { ChatProgress } from '@sdk/types/entities/agents/manager';
 import { noop } from '@sdk/utils';
@@ -471,14 +472,14 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
         });
     }
 
-    function handleTurnStarted(_subject: string, data: any): void {
+    function handleTurnStarted(_subject: string, data: TurnEventPayload): void {
         usingTurnEvents = true;
         currentTurnId = data?.turn_id ?? null;
         currentActivityState = AgentActivityState.Loading;
         callbacks.onAgentActivityStateChange?.(AgentActivityState.Loading);
     }
 
-    function handleTurnEnded(_subject: string, data: any): void {
+    function handleTurnEnded(_subject: string, data: TurnEventPayload): void {
         const turnId: number | null = data?.turn_id ?? null;
         if (currentTurnId !== null && turnId !== null && turnId < currentTurnId) return;
         currentActivityState = AgentActivityState.Idle;

--- a/src/types/stream/stream.ts
+++ b/src/types/stream/stream.ts
@@ -42,6 +42,8 @@ export enum StreamEvents {
     ToolCallStarted = 'tool-call/started',
     ToolCallDone = 'tool-call/done',
     ToolCallError = 'tool-call/error',
+    TurnStarted = 'turn/started',
+    TurnEnded = 'turn/ended',
 }
 
 export enum ConnectionState {

--- a/src/types/stream/stream.ts
+++ b/src/types/stream/stream.ts
@@ -249,6 +249,10 @@ export interface ToolCallErrorPayload {
 
 export type ToolEventPayload = ToolCallStartedPayload | ToolCallDonePayload | ToolCallErrorPayload;
 
+export interface TurnEventPayload {
+    turn_id: number | null;
+}
+
 export type ToolEventCallback = {
     (event: StreamEvents.ToolCallStarted, data: ToolCallStartedPayload): void;
     (event: StreamEvents.ToolCallDone, data: ToolCallDonePayload): void;


### PR DESCRIPTION
### Pull Request Type

🔮 Feature

### Description
- Consume the new `turn/started` / `turn/ended` events and drive `AgentActivityState` from the **turn lifecycle** instead of inferring it per sequence: `turn/started` → `Loading`, `turn/ended` → the **sole** `Idle` terminal.
- A `usingTurnEvents` latch keeps servers that don't emit turn events on the exact legacy per-sequence behavior (fully backward compatible).
- Mid-turn `stream-video/*` and `tool-call/*` terminals now **stay busy** (`Talking` / `ToolActive`) instead of flicking to `Idle` — fixes the mid-turn idle flicker on multi-sequence (tool) turns.
- A stale `turn/ended` from a superseded turn is dropped (`turn_id < currentTurnId`); `turn_id` is mirrored from the server, never counted client-side, so it can't drift.
- Adds `StreamEvents.TurnStarted` / `TurnEnded` and 4 unit tests (Loading on start, Idle only on end, stay-ToolActive mid-turn, straggler drop).

Server contract: de-id/streaming-orchestrator-worker#583.

### Reference Links
-   [Asana]()
