### PR TITLE
bugfix(client-tools): drop the tool-name prefix from a client tool's error message

### DIFF
--- a/src/services/agent-manager/index.test.ts
+++ b/src/services/agent-manager/index.test.ts
@@ -1074,9 +1074,7 @@ describe('createAgentManager', () => {
             expect(result).toBe('result2');
         });
 
-        // LiveKit forwards a thrown RpcError verbatim but replaces anything else with
-        // APPLICATION_ERROR's fixed message, so a plain Error's reason never reaches the caller.
-        it('should throw an RpcError carrying the reason when a handler rejects', async () => {
+        it('should throw an RpcError carrying the handler reason verbatim', async () => {
             const handler = jest.fn().mockRejectedValue(new Error('No form fields configured.'));
 
             await manager.connect();
@@ -1085,9 +1083,22 @@ describe('createAgentManager', () => {
 
             await expect(rpcHandler({ payload: '{}' })).rejects.toMatchObject({
                 code: RpcError.ErrorCode.APPLICATION_ERROR,
-                message: 'Client tool "testTool" failed: No form fields configured.',
+                message: 'No form fields configured.',
             });
             await expect(rpcHandler({ payload: '{}' })).rejects.toBeInstanceOf(RpcError);
+        });
+
+        it('should fall back to a generic message when a handler throws a non-Error', async () => {
+            const handler = jest.fn().mockRejectedValue('boom');
+
+            await manager.connect();
+            manager.registerClientTool('testTool', handler);
+            const rpcHandler = mockStreamingManager.registerRpcMethod.mock.calls[0][1];
+
+            await expect(rpcHandler({ payload: '{}' })).rejects.toMatchObject({
+                code: RpcError.ErrorCode.APPLICATION_ERROR,
+                message: 'Client tool failed',
+            });
         });
 
         it('should pass through an RpcError thrown by the handler, keeping its code and data', async () => {

--- a/src/services/agent-manager/index.ts
+++ b/src/services/agent-manager/index.ts
@@ -156,7 +156,7 @@ export async function createAgentManager(agent: string, options: AgentManagerOpt
                 if (error instanceof RpcError) {
                     throw error;
                 }
-                throw applicationError(`Client tool "${toolName}" failed: ${(error as Error).message}`);
+                throw applicationError((error as Error)?.message || 'Client tool failed');
             }
         };
     }


### PR DESCRIPTION
### Pull Request Type

🐛 BugFix

### Description

- `createRpcHandler` wrapped every handler failure as `Client tool "<name>" failed: <message>`. The caller already knows which tool it invoked, and LiveKit's own client-side warning already names the method (`Uncaught error returned by RPC handler for <method>`), so the prefix told nobody anything — while consuming ~36 bytes of `RpcError`'s 256-byte message budget.
- The prefix made sense historically: before 2.0.4 the message was replaced by LiveKit with a fixed constant, so it only ever surfaced in a browser console, where a bare reason lacks context. Now that it reaches the caller, it's pure noise — a widget render failure arrived at the orchestrator as `Client tool "__did_widget__" failed: No form fields configured.`, leaking an internal RPC method name into an LLM's context.
- Falls back to a generic string when a non-`Error` is thrown; previously the prefix masked that as `... failed: undefined`.
- The tool name stays on the `No handler registered for client tool: <name>` error, where it is the content rather than context.

No documented contract change — the prefix was never part of the public API.

Verified: 107 tests pass in `src/services/agent-manager/`, `tsc --noEmit` clean, prettier clean.

### Reference Links
-   [Asana](https://app.asana.com/1/856614567666442/project/1216229456433893/task/1216381150955251?focus=true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fU8rY9oEy59VPY9fko1PD