### PR TITLE
feat: expose closed_captions_enabled on agent advanced settings

### DIFF
--- a/src/types/entities/agents/agent.ts
+++ b/src/types/entities/agents/agent.ts
@@ -25,7 +25,7 @@ export interface Agent {
     vision?: { enabled: boolean };
     end_of_call_feedback?: EndOfCallFeedbackConfig;
     triggers_available?: boolean;
-    advanced_settings?: { ui_debug_mode?: boolean; vm_account_id?: string };
+    advanced_settings?: { ui_debug_mode?: boolean; vm_account_id?: string; closed_captions_enabled?: boolean };
 }
 
 export interface AgentsAPI {


### PR DESCRIPTION
### Pull Request Type

🔮 Feature

### Description

-   Types `closed_captions_enabled` on `Agent.advanced_settings`, matching the backend's runtime agent projection (`GET /agents/:id/runtime`) — see de-id/serverless#7494.
-   Lets the agent UI read the per-agent closed-captions gate directly instead of casting `advanced_settings`. Type-only change; no runtime behavior is affected.

### Reference Links

-   [Asana](https://app.asana.com/1/856614567666442/project/1216943078884032/task/1217028135635195?focus=true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
