### PR TITLE
refactor(livekit): drop usingTurnEvents latch, turn events drive activity state

### DIFF
--- a/src/services/streaming-manager/livekit-manager.test.ts
+++ b/src/services/streaming-manager/livekit-manager.test.ts
@@ -587,14 +587,11 @@ describe('LiveKit Streaming Manager - Microphone Stream', () => {
             };
         });
 
-        it.each([
-            [StreamEvents.StreamVideoCreated, AgentActivityState.Talking],
-            [StreamEvents.StreamVideoDone, AgentActivityState.Idle],
-        ])('should set activity state on %s event', (event, expectedState) => {
-            sendDataEvent(event);
+        it('should set Talking on stream-video/created event', () => {
+            sendDataEvent(StreamEvents.StreamVideoCreated);
 
             expect(mockOnAgentActivityStateChange).toHaveBeenCalledTimes(1);
-            expect(mockOnAgentActivityStateChange).toHaveBeenCalledWith(expectedState);
+            expect(mockOnAgentActivityStateChange).toHaveBeenCalledWith(AgentActivityState.Talking);
         });
 
         it('should set activity state to Loading on ChatAudioTranscribed event', async () => {
@@ -606,15 +603,6 @@ describe('LiveKit Streaming Manager - Microphone Stream', () => {
             expect(mockOnAgentActivityStateChange).toHaveBeenCalledWith(AgentActivityState.Loading);
         });
 
-        it('should transition from Talking to Idle when video ends', () => {
-            sendDataEvent(StreamEvents.StreamVideoCreated);
-            sendDataEvent(StreamEvents.StreamVideoDone);
-
-            expect(mockOnAgentActivityStateChange).toHaveBeenCalledTimes(2);
-            expect(mockOnAgentActivityStateChange).toHaveBeenNthCalledWith(1, AgentActivityState.Talking);
-            expect(mockOnAgentActivityStateChange).toHaveBeenNthCalledWith(2, AgentActivityState.Idle);
-        });
-
         it('should return to ToolActive when video ends while a tool call is pending', () => {
             sendDataEvent(StreamEvents.ToolCallStarted, { call_id: 'tc1', name: 'form' });
             sendDataEvent(StreamEvents.StreamVideoCreated);
@@ -623,22 +611,6 @@ describe('LiveKit Streaming Manager - Microphone Stream', () => {
             expect(mockOnAgentActivityStateChange).toHaveBeenNthCalledWith(1, AgentActivityState.ToolActive);
             expect(mockOnAgentActivityStateChange).toHaveBeenNthCalledWith(2, AgentActivityState.Talking);
             expect(mockOnAgentActivityStateChange).toHaveBeenNthCalledWith(3, AgentActivityState.ToolActive);
-        });
-
-        it('should set Idle when the last pending tool call resolves', () => {
-            sendDataEvent(StreamEvents.ToolCallStarted, { call_id: 'tc1', name: 'form' });
-            sendDataEvent(StreamEvents.ToolCallDone, { call_id: 'tc1', name: 'form' });
-
-            expect(mockOnAgentActivityStateChange).toHaveBeenLastCalledWith(AgentActivityState.Idle);
-        });
-
-        it('should set Idle when video ends after all tool calls resolved', () => {
-            sendDataEvent(StreamEvents.ToolCallStarted, { call_id: 'tc1', name: 'form' });
-            sendDataEvent(StreamEvents.ToolCallDone, { call_id: 'tc1', name: 'form' });
-            sendDataEvent(StreamEvents.StreamVideoCreated);
-            sendDataEvent(StreamEvents.StreamVideoDone);
-
-            expect(mockOnAgentActivityStateChange).toHaveBeenLastCalledWith(AgentActivityState.Idle);
         });
 
         it('should set Loading on turn/started', () => {
@@ -1503,7 +1475,7 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
     });
 
     describe('handleDataReceived - tool-call/done', () => {
-        it('should forward payload via onToolEvent and release the last pending tool to Idle', async () => {
+        it('should forward payload via onToolEvent without changing activity state', async () => {
             // ARRANGE:
             const onAgentActivityStateChange = jest.fn();
             const onToolEvent = jest.fn();
@@ -1543,7 +1515,7 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
             dataHandler(donePayload);
 
             // ASSERT:
-            expect(onAgentActivityStateChange).toHaveBeenCalledWith(AgentActivityState.Idle);
+            expect(onAgentActivityStateChange).not.toHaveBeenCalled();
             expect(onToolEvent).toHaveBeenCalledWith(
                 StreamEvents.ToolCallDone,
                 expect.objectContaining({
@@ -1556,7 +1528,7 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
     });
 
     describe('handleDataReceived - tool-call/error', () => {
-        it('should forward payload via onToolEvent and release the last pending tool to Idle', async () => {
+        it('should forward payload via onToolEvent without changing activity state', async () => {
             // ARRANGE:
             const onAgentActivityStateChange = jest.fn();
             const onToolEvent = jest.fn();
@@ -1595,7 +1567,7 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
             dataHandler(errorPayload);
 
             // ASSERT:
-            expect(onAgentActivityStateChange).toHaveBeenCalledWith(AgentActivityState.Idle);
+            expect(onAgentActivityStateChange).not.toHaveBeenCalled();
             expect(onToolEvent).toHaveBeenCalledWith(
                 StreamEvents.ToolCallError,
                 expect.objectContaining({
@@ -1713,7 +1685,7 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
     });
 
     describe('Chained tools', () => {
-        it('should stay ToolActive until all pending tool calls resolve', async () => {
+        it('should not emit Idle as chained tool calls resolve', async () => {
             // ARRANGE:
             const onAgentActivityStateChange = jest.fn();
             options.callbacks.onAgentActivityStateChange = onAgentActivityStateChange;
@@ -1732,22 +1704,19 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
                     timestamp: new Date().toISOString(),
                 });
 
-            // ACT: two parallel tool calls; the first resolves while the second is still pending
+            // ACT: two parallel tool calls resolve; idle is driven by turn/ended, not tool resolution
             dataHandler(toolEvent(StreamEvents.ToolCallStarted, 'call-1'));
             dataHandler(toolEvent(StreamEvents.ToolCallStarted, 'call-2'));
             dataHandler(toolEvent(StreamEvents.ToolCallDone, 'call-1'));
-
-            // ASSERT: still ToolActive — no Idle until the last tool resolves
-            expect(onAgentActivityStateChange).not.toHaveBeenCalledWith(AgentActivityState.Idle);
-
             dataHandler(toolEvent(StreamEvents.ToolCallDone, 'call-2'));
 
-            expect(onAgentActivityStateChange).toHaveBeenLastCalledWith(AgentActivityState.Idle);
+            // ASSERT: resolving tool calls never drives Idle
+            expect(onAgentActivityStateChange).not.toHaveBeenCalledWith(AgentActivityState.Idle);
         });
     });
 
     describe('No regression - sessions without tools', () => {
-        it('should handle stream-video/done without metadata (backwards compatible)', async () => {
+        it('should forward stream-video/done via onMessage without emitting Idle', async () => {
             // ARRANGE:
             const onAgentActivityStateChange = jest.fn();
             const onMessage = jest.fn();
@@ -1768,7 +1737,7 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
             dataHandler(payload);
 
             // ASSERT:
-            expect(onAgentActivityStateChange).toHaveBeenCalledWith(AgentActivityState.Idle);
+            expect(onAgentActivityStateChange).not.toHaveBeenCalledWith(AgentActivityState.Idle);
             expect(onMessage).toHaveBeenCalled();
         });
     });

--- a/src/services/streaming-manager/livekit-manager.ts
+++ b/src/services/streaming-manager/livekit-manager.ts
@@ -128,7 +128,6 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
     let currentInterruptible = true;
     const pendingToolCalls = new Set<string>();
     let currentTurnId: number | null = null;
-    let usingTurnEvents = false;
 
     const streamApi = createStreamApiV2(auth, baseURL || didApiUrl, agentId, callbacks.onError);
     let sessionId: string | undefined;
@@ -175,9 +174,6 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
     function handleTranscriptionReceived(_segments: TranscriptionSegment[], participant?: Participant): void {
         if (participant?.isLocal) {
             latencyTimestampTracker.update();
-            if (!usingTurnEvents && currentActivityState === AgentActivityState.Talking) {
-                currentActivityState = AgentActivityState.Idle;
-            }
         }
     }
     async function setUserContextAttributes(): Promise<void> {
@@ -415,10 +411,6 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
 
     function resolvePendingToolCall(callId: string): void {
         pendingToolCalls.delete(callId);
-        if (!usingTurnEvents && pendingToolCalls.size === 0 && currentActivityState === AgentActivityState.ToolActive) {
-            currentActivityState = AgentActivityState.Idle;
-            callbacks.onAgentActivityStateChange?.(AgentActivityState.Idle);
-        }
     }
 
     function handleVideoActivityState(subject: string, data: any): void {
@@ -441,11 +433,6 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
                 callbacks.onAgentActivityStateChange?.(AgentActivityState.ToolActive);
             }
             return;
-        }
-
-        if (!usingTurnEvents && currentInterruptible) {
-            currentActivityState = AgentActivityState.Idle;
-            callbacks.onAgentActivityStateChange?.(AgentActivityState.Idle);
         }
     }
 
@@ -473,7 +460,6 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
     }
 
     function handleTurnStarted(_subject: string, data: TurnEventPayload): void {
-        usingTurnEvents = true;
         currentTurnId = data?.turn_id ?? null;
         currentActivityState = AgentActivityState.Loading;
         callbacks.onAgentActivityStateChange?.(AgentActivityState.Loading);


### PR DESCRIPTION
### Type
Refactor / cleanup

### What
Removes the runtime `usingTurnEvents` latch from `livekit-manager`.

### Why
`livekit-manager` serves only expressive / V2 sessions (`factory.ts` routes `V2 + LiveKit` here), and turn events are now in prod (#444 merged). So the latch is effectively always `true`, and its `!usingTurnEvents` legacy idle transitions are dead code:
- local transcript → Idle
- tool-done → Idle
- video-done → Idle

Turn events are the sole activity-state drivers, unchanged: `turn/started` → Loading, `video/created` → Talking, `turn/ended` → Idle (stale-turn drop and mid-turn ToolActive handling untouched).

### Tests
Updated the activity-state tests to the turn-events contract — dropped the obsolete legacy-idle assertions (already covered by the `turn/*` tests) and fixed the tool/video handler tests to assert no premature idle. Full `streaming-manager` suite green (259), `tsc --noEmit` clean, prettier clean.

### Not in this PR
The `agents-ui` counterpart (gating the idle-suppression to non-expressive sessions) is a separate change in that repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
