### PR TITLE
bugfix(client-tools): throw RpcError so a handler's failure reason reaches the agent

### DIFF
--- a/src/services/agent-manager/index.test.ts
+++ b/src/services/agent-manager/index.test.ts
@@ -1,4 +1,5 @@
 import { MAX_CHAT_MESSAGE_LENGTH } from '@sdk/config/consts';
+import { RpcError } from 'livekit-client';
 import { createAgentsApi } from '../../api/agents';
 import {
     AgentFactory,
@@ -1071,6 +1072,45 @@ describe('createAgentManager', () => {
             expect(handler1).not.toHaveBeenCalled();
             expect(handler2).toHaveBeenCalledWith({ key: 'val' });
             expect(result).toBe('result2');
+        });
+
+        // LiveKit forwards a thrown RpcError verbatim but replaces anything else with
+        // APPLICATION_ERROR's fixed message, so a plain Error's reason never reaches the caller.
+        it('should throw an RpcError carrying the reason when a handler rejects', async () => {
+            const handler = jest.fn().mockRejectedValue(new Error('No form fields configured.'));
+
+            await manager.connect();
+            manager.registerClientTool('testTool', handler);
+            const rpcHandler = mockStreamingManager.registerRpcMethod.mock.calls[0][1];
+
+            await expect(rpcHandler({ payload: '{}' })).rejects.toMatchObject({
+                code: RpcError.ErrorCode.APPLICATION_ERROR,
+                message: 'Client tool "testTool" failed: No form fields configured.',
+            });
+            await expect(rpcHandler({ payload: '{}' })).rejects.toBeInstanceOf(RpcError);
+        });
+
+        it('should pass through an RpcError thrown by the handler, keeping its code and data', async () => {
+            const thrown = new RpcError(1600, 'declined', 'extra');
+            const handler = jest.fn().mockRejectedValue(thrown);
+
+            await manager.connect();
+            manager.registerClientTool('testTool', handler);
+            const rpcHandler = mockStreamingManager.registerRpcMethod.mock.calls[0][1];
+
+            await expect(rpcHandler({ payload: '{}' })).rejects.toBe(thrown);
+        });
+
+        it('should throw an RpcError when no handler is registered for the method', async () => {
+            await manager.connect();
+            manager.registerClientTool('testTool', jest.fn());
+            const rpcHandler = mockStreamingManager.registerRpcMethod.mock.calls[0][1];
+            manager.unregisterClientTool('testTool');
+
+            await expect(rpcHandler({ payload: '{}' })).rejects.toMatchObject({
+                code: RpcError.ErrorCode.APPLICATION_ERROR,
+                message: 'No handler registered for client tool: testTool',
+            });
         });
     });
 });

--- a/src/services/agent-manager/index.ts
+++ b/src/services/agent-manager/index.ts
@@ -21,6 +21,7 @@ import { getRandom } from '@sdk/utils';
 import { isStreamsV2Agent } from '@sdk/utils/agent';
 import { isChatModeWithoutChat, isTextualChat } from '@sdk/utils/chat';
 import { parseMessagePartsMemo } from '@sdk/utils/content-parser';
+import { RpcError } from 'livekit-client';
 import { createAgentsApi } from '../../api/agents';
 import { getAgentInfo, getAnalyticsInfo } from '../../utils/analytics';
 import { defer } from '../../utils/defer';
@@ -41,6 +42,16 @@ export interface AgentManagerItems {
     socketManager?: SocketManager;
     messages: Message[];
     chatMode: ChatMode;
+}
+
+/**
+ * LiveKit only forwards a thrown `RpcError` to the caller — it replaces anything else with
+ * `APPLICATION_ERROR`, whose message is a fixed constant, so a plain `Error`'s message never
+ * leaves the browser. Wrapping keeps the reason for the agent that invoked the tool.
+ * `RpcError` truncates the message at 256 bytes.
+ */
+function applicationError(message: string): RpcError {
+    return new RpcError(RpcError.ErrorCode.APPLICATION_ERROR, message);
 }
 
 /**
@@ -135,13 +146,17 @@ export async function createAgentManager(agent: string, options: AgentManagerOpt
         return async (data: { payload: string }): Promise<string> => {
             const handler = clientToolHandlers.get(toolName);
             if (!handler) {
-                throw new Error(`No handler registered for client tool: ${toolName}`);
+                throw applicationError(`No handler registered for client tool: ${toolName}`);
             }
             try {
                 const args = JSON.parse(data.payload);
                 return await handler(args);
             } catch (error) {
-                throw new Error(`Client tool "${toolName}" failed: ${(error as Error).message}`);
+                // A handler that threw an RpcError chose its own code/data — pass it through.
+                if (error instanceof RpcError) {
+                    throw error;
+                }
+                throw applicationError(`Client tool "${toolName}" failed: ${(error as Error).message}`);
             }
         };
     }


### PR DESCRIPTION
### Pull Request Type

🐛 BugFix

### Description

- LiveKit's `registerRpcMethod` only forwards a thrown `RpcError` to the caller. Anything else is logged locally and replaced with `RpcError.builtIn('APPLICATION_ERROR')`, whose message is the fixed constant `"Application error in method handler"`. Since `createRpcHandler` wrapped every failure in a plain `Error`, **the reason a client tool failed never left the browser** — every failure looked identical to the agent that invoked the tool.
- Handler failures are now wrapped in an `RpcError`, so the message survives the hop (`RpcError` truncates at 256 bytes; the `Client tool "<name>" failed: ` prefix leaves ~220 for the reason). Classification is unchanged — it was already becoming `APPLICATION_ERROR`, just without the text.
- A handler that throws an `RpcError` itself has chosen its own code and `data` (15 KB available), so it now passes through untouched instead of being flattened.
- This affects every client tool, not only D-ID widgets: a customer whose handler throws a descriptive error will now have the agent see it. It's what lets the orchestrator distinguish *why* a widget failed rather than only *that* it did — see de-id/streaming-orchestrator-worker#593, which currently has to supply its own narration because the reason is unavailable.

Verified: 106 tests pass in `src/services/agent-manager/`, `tsc --noEmit` clean, prettier clean. Three new tests cover the wrapped case, the pass-through case, and the missing-handler case.

### Reference Links
-   [Asana](https://app.asana.com/1/856614567666442/project/1216229456433893/task/1216381150955251?focus=true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fU8rY9oEy59VPY9fko1PD