### PR TITLE
feat: expose closed_captions_enabled on agent advanced settings (#454)

### DIFF
--- a/src/types/entities/agents/agent.ts
+++ b/src/types/entities/agents/agent.ts
@@ -25,7 +25,7 @@ export interface Agent {
     vision?: { enabled: boolean };
     end_of_call_feedback?: EndOfCallFeedbackConfig;
     triggers_available?: boolean;
-    advanced_settings?: { ui_debug_mode?: boolean; vm_account_id?: string };
+    advanced_settings?: { ui_debug_mode?: boolean; vm_account_id?: string; closed_captions_enabled?: boolean };
 }
 
 export interface AgentsAPI {


### PR DESCRIPTION
The agent UI gates its closed-captions overlay on a per-agent setting. The backend returns it inside advanced_settings on the runtime agent projection, so type it here to let consumers read it without casting.
