### PR TITLE
fix(tools): derive interruptibility from all pending calls

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,4 +2,5 @@ export * from './errors';
 export * from './services/agent-manager';
 export * from './types';
 export { parseMessageParts } from './utils/content-parser';
+export { isAwaitingTool } from './utils/tool-calls';
 export { SDK_VERSION } from './version';

--- a/src/services/streaming-manager/livekit-manager.test.ts
+++ b/src/services/streaming-manager/livekit-manager.test.ts
@@ -1527,8 +1527,14 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
                 })
             );
 
-        // The manager starts interruptible and only calls back on a change, so with no calls
-        // yet the observed state is the initial true.
+        const emitStreamVideoCreated = (metadata?: { interruptible: boolean }) =>
+            dataHandler(
+                createDataChannelPayload({
+                    subject: StreamEvents.StreamVideoCreated,
+                    metadata,
+                })
+            );
+
         const emitStreamVideoDone = (metadata?: { interruptible: boolean }) =>
             dataHandler(
                 createDataChannelPayload({
@@ -1537,6 +1543,8 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
                 })
             );
 
+        // The manager starts interruptible and only calls back on a change, so with no calls
+        // yet the observed state is the initial true.
         const lastInterruptible = () =>
             onInterruptibleChange.mock.calls.length > 0
                 ? onInterruptibleChange.mock.calls[onInterruptibleChange.mock.calls.length - 1][0]
@@ -1580,18 +1588,37 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
             expect(lastInterruptible()).toBe(false);
         });
 
-        it('becomes non-interruptible when a video activity event carries interruptible: false', () => {
-            emitStreamVideoDone({ interruptible: false });
+        it('becomes non-interruptible while a speech marked interruptible: false is playing', () => {
+            emitStreamVideoCreated({ interruptible: false });
 
             expect(lastInterruptible()).toBe(false);
         });
 
-        it('becomes interruptible again once the speech and every pending call allow it', () => {
+        it('is interruptible while only an async call is pending after a non-interruptible speech', () => {
+            emitStreamVideoCreated({ interruptible: false });
             emitStreamVideoDone({ interruptible: false });
             emitToolStarted({ call_id: 'a', interruptible: true });
-            emitStreamVideoDone({ interruptible: true });
 
             expect(lastInterruptible()).toBe(true);
+        });
+
+        it('becomes interruptible again once the speech and every pending call allow it', () => {
+            emitStreamVideoCreated({ interruptible: false });
+            expect(lastInterruptible()).toBe(false);
+
+            emitToolStarted({ call_id: 'a', interruptible: true });
+            expect(lastInterruptible()).toBe(false);
+
+            emitStreamVideoDone({ interruptible: false });
+            expect(lastInterruptible()).toBe(true);
+        });
+
+        it('stays non-interruptible after the speech ends while a blocking call is pending', () => {
+            emitStreamVideoCreated({ interruptible: false });
+            emitToolStarted({ call_id: 'a', interruptible: false });
+            emitStreamVideoDone({ interruptible: false });
+
+            expect(lastInterruptible()).toBe(false);
         });
     });
 

--- a/src/services/streaming-manager/livekit-manager.test.ts
+++ b/src/services/streaming-manager/livekit-manager.test.ts
@@ -1579,16 +1579,20 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
         });
     });
 
-    describe('handleDataReceived - blocking-mode tool calls', () => {
-        let onBlockingToolPendingChange: jest.Mock;
+    describe('handleDataReceived - running tool calls', () => {
+        let onRunningToolCallsChange: jest.Mock;
+        let onInterruptibleChange: jest.Mock;
+        let manager: Awaited<ReturnType<typeof createLiveKitStreamingManager>>;
         let dataHandler: any;
 
         const emitToolStarted = ({
             call_id,
+            name = 'tool',
             interruptible,
             execution_mode,
         }: {
             call_id: string;
+            name?: string;
             interruptible: boolean;
             execution_mode?: string;
         }) =>
@@ -1596,7 +1600,7 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
                 createDataChannelPayload({
                     subject: StreamEvents.ToolCallStarted,
                     call_id,
-                    name: 'tool',
+                    name,
                     input: {},
                     output: {},
                     interruptible,
@@ -1619,59 +1623,77 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
                 })
             );
 
-        const lastBlockingToolPending = () =>
-            onBlockingToolPendingChange.mock.calls.length > 0
-                ? onBlockingToolPendingChange.mock.calls[onBlockingToolPendingChange.mock.calls.length - 1][0]
-                : false;
+        const lastRunningToolCalls = () =>
+            onRunningToolCallsChange.mock.calls.length > 0
+                ? onRunningToolCallsChange.mock.calls[onRunningToolCallsChange.mock.calls.length - 1][0]
+                : [];
 
         beforeEach(async () => {
-            onBlockingToolPendingChange = jest.fn();
-            options.callbacks.onBlockingToolPendingChange = onBlockingToolPendingChange;
+            onRunningToolCallsChange = jest.fn();
+            onInterruptibleChange = jest.fn();
+            options.callbacks.onRunningToolCallsChange = onRunningToolCallsChange;
+            options.callbacks.onInterruptibleChange = onInterruptibleChange;
 
-            await createLiveKitStreamingManager(agentId, sessionOptions, options);
+            manager = await createLiveKitStreamingManager(agentId, sessionOptions, options);
             await simulateConnection();
             dataHandler = getDataReceivedHandler();
         });
 
-        it('emits true while a blocking-mode call is pending and false once it resolves', () => {
-            emitToolStarted({ call_id: 'a', interruptible: false, execution_mode: 'blocking' });
-            expect(lastBlockingToolPending()).toBe(true);
+        it('emits the running call while it is pending and an empty array once it resolves', () => {
+            emitToolStarted({ call_id: 'a', name: 'get_weather', interruptible: false, execution_mode: 'blocking' });
+            expect(lastRunningToolCalls()).toEqual([{ callId: 'a', name: 'get_weather', executionMode: 'blocking' }]);
 
             emitToolDone({ call_id: 'a' });
-            expect(lastBlockingToolPending()).toBe(false);
+            expect(lastRunningToolCalls()).toEqual([]);
         });
 
-        it('never fires for an async-mode call', () => {
+        it('reports an async-mode call as async', () => {
             emitToolStarted({ call_id: 'a', interruptible: true, execution_mode: 'async' });
 
-            expect(onBlockingToolPendingChange).not.toHaveBeenCalled();
+            expect(lastRunningToolCalls()).toEqual([{ callId: 'a', name: 'tool', executionMode: 'async' }]);
         });
 
         it('treats a missing execution_mode as blocking', () => {
             emitToolStarted({ call_id: 'a', interruptible: false });
 
-            expect(lastBlockingToolPending()).toBe(true);
+            expect(lastRunningToolCalls()).toEqual([{ callId: 'a', name: 'tool', executionMode: 'blocking' }]);
         });
 
-        it('stays true while any blocking call is pending and drops only when the last one resolves', () => {
+        it('keeps reporting the calls still running and drops only the ones that resolved', () => {
             emitToolStarted({ call_id: 'a', interruptible: true, execution_mode: 'async' });
             emitToolStarted({ call_id: 'b', interruptible: false, execution_mode: 'blocking' });
             emitToolStarted({ call_id: 'c', interruptible: false, execution_mode: 'blocking' });
-            expect(lastBlockingToolPending()).toBe(true);
+            expect(lastRunningToolCalls().map((call: { callId: string }) => call.callId)).toEqual(['a', 'b', 'c']);
 
             emitToolDone({ call_id: 'b' });
-            expect(lastBlockingToolPending()).toBe(true);
+            expect(lastRunningToolCalls().map((call: { callId: string }) => call.callId)).toEqual(['a', 'c']);
 
             emitToolDone({ call_id: 'c' });
-            expect(lastBlockingToolPending()).toBe(false);
+            expect(lastRunningToolCalls().map((call: { callId: string }) => call.callId)).toEqual(['a']);
         });
 
-        it('fires only on an actual change, not once per event', () => {
+        it('fires once per start, not only when the blocking aggregate flips', () => {
             emitToolStarted({ call_id: 'a', interruptible: false, execution_mode: 'blocking' });
             emitToolStarted({ call_id: 'b', interruptible: false, execution_mode: 'blocking' });
 
-            expect(onBlockingToolPendingChange).toHaveBeenCalledTimes(1);
-            expect(onBlockingToolPendingChange).toHaveBeenCalledWith(true);
+            expect(onRunningToolCallsChange).toHaveBeenCalledTimes(2);
+        });
+
+        it('does not leak the internal interruptible flag into the emitted calls', () => {
+            emitToolStarted({ call_id: 'a', interruptible: false, execution_mode: 'blocking' });
+
+            expect(Object.keys(lastRunningToolCalls()[0])).toEqual(['callId', 'name', 'executionMode']);
+        });
+
+        it('emits an empty array and restores interruptible on disconnect', async () => {
+            emitToolStarted({ call_id: 'a', interruptible: false, execution_mode: 'blocking' });
+            expect(onInterruptibleChange).toHaveBeenLastCalledWith(false);
+            onRunningToolCallsChange.mockClear();
+
+            await manager.disconnect();
+
+            expect(onRunningToolCallsChange).toHaveBeenCalledWith([]);
+            expect(onInterruptibleChange).toHaveBeenLastCalledWith(true);
         });
     });
 

--- a/src/services/streaming-manager/livekit-manager.test.ts
+++ b/src/services/streaming-manager/livekit-manager.test.ts
@@ -1527,14 +1527,6 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
                 })
             );
 
-        const emitStreamVideoCreated = (metadata?: { interruptible: boolean }) =>
-            dataHandler(
-                createDataChannelPayload({
-                    subject: StreamEvents.StreamVideoCreated,
-                    metadata,
-                })
-            );
-
         const emitStreamVideoDone = (metadata?: { interruptible: boolean }) =>
             dataHandler(
                 createDataChannelPayload({
@@ -1585,44 +1577,10 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
 
             expect(lastInterruptible()).toBe(false);
         });
-
-        it('becomes non-interruptible while a speech marked interruptible: false is playing', () => {
-            emitStreamVideoCreated({ interruptible: false });
-
-            expect(lastInterruptible()).toBe(false);
-        });
-
-        it('is interruptible while only an async call is pending after a non-interruptible speech', () => {
-            emitStreamVideoCreated({ interruptible: false });
-            emitStreamVideoDone({ interruptible: false });
-            emitToolStarted({ call_id: 'a', interruptible: true });
-
-            expect(lastInterruptible()).toBe(true);
-        });
-
-        it('becomes interruptible again once the speech and every pending call allow it', () => {
-            emitStreamVideoCreated({ interruptible: false });
-            expect(lastInterruptible()).toBe(false);
-
-            emitToolStarted({ call_id: 'a', interruptible: true });
-            expect(lastInterruptible()).toBe(false);
-
-            emitStreamVideoDone({ interruptible: false });
-            expect(lastInterruptible()).toBe(true);
-        });
-
-        it('stays non-interruptible after the speech ends while a blocking call is pending', () => {
-            emitStreamVideoCreated({ interruptible: false });
-            emitToolStarted({ call_id: 'a', interruptible: false });
-            emitStreamVideoDone({ interruptible: false });
-
-            expect(lastInterruptible()).toBe(false);
-        });
     });
 
     describe('handleDataReceived - blocking-mode tool calls', () => {
         let onBlockingToolPendingChange: jest.Mock;
-        let onInterruptibleChange: jest.Mock;
         let dataHandler: any;
 
         const emitToolStarted = ({
@@ -1661,14 +1619,6 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
                 })
             );
 
-        const emitStreamVideoCreated = (metadata?: { interruptible: boolean }) =>
-            dataHandler(
-                createDataChannelPayload({
-                    subject: StreamEvents.StreamVideoCreated,
-                    metadata,
-                })
-            );
-
         const lastBlockingToolPending = () =>
             onBlockingToolPendingChange.mock.calls.length > 0
                 ? onBlockingToolPendingChange.mock.calls[onBlockingToolPendingChange.mock.calls.length - 1][0]
@@ -1676,9 +1626,7 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
 
         beforeEach(async () => {
             onBlockingToolPendingChange = jest.fn();
-            onInterruptibleChange = jest.fn();
             options.callbacks.onBlockingToolPendingChange = onBlockingToolPendingChange;
-            options.callbacks.onInterruptibleChange = onInterruptibleChange;
 
             await createLiveKitStreamingManager(agentId, sessionOptions, options);
             await simulateConnection();
@@ -1724,20 +1672,6 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
 
             expect(onBlockingToolPendingChange).toHaveBeenCalledTimes(1);
             expect(onBlockingToolPendingChange).toHaveBeenCalledWith(true);
-        });
-
-        it('ignores speech interruptibility', () => {
-            emitStreamVideoCreated({ interruptible: false });
-
-            expect(onInterruptibleChange).toHaveBeenCalledWith(false);
-            expect(onBlockingToolPendingChange).not.toHaveBeenCalled();
-        });
-
-        it('reports an async call as not blocking even while the speech is non-interruptible', () => {
-            emitStreamVideoCreated({ interruptible: false });
-            emitToolStarted({ call_id: 'a', interruptible: true, execution_mode: 'async' });
-
-            expect(lastBlockingToolPending()).toBe(false);
         });
     });
 

--- a/src/services/streaming-manager/livekit-manager.test.ts
+++ b/src/services/streaming-manager/livekit-manager.test.ts
@@ -1449,7 +1449,7 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
             // ACT:
             dataHandler(payload);
 
-            // ASSERT: the manager starts interruptible, so this is not a change
+            // ASSERT:
             expect(onInterruptibleChange).not.toHaveBeenCalled();
         });
 
@@ -1491,7 +1491,7 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
                 })
             );
 
-            // ASSERT: the pending map is now empty, which is interruptible
+            // ASSERT:
             expect(onInterruptibleChange).toHaveBeenCalledWith(true);
         });
     });
@@ -1543,8 +1543,6 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
                 })
             );
 
-        // The manager starts interruptible and only calls back on a change, so with no calls
-        // yet the observed state is the initial true.
         const lastInterruptible = () =>
             onInterruptibleChange.mock.calls.length > 0
                 ? onInterruptibleChange.mock.calls[onInterruptibleChange.mock.calls.length - 1][0]
@@ -1671,7 +1669,6 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
                 })
             );
 
-        // Nothing is pending at start, so with no callback yet the observed state is the initial false.
         const lastBlockingToolPending = () =>
             onBlockingToolPendingChange.mock.calls.length > 0
                 ? onBlockingToolPendingChange.mock.calls[onBlockingToolPendingChange.mock.calls.length - 1][0]
@@ -1729,7 +1726,6 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
             expect(onBlockingToolPendingChange).toHaveBeenCalledWith(true);
         });
 
-        // The whole point of the split: a non-interruptible speech is not a blocking tool.
         it('ignores speech interruptibility', () => {
             emitStreamVideoCreated({ interruptible: false });
 

--- a/src/services/streaming-manager/livekit-manager.test.ts
+++ b/src/services/streaming-manager/livekit-manager.test.ts
@@ -1622,6 +1622,129 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
         });
     });
 
+    describe('handleDataReceived - blocking-mode tool calls', () => {
+        let onBlockingToolPendingChange: jest.Mock;
+        let onInterruptibleChange: jest.Mock;
+        let dataHandler: any;
+
+        const emitToolStarted = ({
+            call_id,
+            interruptible,
+            execution_mode,
+        }: {
+            call_id: string;
+            interruptible: boolean;
+            execution_mode?: string;
+        }) =>
+            dataHandler(
+                createDataChannelPayload({
+                    subject: StreamEvents.ToolCallStarted,
+                    call_id,
+                    name: 'tool',
+                    input: {},
+                    output: {},
+                    interruptible,
+                    ...(execution_mode ? { execution_mode } : {}),
+                    timestamp: new Date().toISOString(),
+                })
+            );
+
+        const emitToolDone = ({ call_id }: { call_id: string }) =>
+            dataHandler(
+                createDataChannelPayload({
+                    subject: StreamEvents.ToolCallDone,
+                    call_id,
+                    name: 'tool',
+                    input: {},
+                    output: {},
+                    duration_ms: 50,
+                    extra: {},
+                    timestamp: new Date().toISOString(),
+                })
+            );
+
+        const emitStreamVideoCreated = (metadata?: { interruptible: boolean }) =>
+            dataHandler(
+                createDataChannelPayload({
+                    subject: StreamEvents.StreamVideoCreated,
+                    metadata,
+                })
+            );
+
+        // Nothing is pending at start, so with no callback yet the observed state is the initial false.
+        const lastBlockingToolPending = () =>
+            onBlockingToolPendingChange.mock.calls.length > 0
+                ? onBlockingToolPendingChange.mock.calls[onBlockingToolPendingChange.mock.calls.length - 1][0]
+                : false;
+
+        beforeEach(async () => {
+            onBlockingToolPendingChange = jest.fn();
+            onInterruptibleChange = jest.fn();
+            options.callbacks.onBlockingToolPendingChange = onBlockingToolPendingChange;
+            options.callbacks.onInterruptibleChange = onInterruptibleChange;
+
+            await createLiveKitStreamingManager(agentId, sessionOptions, options);
+            await simulateConnection();
+            dataHandler = getDataReceivedHandler();
+        });
+
+        it('emits true while a blocking-mode call is pending and false once it resolves', () => {
+            emitToolStarted({ call_id: 'a', interruptible: false, execution_mode: 'blocking' });
+            expect(lastBlockingToolPending()).toBe(true);
+
+            emitToolDone({ call_id: 'a' });
+            expect(lastBlockingToolPending()).toBe(false);
+        });
+
+        it('never fires for an async-mode call', () => {
+            emitToolStarted({ call_id: 'a', interruptible: true, execution_mode: 'async' });
+
+            expect(onBlockingToolPendingChange).not.toHaveBeenCalled();
+        });
+
+        it('treats a missing execution_mode as blocking', () => {
+            emitToolStarted({ call_id: 'a', interruptible: false });
+
+            expect(lastBlockingToolPending()).toBe(true);
+        });
+
+        it('stays true while any blocking call is pending and drops only when the last one resolves', () => {
+            emitToolStarted({ call_id: 'a', interruptible: true, execution_mode: 'async' });
+            emitToolStarted({ call_id: 'b', interruptible: false, execution_mode: 'blocking' });
+            emitToolStarted({ call_id: 'c', interruptible: false, execution_mode: 'blocking' });
+            expect(lastBlockingToolPending()).toBe(true);
+
+            emitToolDone({ call_id: 'b' });
+            expect(lastBlockingToolPending()).toBe(true);
+
+            emitToolDone({ call_id: 'c' });
+            expect(lastBlockingToolPending()).toBe(false);
+        });
+
+        it('fires only on an actual change, not once per event', () => {
+            emitToolStarted({ call_id: 'a', interruptible: false, execution_mode: 'blocking' });
+            emitToolStarted({ call_id: 'b', interruptible: false, execution_mode: 'blocking' });
+
+            expect(onBlockingToolPendingChange).toHaveBeenCalledTimes(1);
+            expect(onBlockingToolPendingChange).toHaveBeenCalledWith(true);
+        });
+
+        // The whole point of the split: a non-interruptible speech is not a blocking tool.
+        it('ignores speech interruptibility', () => {
+            emitStreamVideoCreated({ interruptible: false });
+
+            expect(onInterruptibleChange).toHaveBeenCalledWith(false);
+            expect(onBlockingToolPendingChange).not.toHaveBeenCalled();
+        });
+
+        it('reports an async call as not blocking even while the speech is non-interruptible', () => {
+            emitStreamVideoCreated({ interruptible: false });
+            emitToolStarted({ call_id: 'a', interruptible: true, execution_mode: 'async' });
+
+            expect(lastBlockingToolPending()).toBe(false);
+        });
+    });
+
     describe('handleDataReceived - tool-call/done', () => {
         it('should forward payload via onToolEvent without changing activity state', async () => {
             // ARRANGE:

--- a/src/services/streaming-manager/livekit-manager.test.ts
+++ b/src/services/streaming-manager/livekit-manager.test.ts
@@ -1427,7 +1427,7 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
             expect(onInterruptibleChange).toHaveBeenCalledWith(false);
         });
 
-        it('should emit onInterruptibleChange(true) when tool-call/started carries interruptible: true', async () => {
+        it('should not emit onInterruptibleChange when an interruptible tool-call/started leaves the aggregate unchanged', async () => {
             // ARRANGE:
             const onInterruptibleChange = jest.fn();
             options.callbacks.onInterruptibleChange = onInterruptibleChange;
@@ -1449,11 +1449,11 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
             // ACT:
             dataHandler(payload);
 
-            // ASSERT:
-            expect(onInterruptibleChange).toHaveBeenCalledWith(true);
+            // ASSERT: the manager starts interruptible, so this is not a change
+            expect(onInterruptibleChange).not.toHaveBeenCalled();
         });
 
-        it('should not emit onInterruptibleChange on tool-call/done', async () => {
+        it('should emit onInterruptibleChange(true) on tool-call/done when the last blocking call resolves', async () => {
             // ARRANGE:
             const onInterruptibleChange = jest.fn();
             options.callbacks.onInterruptibleChange = onInterruptibleChange;
@@ -1491,8 +1491,8 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
                 })
             );
 
-            // ASSERT:
-            expect(onInterruptibleChange).not.toHaveBeenCalled();
+            // ASSERT: the pending map is now empty, which is interruptible
+            expect(onInterruptibleChange).toHaveBeenCalledWith(true);
         });
     });
 
@@ -1529,6 +1529,14 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
 
         // The manager starts interruptible and only calls back on a change, so with no calls
         // yet the observed state is the initial true.
+        const emitStreamVideoDone = (metadata?: { interruptible: boolean }) =>
+            dataHandler(
+                createDataChannelPayload({
+                    subject: StreamEvents.StreamVideoDone,
+                    metadata,
+                })
+            );
+
         const lastInterruptible = () =>
             onInterruptibleChange.mock.calls.length > 0
                 ? onInterruptibleChange.mock.calls[onInterruptibleChange.mock.calls.length - 1][0]
@@ -1563,6 +1571,27 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
             expect(lastInterruptible()).toBe(true);
             emitToolStarted({ call_id: 'b', interruptible: false });
             expect(lastInterruptible()).toBe(false);
+        });
+
+        it('stays non-interruptible when a video activity event arrives while a blocking call is pending', () => {
+            emitToolStarted({ call_id: 'a', interruptible: false });
+            emitStreamVideoDone();
+
+            expect(lastInterruptible()).toBe(false);
+        });
+
+        it('becomes non-interruptible when a video activity event carries interruptible: false', () => {
+            emitStreamVideoDone({ interruptible: false });
+
+            expect(lastInterruptible()).toBe(false);
+        });
+
+        it('becomes interruptible again once the speech and every pending call allow it', () => {
+            emitStreamVideoDone({ interruptible: false });
+            emitToolStarted({ call_id: 'a', interruptible: true });
+            emitStreamVideoDone({ interruptible: true });
+
+            expect(lastInterruptible()).toBe(true);
         });
     });
 

--- a/src/services/streaming-manager/livekit-manager.test.ts
+++ b/src/services/streaming-manager/livekit-manager.test.ts
@@ -1496,92 +1496,9 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
         });
     });
 
-    describe('handleDataReceived - interruptible across parallel tool calls', () => {
+    describe('handleDataReceived - pending tool calls', () => {
         let onInterruptibleChange: jest.Mock;
-        let dataHandler: any;
-
-        const emitToolStarted = ({ call_id, interruptible }: { call_id: string; interruptible: boolean }) =>
-            dataHandler(
-                createDataChannelPayload({
-                    subject: StreamEvents.ToolCallStarted,
-                    call_id,
-                    name: 'tool',
-                    input: {},
-                    output: {},
-                    interruptible,
-                    timestamp: new Date().toISOString(),
-                })
-            );
-
-        const emitToolDone = ({ call_id }: { call_id: string }) =>
-            dataHandler(
-                createDataChannelPayload({
-                    subject: StreamEvents.ToolCallDone,
-                    call_id,
-                    name: 'tool',
-                    input: {},
-                    output: {},
-                    duration_ms: 50,
-                    extra: {},
-                    timestamp: new Date().toISOString(),
-                })
-            );
-
-        const emitStreamVideoDone = (metadata?: { interruptible: boolean }) =>
-            dataHandler(
-                createDataChannelPayload({
-                    subject: StreamEvents.StreamVideoDone,
-                    metadata,
-                })
-            );
-
-        const lastInterruptible = () =>
-            onInterruptibleChange.mock.calls.length > 0
-                ? onInterruptibleChange.mock.calls[onInterruptibleChange.mock.calls.length - 1][0]
-                : true;
-
-        beforeEach(async () => {
-            onInterruptibleChange = jest.fn();
-            options.callbacks.onInterruptibleChange = onInterruptibleChange;
-
-            await createLiveKitStreamingManager(agentId, sessionOptions, options);
-            await simulateConnection();
-            dataHandler = getDataReceivedHandler();
-        });
-
-        it('stays non-interruptible while any blocking call is pending', () => {
-            emitToolStarted({ call_id: 'a', interruptible: true });
-            emitToolStarted({ call_id: 'b', interruptible: false });
-
-            expect(lastInterruptible()).toBe(false);
-        });
-
-        it('becomes interruptible once the blocking call resolves', () => {
-            emitToolStarted({ call_id: 'a', interruptible: true });
-            emitToolStarted({ call_id: 'b', interruptible: false });
-            emitToolDone({ call_id: 'b' });
-
-            expect(lastInterruptible()).toBe(true);
-        });
-
-        it('does not regress interruptibility when a blocking call starts after an async one', () => {
-            emitToolStarted({ call_id: 'a', interruptible: true });
-            expect(lastInterruptible()).toBe(true);
-            emitToolStarted({ call_id: 'b', interruptible: false });
-            expect(lastInterruptible()).toBe(false);
-        });
-
-        it('stays non-interruptible when a video activity event arrives while a blocking call is pending', () => {
-            emitToolStarted({ call_id: 'a', interruptible: false });
-            emitStreamVideoDone();
-
-            expect(lastInterruptible()).toBe(false);
-        });
-    });
-
-    describe('handleDataReceived - running tool calls', () => {
         let onRunningToolCallsChange: jest.Mock;
-        let onInterruptibleChange: jest.Mock;
         let manager: Awaited<ReturnType<typeof createLiveKitStreamingManager>>;
         let dataHandler: any;
 
@@ -1590,11 +1507,13 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
             name = 'tool',
             interruptible,
             execution_mode,
+            turn_id,
         }: {
             call_id: string;
             name?: string;
             interruptible: boolean;
             execution_mode?: string;
+            turn_id?: number;
         }) =>
             dataHandler(
                 createDataChannelPayload({
@@ -1605,6 +1524,7 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
                     output: {},
                     interruptible,
                     ...(execution_mode ? { execution_mode } : {}),
+                    ...(turn_id !== undefined ? { turn_id } : {}),
                     timestamp: new Date().toISOString(),
                 })
             );
@@ -1623,77 +1543,205 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
                 })
             );
 
+        const emitStreamVideoDone = () =>
+            dataHandler(createDataChannelPayload({ subject: StreamEvents.StreamVideoDone }));
+
+        const emitTurnStarted = (turn_id: number) =>
+            dataHandler(createDataChannelPayload({ subject: StreamEvents.TurnStarted, turn_id }));
+
+        const emitTurnEnded = (turn_id: number) =>
+            dataHandler(createDataChannelPayload({ subject: StreamEvents.TurnEnded, turn_id }));
+
+        const lastInterruptible = () =>
+            onInterruptibleChange.mock.calls.length > 0
+                ? onInterruptibleChange.mock.calls[onInterruptibleChange.mock.calls.length - 1][0]
+                : true;
+
         const lastRunningToolCalls = () =>
             onRunningToolCallsChange.mock.calls.length > 0
                 ? onRunningToolCallsChange.mock.calls[onRunningToolCallsChange.mock.calls.length - 1][0]
                 : [];
 
         beforeEach(async () => {
-            onRunningToolCallsChange = jest.fn();
             onInterruptibleChange = jest.fn();
-            options.callbacks.onRunningToolCallsChange = onRunningToolCallsChange;
+            onRunningToolCallsChange = jest.fn();
             options.callbacks.onInterruptibleChange = onInterruptibleChange;
+            options.callbacks.onRunningToolCallsChange = onRunningToolCallsChange;
 
             manager = await createLiveKitStreamingManager(agentId, sessionOptions, options);
             await simulateConnection();
             dataHandler = getDataReceivedHandler();
         });
 
-        it('emits the running call while it is pending and an empty array once it resolves', () => {
-            emitToolStarted({ call_id: 'a', name: 'get_weather', interruptible: false, execution_mode: 'blocking' });
-            expect(lastRunningToolCalls()).toEqual([{ callId: 'a', name: 'get_weather', executionMode: 'blocking' }]);
+        describe('interruptible across parallel tool calls', () => {
+            it('stays non-interruptible while any blocking call is pending', () => {
+                emitToolStarted({ call_id: 'a', interruptible: true });
+                emitToolStarted({ call_id: 'b', interruptible: false });
 
-            emitToolDone({ call_id: 'a' });
-            expect(lastRunningToolCalls()).toEqual([]);
+                expect(lastInterruptible()).toBe(false);
+            });
+
+            it('becomes interruptible once the blocking call resolves', () => {
+                emitToolStarted({ call_id: 'a', interruptible: true });
+                emitToolStarted({ call_id: 'b', interruptible: false });
+                emitToolDone({ call_id: 'b' });
+
+                expect(lastInterruptible()).toBe(true);
+            });
+
+            it('does not regress interruptibility when a blocking call starts after an async one', () => {
+                emitToolStarted({ call_id: 'a', interruptible: true });
+                expect(lastInterruptible()).toBe(true);
+                emitToolStarted({ call_id: 'b', interruptible: false });
+                expect(lastInterruptible()).toBe(false);
+            });
+
+            it('stays non-interruptible when an async call starts after a blocking one', () => {
+                emitToolStarted({ call_id: 'a', interruptible: false });
+                emitToolStarted({ call_id: 'b', interruptible: true });
+
+                expect(lastInterruptible()).toBe(false);
+            });
+
+            it('stays non-interruptible when a video activity event arrives while a blocking call is pending', () => {
+                emitToolStarted({ call_id: 'a', interruptible: false });
+                emitStreamVideoDone();
+
+                expect(lastInterruptible()).toBe(false);
+            });
         });
 
-        it('reports an async-mode call as async', () => {
-            emitToolStarted({ call_id: 'a', interruptible: true, execution_mode: 'async' });
+        describe('running tool calls', () => {
+            it('emits the running call while it is pending and an empty array once it resolves', () => {
+                emitToolStarted({
+                    call_id: 'a',
+                    name: 'get_weather',
+                    interruptible: false,
+                    execution_mode: 'blocking',
+                });
+                expect(lastRunningToolCalls()).toEqual([
+                    { callId: 'a', name: 'get_weather', executionMode: 'blocking' },
+                ]);
 
-            expect(lastRunningToolCalls()).toEqual([{ callId: 'a', name: 'tool', executionMode: 'async' }]);
+                emitToolDone({ call_id: 'a' });
+                expect(lastRunningToolCalls()).toEqual([]);
+            });
+
+            it('reports an async-mode call as async', () => {
+                emitToolStarted({ call_id: 'a', interruptible: true, execution_mode: 'async' });
+
+                expect(lastRunningToolCalls()).toEqual([{ callId: 'a', name: 'tool', executionMode: 'async' }]);
+            });
+
+            it('treats a missing execution_mode as blocking', () => {
+                emitToolStarted({ call_id: 'a', interruptible: false });
+
+                expect(lastRunningToolCalls()).toEqual([{ callId: 'a', name: 'tool', executionMode: 'blocking' }]);
+            });
+
+            it('keeps reporting the calls still running and drops only the ones that resolved', () => {
+                emitToolStarted({ call_id: 'a', interruptible: true, execution_mode: 'async' });
+                emitToolStarted({ call_id: 'b', interruptible: false, execution_mode: 'blocking' });
+                emitToolStarted({ call_id: 'c', interruptible: false, execution_mode: 'blocking' });
+                expect(lastRunningToolCalls().map((call: { callId: string }) => call.callId)).toEqual(['a', 'b', 'c']);
+
+                emitToolDone({ call_id: 'b' });
+                expect(lastRunningToolCalls().map((call: { callId: string }) => call.callId)).toEqual(['a', 'c']);
+
+                emitToolDone({ call_id: 'c' });
+                expect(lastRunningToolCalls().map((call: { callId: string }) => call.callId)).toEqual(['a']);
+            });
+
+            it('fires once per start, not only when the blocking aggregate flips', () => {
+                emitToolStarted({ call_id: 'a', interruptible: false, execution_mode: 'blocking' });
+                emitToolStarted({ call_id: 'b', interruptible: false, execution_mode: 'blocking' });
+
+                expect(onRunningToolCallsChange).toHaveBeenCalledTimes(2);
+            });
+
+            it('does not leak the internal bookkeeping fields into the emitted calls', () => {
+                emitToolStarted({ call_id: 'a', interruptible: false, execution_mode: 'blocking', turn_id: 1 });
+
+                expect(Object.keys(lastRunningToolCalls()[0])).toEqual(['callId', 'name', 'executionMode']);
+            });
+
+            it('does not re-emit when a call that is not pending resolves', () => {
+                emitToolDone({ call_id: 'never-started' });
+
+                expect(onRunningToolCallsChange).not.toHaveBeenCalled();
+            });
+
+            it('emits the same empty-collection reference every time nothing is running', () => {
+                emitToolStarted({ call_id: 'a', interruptible: false, execution_mode: 'blocking' });
+                emitToolDone({ call_id: 'a' });
+                const first = lastRunningToolCalls();
+
+                emitToolStarted({ call_id: 'b', interruptible: false, execution_mode: 'blocking' });
+                emitToolDone({ call_id: 'b' });
+
+                expect(lastRunningToolCalls()).toBe(first);
+            });
+
+            it('emits an empty array and restores interruptible on disconnect', async () => {
+                emitToolStarted({ call_id: 'a', interruptible: false, execution_mode: 'blocking' });
+                expect(onInterruptibleChange).toHaveBeenLastCalledWith(false);
+                onRunningToolCallsChange.mockClear();
+
+                await manager.disconnect();
+
+                expect(onRunningToolCallsChange).toHaveBeenCalledWith([]);
+                expect(onInterruptibleChange).toHaveBeenLastCalledWith(true);
+            });
+
+            it('does not emit on disconnect when nothing was running', async () => {
+                onRunningToolCallsChange.mockClear();
+
+                await manager.disconnect();
+
+                expect(onRunningToolCallsChange).not.toHaveBeenCalled();
+            });
         });
 
-        it('treats a missing execution_mode as blocking', () => {
-            emitToolStarted({ call_id: 'a', interruptible: false });
+        describe('turn/ended reaping a leaked pending call', () => {
+            it('drops a blocking call whose turn ended and recovers interruptibility', () => {
+                emitTurnStarted(1);
+                emitToolStarted({ call_id: 'a', interruptible: false, execution_mode: 'blocking', turn_id: 1 });
+                expect(lastInterruptible()).toBe(false);
 
-            expect(lastRunningToolCalls()).toEqual([{ callId: 'a', name: 'tool', executionMode: 'blocking' }]);
-        });
+                emitTurnEnded(1);
 
-        it('keeps reporting the calls still running and drops only the ones that resolved', () => {
-            emitToolStarted({ call_id: 'a', interruptible: true, execution_mode: 'async' });
-            emitToolStarted({ call_id: 'b', interruptible: false, execution_mode: 'blocking' });
-            emitToolStarted({ call_id: 'c', interruptible: false, execution_mode: 'blocking' });
-            expect(lastRunningToolCalls().map((call: { callId: string }) => call.callId)).toEqual(['a', 'b', 'c']);
+                expect(lastRunningToolCalls()).toEqual([]);
+                expect(lastInterruptible()).toBe(true);
+            });
 
-            emitToolDone({ call_id: 'b' });
-            expect(lastRunningToolCalls().map((call: { callId: string }) => call.callId)).toEqual(['a', 'c']);
+            it('keeps an async call pending when its turn ends', () => {
+                emitTurnStarted(1);
+                emitToolStarted({ call_id: 'a', interruptible: true, execution_mode: 'async', turn_id: 1 });
 
-            emitToolDone({ call_id: 'c' });
-            expect(lastRunningToolCalls().map((call: { callId: string }) => call.callId)).toEqual(['a']);
-        });
+                emitTurnEnded(1);
 
-        it('fires once per start, not only when the blocking aggregate flips', () => {
-            emitToolStarted({ call_id: 'a', interruptible: false, execution_mode: 'blocking' });
-            emitToolStarted({ call_id: 'b', interruptible: false, execution_mode: 'blocking' });
+                expect(lastRunningToolCalls()).toEqual([{ callId: 'a', name: 'tool', executionMode: 'async' }]);
+            });
 
-            expect(onRunningToolCallsChange).toHaveBeenCalledTimes(2);
-        });
+            it('keeps a blocking call from a later turn when an earlier turn ends', () => {
+                emitTurnStarted(1);
+                emitToolStarted({ call_id: 'a', interruptible: false, execution_mode: 'blocking', turn_id: 2 });
 
-        it('does not leak the internal interruptible flag into the emitted calls', () => {
-            emitToolStarted({ call_id: 'a', interruptible: false, execution_mode: 'blocking' });
+                emitTurnEnded(1);
 
-            expect(Object.keys(lastRunningToolCalls()[0])).toEqual(['callId', 'name', 'executionMode']);
-        });
+                expect(lastRunningToolCalls()).toEqual([{ callId: 'a', name: 'tool', executionMode: 'blocking' }]);
+                expect(lastInterruptible()).toBe(false);
+            });
 
-        it('emits an empty array and restores interruptible on disconnect', async () => {
-            emitToolStarted({ call_id: 'a', interruptible: false, execution_mode: 'blocking' });
-            expect(onInterruptibleChange).toHaveBeenLastCalledWith(false);
-            onRunningToolCallsChange.mockClear();
+            it('does not re-emit on turn/ended when nothing blocking is pending', () => {
+                emitTurnStarted(1);
+                emitToolStarted({ call_id: 'a', interruptible: true, execution_mode: 'async', turn_id: 1 });
+                onRunningToolCallsChange.mockClear();
 
-            await manager.disconnect();
+                emitTurnEnded(1);
 
-            expect(onRunningToolCallsChange).toHaveBeenCalledWith([]);
-            expect(onInterruptibleChange).toHaveBeenLastCalledWith(true);
+                expect(onRunningToolCallsChange).not.toHaveBeenCalled();
+            });
         });
     });
 
@@ -1801,8 +1849,8 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
         });
     });
 
-    describe('handleDataReceived - stream-video/done with interruptible', () => {
-        it('should stay ToolActive on stream-video/done while a tool call is pending (interruptible true)', async () => {
+    describe('handleDataReceived - stream-video/done while a tool call is pending', () => {
+        it('should stay ToolActive on stream-video/done while a tool call is pending', async () => {
             // ARRANGE:
             const onAgentActivityStateChange = jest.fn();
             options.callbacks.onAgentActivityStateChange = onAgentActivityStateChange;
@@ -1825,82 +1873,8 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
             );
             onAgentActivityStateChange.mockClear();
 
-            const streamVideoDonePayload = createDataChannelPayload({
-                subject: StreamEvents.StreamVideoDone,
-                metadata: { interruptible: true },
-            });
-
             // ACT:
-            dataHandler(streamVideoDonePayload);
-
-            // ASSERT:
-            expect(onAgentActivityStateChange).not.toHaveBeenCalled();
-        });
-
-        it('should stay ToolActive on stream-video/done while a tool call is pending (interruptible absent)', async () => {
-            // ARRANGE:
-            const onAgentActivityStateChange = jest.fn();
-            options.callbacks.onAgentActivityStateChange = onAgentActivityStateChange;
-
-            await createLiveKitStreamingManager(agentId, sessionOptions, options);
-            await simulateConnection();
-
-            const dataHandler = getDataReceivedHandler();
-
-            // Set ToolActive state first
-            dataHandler(
-                createDataChannelPayload({
-                    subject: StreamEvents.ToolCallStarted,
-                    call_id: 'call-123',
-                    name: 'test',
-                    input: {},
-                    output: {},
-                    timestamp: new Date().toISOString(),
-                })
-            );
-            onAgentActivityStateChange.mockClear();
-
-            const streamVideoDonePayload = createDataChannelPayload({
-                subject: StreamEvents.StreamVideoDone,
-            });
-
-            // ACT:
-            dataHandler(streamVideoDonePayload);
-
-            // ASSERT:
-            expect(onAgentActivityStateChange).not.toHaveBeenCalled();
-        });
-
-        it('should stay in ToolActive on stream-video/done when interruptible is false', async () => {
-            // ARRANGE:
-            const onAgentActivityStateChange = jest.fn();
-            options.callbacks.onAgentActivityStateChange = onAgentActivityStateChange;
-
-            await createLiveKitStreamingManager(agentId, sessionOptions, options);
-            await simulateConnection();
-
-            const dataHandler = getDataReceivedHandler();
-
-            // Set ToolActive state first
-            dataHandler(
-                createDataChannelPayload({
-                    subject: StreamEvents.ToolCallStarted,
-                    call_id: 'call-123',
-                    name: 'test',
-                    input: {},
-                    output: {},
-                    timestamp: new Date().toISOString(),
-                })
-            );
-            onAgentActivityStateChange.mockClear();
-
-            const streamVideoDonePayload = createDataChannelPayload({
-                subject: StreamEvents.StreamVideoDone,
-                metadata: { interruptible: false },
-            });
-
-            // ACT:
-            dataHandler(streamVideoDonePayload);
+            dataHandler(createDataChannelPayload({ subject: StreamEvents.StreamVideoDone }));
 
             // ASSERT:
             expect(onAgentActivityStateChange).not.toHaveBeenCalled();

--- a/src/services/streaming-manager/livekit-manager.test.ts
+++ b/src/services/streaming-manager/livekit-manager.test.ts
@@ -1401,7 +1401,7 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
             );
         });
 
-        it('should emit onInterruptibleChange(false) when tool-call/started carries interruptible: false', async () => {
+        it('should emit onInterruptibleChange(false) when a blocking tool-call/started arrives', async () => {
             // ARRANGE:
             const onInterruptibleChange = jest.fn();
             options.callbacks.onInterruptibleChange = onInterruptibleChange;
@@ -1427,7 +1427,7 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
             expect(onInterruptibleChange).toHaveBeenCalledWith(false);
         });
 
-        it('should not emit onInterruptibleChange when an interruptible tool-call/started leaves the aggregate unchanged', async () => {
+        it('should not emit onInterruptibleChange when an async tool-call/started leaves the aggregate unchanged', async () => {
             // ARRANGE:
             const onInterruptibleChange = jest.fn();
             options.callbacks.onInterruptibleChange = onInterruptibleChange;
@@ -1442,7 +1442,8 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
                 name: 'get_weather',
                 input: {},
                 output: {},
-                interruptible: true,
+                interruptible: false,
+                execution_mode: 'async',
                 timestamp: new Date().toISOString(),
             });
 
@@ -1505,13 +1506,13 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
         const emitToolStarted = ({
             call_id,
             name = 'tool',
-            interruptible,
+            interruptible = false,
             execution_mode,
             turn_id,
         }: {
             call_id: string;
             name?: string;
-            interruptible: boolean;
+            interruptible?: boolean;
             execution_mode?: string;
             turn_id?: number;
         }) =>
@@ -1575,37 +1576,43 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
 
         describe('interruptible across parallel tool calls', () => {
             it('stays non-interruptible while any blocking call is pending', () => {
-                emitToolStarted({ call_id: 'a', interruptible: true });
-                emitToolStarted({ call_id: 'b', interruptible: false });
+                emitToolStarted({ call_id: 'a', execution_mode: 'async' });
+                emitToolStarted({ call_id: 'b', execution_mode: 'blocking' });
 
                 expect(lastInterruptible()).toBe(false);
             });
 
             it('becomes interruptible once the blocking call resolves', () => {
-                emitToolStarted({ call_id: 'a', interruptible: true });
-                emitToolStarted({ call_id: 'b', interruptible: false });
+                emitToolStarted({ call_id: 'a', execution_mode: 'async' });
+                emitToolStarted({ call_id: 'b', execution_mode: 'blocking' });
                 emitToolDone({ call_id: 'b' });
 
                 expect(lastInterruptible()).toBe(true);
             });
 
             it('does not regress interruptibility when a blocking call starts after an async one', () => {
-                emitToolStarted({ call_id: 'a', interruptible: true });
+                emitToolStarted({ call_id: 'a', execution_mode: 'async' });
                 expect(lastInterruptible()).toBe(true);
-                emitToolStarted({ call_id: 'b', interruptible: false });
+                emitToolStarted({ call_id: 'b', execution_mode: 'blocking' });
                 expect(lastInterruptible()).toBe(false);
             });
 
             it('stays non-interruptible when an async call starts after a blocking one', () => {
-                emitToolStarted({ call_id: 'a', interruptible: false });
-                emitToolStarted({ call_id: 'b', interruptible: true });
+                emitToolStarted({ call_id: 'a', execution_mode: 'blocking' });
+                emitToolStarted({ call_id: 'b', execution_mode: 'async' });
 
                 expect(lastInterruptible()).toBe(false);
             });
 
             it('stays non-interruptible when a video activity event arrives while a blocking call is pending', () => {
-                emitToolStarted({ call_id: 'a', interruptible: false });
+                emitToolStarted({ call_id: 'a', execution_mode: 'blocking' });
                 emitStreamVideoDone();
+
+                expect(lastInterruptible()).toBe(false);
+            });
+
+            it('ignores the per-call interruptible flag when deriving the aggregate', () => {
+                emitToolStarted({ call_id: 'a', interruptible: true, execution_mode: 'blocking' });
 
                 expect(lastInterruptible()).toBe(false);
             });
@@ -1628,7 +1635,7 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
             });
 
             it('reports an async-mode call as async', () => {
-                emitToolStarted({ call_id: 'a', interruptible: true, execution_mode: 'async' });
+                emitToolStarted({ call_id: 'a', execution_mode: 'async' });
 
                 expect(lastRunningToolCalls()).toEqual([{ callId: 'a', name: 'tool', executionMode: 'async' }]);
             });
@@ -1640,7 +1647,7 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
             });
 
             it('keeps reporting the calls still running and drops only the ones that resolved', () => {
-                emitToolStarted({ call_id: 'a', interruptible: true, execution_mode: 'async' });
+                emitToolStarted({ call_id: 'a', execution_mode: 'async' });
                 emitToolStarted({ call_id: 'b', interruptible: false, execution_mode: 'blocking' });
                 emitToolStarted({ call_id: 'c', interruptible: false, execution_mode: 'blocking' });
                 expect(lastRunningToolCalls().map((call: { callId: string }) => call.callId)).toEqual(['a', 'b', 'c']);
@@ -1716,7 +1723,7 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
 
             it('keeps an async call pending when its turn ends', () => {
                 emitTurnStarted(1);
-                emitToolStarted({ call_id: 'a', interruptible: true, execution_mode: 'async', turn_id: 1 });
+                emitToolStarted({ call_id: 'a', execution_mode: 'async', turn_id: 1 });
 
                 emitTurnEnded(1);
 
@@ -1735,7 +1742,7 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
 
             it('does not re-emit on turn/ended when nothing blocking is pending', () => {
                 emitTurnStarted(1);
-                emitToolStarted({ call_id: 'a', interruptible: true, execution_mode: 'async', turn_id: 1 });
+                emitToolStarted({ call_id: 'a', execution_mode: 'async', turn_id: 1 });
                 onRunningToolCallsChange.mockClear();
 
                 emitTurnEnded(1);

--- a/src/services/streaming-manager/livekit-manager.test.ts
+++ b/src/services/streaming-manager/livekit-manager.test.ts
@@ -1496,6 +1496,76 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
         });
     });
 
+    describe('handleDataReceived - interruptible across parallel tool calls', () => {
+        let onInterruptibleChange: jest.Mock;
+        let dataHandler: any;
+
+        const emitToolStarted = ({ call_id, interruptible }: { call_id: string; interruptible: boolean }) =>
+            dataHandler(
+                createDataChannelPayload({
+                    subject: StreamEvents.ToolCallStarted,
+                    call_id,
+                    name: 'tool',
+                    input: {},
+                    output: {},
+                    interruptible,
+                    timestamp: new Date().toISOString(),
+                })
+            );
+
+        const emitToolDone = ({ call_id }: { call_id: string }) =>
+            dataHandler(
+                createDataChannelPayload({
+                    subject: StreamEvents.ToolCallDone,
+                    call_id,
+                    name: 'tool',
+                    input: {},
+                    output: {},
+                    duration_ms: 50,
+                    extra: {},
+                    timestamp: new Date().toISOString(),
+                })
+            );
+
+        // The manager starts interruptible and only calls back on a change, so with no calls
+        // yet the observed state is the initial true.
+        const lastInterruptible = () =>
+            onInterruptibleChange.mock.calls.length > 0
+                ? onInterruptibleChange.mock.calls[onInterruptibleChange.mock.calls.length - 1][0]
+                : true;
+
+        beforeEach(async () => {
+            onInterruptibleChange = jest.fn();
+            options.callbacks.onInterruptibleChange = onInterruptibleChange;
+
+            await createLiveKitStreamingManager(agentId, sessionOptions, options);
+            await simulateConnection();
+            dataHandler = getDataReceivedHandler();
+        });
+
+        it('stays non-interruptible while any blocking call is pending', () => {
+            emitToolStarted({ call_id: 'a', interruptible: true });
+            emitToolStarted({ call_id: 'b', interruptible: false });
+
+            expect(lastInterruptible()).toBe(false);
+        });
+
+        it('becomes interruptible once the blocking call resolves', () => {
+            emitToolStarted({ call_id: 'a', interruptible: true });
+            emitToolStarted({ call_id: 'b', interruptible: false });
+            emitToolDone({ call_id: 'b' });
+
+            expect(lastInterruptible()).toBe(true);
+        });
+
+        it('does not regress interruptibility when a blocking call starts after an async one', () => {
+            emitToolStarted({ call_id: 'a', interruptible: true });
+            expect(lastInterruptible()).toBe(true);
+            emitToolStarted({ call_id: 'b', interruptible: false });
+            expect(lastInterruptible()).toBe(false);
+        });
+    });
+
     describe('handleDataReceived - tool-call/done', () => {
         it('should forward payload via onToolEvent without changing activity state', async () => {
             // ARRANGE:

--- a/src/services/streaming-manager/livekit-manager.ts
+++ b/src/services/streaming-manager/livekit-manager.ts
@@ -53,6 +53,12 @@ interface TrackPublishState {
     publication: LocalTrackPublication | null;
 }
 
+interface PendingToolCall {
+    call: RunningToolCall;
+    interruptible: boolean;
+    turnId: number | null;
+}
+
 async function importLiveKit(): Promise<{
     Room: typeof Room;
     RoomEvent: typeof RoomEvent;
@@ -130,7 +136,7 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
     let trackSubscriptionTimeoutId: ReturnType<typeof setTimeout> | null = null;
     let currentActivityState: AgentActivityState = AgentActivityState.Idle;
     let currentInterruptible = true;
-    const pendingToolCalls = new Map<string, RunningToolCall & { interruptible: boolean; turnId: number | null }>();
+    const pendingToolCalls = new Map<string, PendingToolCall>();
     let currentTurnId: number | null = null;
 
     const streamApi = createStreamApiV2(auth, baseURL || didApiUrl, agentId, callbacks.onError);
@@ -387,10 +393,12 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
         if (subject === StreamEvents.ToolCallStarted) {
             const payload = data as ToolCallStartedPayload;
             pendingToolCalls.set(payload.call_id, {
-                callId: payload.call_id,
-                name: payload.name,
-                executionMode: payload.execution_mode === 'async' ? 'async' : 'blocking',
-                interruptible: payload.interruptible !== false,
+                call: {
+                    callId: payload.call_id,
+                    name: payload.name,
+                    executionMode: payload.execution_mode === 'async' ? 'async' : 'blocking',
+                },
+                interruptible: payload.interruptible === true,
                 turnId: payload.turn_id ?? currentTurnId,
             });
             recomputeInterruptible();
@@ -424,9 +432,9 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
     function dropBlockingToolCallsForTurn(turnId: number | null): void {
         let dropped = false;
 
-        for (const [callId, call] of pendingToolCalls) {
-            if (call.executionMode !== 'blocking') continue;
-            if (turnId !== null && call.turnId !== null && call.turnId !== turnId) continue;
+        for (const [callId, pending] of pendingToolCalls) {
+            if (pending.call.executionMode !== 'blocking') continue;
+            if (turnId !== null && pending.turnId !== null && pending.turnId !== turnId) continue;
             pendingToolCalls.delete(callId);
             dropped = true;
         }
@@ -437,7 +445,7 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
     }
 
     function recomputeInterruptible(): void {
-        const next = [...pendingToolCalls.values()].every(call => call.interruptible);
+        const next = ![...pendingToolCalls.values()].some(({ call }) => call.executionMode === 'blocking');
         if (next === currentInterruptible) return;
         currentInterruptible = next;
         callbacks.onInterruptibleChange?.(next);
@@ -445,13 +453,7 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
 
     function emitRunningToolCalls(): void {
         callbacks.onRunningToolCallsChange?.(
-            pendingToolCalls.size === 0
-                ? NO_RUNNING_TOOL_CALLS
-                : [...pendingToolCalls.values()].map(({ callId, name, executionMode }) => ({
-                      callId,
-                      name,
-                      executionMode,
-                  }))
+            pendingToolCalls.size === 0 ? NO_RUNNING_TOOL_CALLS : [...pendingToolCalls.values()].map(({ call }) => call)
         );
     }
 

--- a/src/services/streaming-manager/livekit-manager.ts
+++ b/src/services/streaming-manager/livekit-manager.ts
@@ -127,10 +127,13 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
     let trackSubscriptionTimeoutId: ReturnType<typeof setTimeout> | null = null;
     let currentActivityState: AgentActivityState = AgentActivityState.Idle;
     let currentInterruptible = true;
+    let currentBlockingToolPending = false;
     // Whether the speech currently playing can be barged in on. An input to the aggregate,
     // not a second writer of it, and only meaningful while the agent is speaking.
     let videoInterruptible = true;
-    const pendingToolCalls = new Map<string, boolean>();
+    // Two independent facts per call: whether the user may barge in, and whether the call
+    // occupies the agent's turn. They are not each other's negation.
+    const pendingToolCalls = new Map<string, { interruptible: boolean; blocking: boolean }>();
     let currentTurnId: number | null = null;
 
     const streamApi = createStreamApiV2(auth, baseURL || didApiUrl, agentId, callbacks.onError);
@@ -386,8 +389,13 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
     function handleToolEvents(subject: string, data: any): void {
         if (subject === StreamEvents.ToolCallStarted) {
             const payload = data as ToolCallStartedPayload;
-            pendingToolCalls.set(payload.call_id, payload.interruptible !== false);
+            pendingToolCalls.set(payload.call_id, {
+                interruptible: payload.interruptible !== false,
+                // A worker that predates execution_mode sends nothing, which means blocking.
+                blocking: payload.execution_mode !== 'async',
+            });
             recomputeInterruptible();
+            recomputeBlockingToolPending();
             currentActivityState = AgentActivityState.ToolActive;
             callbacks.onAgentActivityStateChange?.(AgentActivityState.ToolActive);
             callbacks.onToolEvent?.(StreamEvents.ToolCallStarted, payload);
@@ -411,16 +419,27 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
     function resolvePendingToolCall(callId: string): void {
         pendingToolCalls.delete(callId);
         recomputeInterruptible();
+        recomputeBlockingToolPending();
     }
 
     // Interruptible only when the speech allows it and nothing blocking is pending. Derived,
     // never assigned from the latest event: async and blocking tools can overlap, and
     // whichever started last is not the answer.
     function recomputeInterruptible(): void {
-        const next = videoInterruptible && [...pendingToolCalls.values()].every(Boolean);
+        const next = videoInterruptible && [...pendingToolCalls.values()].every(call => call.interruptible);
         if (next === currentInterruptible) return;
         currentInterruptible = next;
         callbacks.onInterruptibleChange?.(next);
+    }
+
+    // Whether a blocking-mode call is occupying the turn. Same discipline as the aggregate
+    // above -- derived from every pending call, never assigned from the latest event -- but a
+    // separate question: speech interruptibility is deliberately not folded in here.
+    function recomputeBlockingToolPending(): void {
+        const next = [...pendingToolCalls.values()].some(call => call.blocking);
+        if (next === currentBlockingToolPending) return;
+        currentBlockingToolPending = next;
+        callbacks.onBlockingToolPendingChange?.(next);
     }
 
     function handleVideoActivityState(subject: string, data: any): void {
@@ -748,6 +767,7 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
         isConnected = false;
         hasEmittedConnected = false;
         pendingToolCalls.clear();
+        recomputeBlockingToolPending();
         currentTurnId = null;
         callbacks.onAgentActivityStateChange?.(AgentActivityState.Idle);
         currentActivityState = AgentActivityState.Idle;

--- a/src/services/streaming-manager/livekit-manager.ts
+++ b/src/services/streaming-manager/livekit-manager.ts
@@ -381,7 +381,7 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
      * - tool-call/started -> ToolActive
      * - stream-video/created -> Talking, then back to ToolActive on stream-video/done
      *   while any tool call is still pending (e.g. a client tool waiting for user input)
-     * - last tool-call/done|error -> Idle
+     * - tool-call/done|error only drops the pending call; Idle comes from turn/ended
      */
     function handleToolEvents(subject: string, data: any): void {
         if (subject === StreamEvents.ToolCallStarted) {

--- a/src/services/streaming-manager/livekit-manager.ts
+++ b/src/services/streaming-manager/livekit-manager.ts
@@ -12,6 +12,7 @@ import {
     StreamingManagerOptions,
     StreamingState,
     StreamType,
+    ToolCall,
     ToolCallDonePayload,
     ToolCallErrorPayload,
     ToolCallStartedPayload,
@@ -127,8 +128,7 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
     let trackSubscriptionTimeoutId: ReturnType<typeof setTimeout> | null = null;
     let currentActivityState: AgentActivityState = AgentActivityState.Idle;
     let currentInterruptible = true;
-    let currentBlockingToolPending = false;
-    const pendingToolCalls = new Map<string, { interruptible: boolean; blocking: boolean }>();
+    const pendingToolCalls = new Map<string, ToolCall & { interruptible: boolean }>();
     let currentTurnId: number | null = null;
 
     const streamApi = createStreamApiV2(auth, baseURL || didApiUrl, agentId, callbacks.onError);
@@ -385,11 +385,13 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
         if (subject === StreamEvents.ToolCallStarted) {
             const payload = data as ToolCallStartedPayload;
             pendingToolCalls.set(payload.call_id, {
+                callId: payload.call_id,
+                name: payload.name,
+                executionMode: payload.execution_mode === 'async' ? 'async' : 'blocking',
                 interruptible: payload.interruptible !== false,
-                blocking: payload.execution_mode !== 'async',
             });
             recomputeInterruptible();
-            recomputeBlockingToolPending();
+            emitRunningToolCalls();
             currentActivityState = AgentActivityState.ToolActive;
             callbacks.onAgentActivityStateChange?.(AgentActivityState.ToolActive);
             callbacks.onToolEvent?.(StreamEvents.ToolCallStarted, payload);
@@ -413,7 +415,7 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
     function resolvePendingToolCall(callId: string): void {
         pendingToolCalls.delete(callId);
         recomputeInterruptible();
-        recomputeBlockingToolPending();
+        emitRunningToolCalls();
     }
 
     function recomputeInterruptible(): void {
@@ -423,11 +425,14 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
         callbacks.onInterruptibleChange?.(next);
     }
 
-    function recomputeBlockingToolPending(): void {
-        const next = [...pendingToolCalls.values()].some(call => call.blocking);
-        if (next === currentBlockingToolPending) return;
-        currentBlockingToolPending = next;
-        callbacks.onBlockingToolPendingChange?.(next);
+    function emitRunningToolCalls(): void {
+        callbacks.onRunningToolCallsChange?.(
+            [...pendingToolCalls.values()].map(({ callId, name, executionMode }) => ({
+                callId,
+                name,
+                executionMode,
+            }))
+        );
     }
 
     function handleVideoActivityState(subject: string, data: any): void {
@@ -748,7 +753,8 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
         isConnected = false;
         hasEmittedConnected = false;
         pendingToolCalls.clear();
-        recomputeBlockingToolPending();
+        recomputeInterruptible();
+        emitRunningToolCalls();
         currentTurnId = null;
         callbacks.onAgentActivityStateChange?.(AgentActivityState.Idle);
         currentActivityState = AgentActivityState.Idle;

--- a/src/services/streaming-manager/livekit-manager.ts
+++ b/src/services/streaming-manager/livekit-manager.ts
@@ -127,7 +127,7 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
     let trackSubscriptionTimeoutId: ReturnType<typeof setTimeout> | null = null;
     let currentActivityState: AgentActivityState = AgentActivityState.Idle;
     let currentInterruptible = true;
-    const pendingToolCalls = new Set<string>();
+    const pendingToolCalls = new Map<string, boolean>();
     let currentTurnId: number | null = null;
 
     const streamApi = createStreamApiV2(auth, baseURL || didApiUrl, agentId, callbacks.onError);
@@ -383,13 +383,8 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
     function handleToolEvents(subject: string, data: any): void {
         if (subject === StreamEvents.ToolCallStarted) {
             const payload = data as ToolCallStartedPayload;
-            // TODO: race condition with parallel tool calls — if one tool is interruptible
-            // and another isn't, the last tool-call/started wins instead of AND-ing the flags.
-            // Backend currently sends interruptible: false for all tools, so this works in practice.
-            // Future fix: track interruptible per toolId and derive the aggregate state.
-            currentInterruptible = payload.interruptible !== false;
-            callbacks.onInterruptibleChange?.(currentInterruptible);
-            pendingToolCalls.add(payload.call_id);
+            pendingToolCalls.set(payload.call_id, payload.interruptible !== false);
+            recomputeInterruptible();
             currentActivityState = AgentActivityState.ToolActive;
             callbacks.onAgentActivityStateChange?.(AgentActivityState.ToolActive);
             callbacks.onToolEvent?.(StreamEvents.ToolCallStarted, payload);
@@ -412,6 +407,17 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
 
     function resolvePendingToolCall(callId: string): void {
         pendingToolCalls.delete(callId);
+        recomputeInterruptible();
+    }
+
+    // Interruptible only when nothing blocking is pending. Derived, never assigned
+    // from the latest event: async and blocking tools can overlap, and whichever
+    // started last is not the answer.
+    function recomputeInterruptible(): void {
+        const next = [...pendingToolCalls.values()].every(Boolean);
+        if (next === currentInterruptible) return;
+        currentInterruptible = next;
+        callbacks.onInterruptibleChange?.(next);
     }
 
     function handleVideoActivityState(subject: string, data: any): void {

--- a/src/services/streaming-manager/livekit-manager.ts
+++ b/src/services/streaming-manager/livekit-manager.ts
@@ -387,7 +387,6 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
             const payload = data as ToolCallStartedPayload;
             pendingToolCalls.set(payload.call_id, {
                 interruptible: payload.interruptible !== false,
-                // A worker that predates execution_mode sends nothing, which means blocking.
                 blocking: payload.execution_mode !== 'async',
             });
             recomputeInterruptible();

--- a/src/services/streaming-manager/livekit-manager.ts
+++ b/src/services/streaming-manager/livekit-manager.ts
@@ -8,11 +8,11 @@ import {
     Interrupt,
     Message,
     PayloadType,
+    RunningToolCall,
     StreamEvents,
     StreamingManagerOptions,
     StreamingState,
     StreamType,
-    ToolCall,
     ToolCallDonePayload,
     ToolCallErrorPayload,
     ToolCallStartedPayload,
@@ -45,6 +45,8 @@ import { createAudioStatsDetector, createVideoStatsMonitor } from './stats/poll'
 import { VideoRTCStatsReport } from './stats/report';
 
 const TRACK_SUBSCRIPTION_TIMEOUT_MS = 20000;
+
+const NO_RUNNING_TOOL_CALLS: readonly RunningToolCall[] = [];
 
 interface TrackPublishState {
     isPublishing: boolean;
@@ -128,7 +130,7 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
     let trackSubscriptionTimeoutId: ReturnType<typeof setTimeout> | null = null;
     let currentActivityState: AgentActivityState = AgentActivityState.Idle;
     let currentInterruptible = true;
-    const pendingToolCalls = new Map<string, ToolCall & { interruptible: boolean }>();
+    const pendingToolCalls = new Map<string, RunningToolCall & { interruptible: boolean; turnId: number | null }>();
     let currentTurnId: number | null = null;
 
     const streamApi = createStreamApiV2(auth, baseURL || didApiUrl, agentId, callbacks.onError);
@@ -389,6 +391,7 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
                 name: payload.name,
                 executionMode: payload.execution_mode === 'async' ? 'async' : 'blocking',
                 interruptible: payload.interruptible !== false,
+                turnId: payload.turn_id ?? currentTurnId,
             });
             recomputeInterruptible();
             emitRunningToolCalls();
@@ -413,7 +416,22 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
     }
 
     function resolvePendingToolCall(callId: string): void {
-        pendingToolCalls.delete(callId);
+        if (!pendingToolCalls.delete(callId)) return;
+        recomputeInterruptible();
+        emitRunningToolCalls();
+    }
+
+    function dropBlockingToolCallsForTurn(turnId: number | null): void {
+        let dropped = false;
+
+        for (const [callId, call] of pendingToolCalls) {
+            if (call.executionMode !== 'blocking') continue;
+            if (turnId !== null && call.turnId !== null && call.turnId !== turnId) continue;
+            pendingToolCalls.delete(callId);
+            dropped = true;
+        }
+
+        if (!dropped) return;
         recomputeInterruptible();
         emitRunningToolCalls();
     }
@@ -427,11 +445,13 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
 
     function emitRunningToolCalls(): void {
         callbacks.onRunningToolCallsChange?.(
-            [...pendingToolCalls.values()].map(({ callId, name, executionMode }) => ({
-                callId,
-                name,
-                executionMode,
-            }))
+            pendingToolCalls.size === 0
+                ? NO_RUNNING_TOOL_CALLS
+                : [...pendingToolCalls.values()].map(({ callId, name, executionMode }) => ({
+                      callId,
+                      name,
+                      executionMode,
+                  }))
         );
     }
 
@@ -487,6 +507,7 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
     function handleTurnEnded(_subject: string, data: TurnEventPayload): void {
         const turnId: number | null = data?.turn_id ?? null;
         if (currentTurnId !== null && turnId !== null && turnId < currentTurnId) return;
+        dropBlockingToolCallsForTurn(turnId);
         currentActivityState = AgentActivityState.Idle;
         callbacks.onAgentActivityStateChange?.(AgentActivityState.Idle);
     }
@@ -752,9 +773,11 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
         cleanMediaStream();
         isConnected = false;
         hasEmittedConnected = false;
-        pendingToolCalls.clear();
-        recomputeInterruptible();
-        emitRunningToolCalls();
+        if (pendingToolCalls.size > 0) {
+            pendingToolCalls.clear();
+            recomputeInterruptible();
+            emitRunningToolCalls();
+        }
         currentTurnId = null;
         callbacks.onAgentActivityStateChange?.(AgentActivityState.Idle);
         currentActivityState = AgentActivityState.Idle;

--- a/src/services/streaming-manager/livekit-manager.ts
+++ b/src/services/streaming-manager/livekit-manager.ts
@@ -127,6 +127,9 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
     let trackSubscriptionTimeoutId: ReturnType<typeof setTimeout> | null = null;
     let currentActivityState: AgentActivityState = AgentActivityState.Idle;
     let currentInterruptible = true;
+    // The agent's current speech, which the backend marks non-interruptible while it is
+    // speaking into a tool call. An input to the aggregate, not a second writer of it.
+    let videoInterruptible = true;
     const pendingToolCalls = new Map<string, boolean>();
     let currentTurnId: number | null = null;
 
@@ -410,19 +413,19 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
         recomputeInterruptible();
     }
 
-    // Interruptible only when nothing blocking is pending. Derived, never assigned
-    // from the latest event: async and blocking tools can overlap, and whichever
-    // started last is not the answer.
+    // Interruptible only when the speech allows it and nothing blocking is pending. Derived,
+    // never assigned from the latest event: async and blocking tools can overlap, and
+    // whichever started last is not the answer.
     function recomputeInterruptible(): void {
-        const next = [...pendingToolCalls.values()].every(Boolean);
+        const next = videoInterruptible && [...pendingToolCalls.values()].every(Boolean);
         if (next === currentInterruptible) return;
         currentInterruptible = next;
         callbacks.onInterruptibleChange?.(next);
     }
 
     function handleVideoActivityState(subject: string, data: any): void {
-        currentInterruptible = data.metadata?.interruptible !== false;
-        callbacks.onInterruptibleChange?.(currentInterruptible);
+        videoInterruptible = data.metadata?.interruptible !== false;
+        recomputeInterruptible();
 
         if (subject === StreamEvents.StreamVideoCreated) {
             currentActivityState = AgentActivityState.Talking;

--- a/src/services/streaming-manager/livekit-manager.ts
+++ b/src/services/streaming-manager/livekit-manager.ts
@@ -128,7 +128,6 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
     let currentActivityState: AgentActivityState = AgentActivityState.Idle;
     let currentInterruptible = true;
     let currentBlockingToolPending = false;
-    let videoInterruptible = true;
     const pendingToolCalls = new Map<string, { interruptible: boolean; blocking: boolean }>();
     let currentTurnId: number | null = null;
 
@@ -418,7 +417,7 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
     }
 
     function recomputeInterruptible(): void {
-        const next = videoInterruptible && [...pendingToolCalls.values()].every(call => call.interruptible);
+        const next = [...pendingToolCalls.values()].every(call => call.interruptible);
         if (next === currentInterruptible) return;
         currentInterruptible = next;
         callbacks.onInterruptibleChange?.(next);
@@ -433,8 +432,6 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
 
     function handleVideoActivityState(subject: string, data: any): void {
         if (subject === StreamEvents.StreamVideoCreated) {
-            videoInterruptible = data.metadata?.interruptible !== false;
-            recomputeInterruptible();
             currentActivityState = AgentActivityState.Talking;
             callbacks.onAgentActivityStateChange?.(AgentActivityState.Talking);
             audioStatsDetector?.arm({
@@ -443,10 +440,6 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
             });
             return;
         }
-
-        // The done event still carries the finished speech's own flag, so lift it explicitly.
-        videoInterruptible = true;
-        recomputeInterruptible();
 
         if (pendingToolCalls.size > 0) {
             if (currentActivityState !== AgentActivityState.ToolActive) {

--- a/src/services/streaming-manager/livekit-manager.ts
+++ b/src/services/streaming-manager/livekit-manager.ts
@@ -128,11 +128,7 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
     let currentActivityState: AgentActivityState = AgentActivityState.Idle;
     let currentInterruptible = true;
     let currentBlockingToolPending = false;
-    // Whether the speech currently playing can be barged in on. An input to the aggregate,
-    // not a second writer of it, and only meaningful while the agent is speaking.
     let videoInterruptible = true;
-    // Two independent facts per call: whether the user may barge in, and whether the call
-    // occupies the agent's turn. They are not each other's negation.
     const pendingToolCalls = new Map<string, { interruptible: boolean; blocking: boolean }>();
     let currentTurnId: number | null = null;
 
@@ -422,9 +418,6 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
         recomputeBlockingToolPending();
     }
 
-    // Interruptible only when the speech allows it and nothing blocking is pending. Derived,
-    // never assigned from the latest event: async and blocking tools can overlap, and
-    // whichever started last is not the answer.
     function recomputeInterruptible(): void {
         const next = videoInterruptible && [...pendingToolCalls.values()].every(call => call.interruptible);
         if (next === currentInterruptible) return;
@@ -432,9 +425,6 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
         callbacks.onInterruptibleChange?.(next);
     }
 
-    // Whether a blocking-mode call is occupying the turn. Same discipline as the aggregate
-    // above -- derived from every pending call, never assigned from the latest event -- but a
-    // separate question: speech interruptibility is deliberately not folded in here.
     function recomputeBlockingToolPending(): void {
         const next = [...pendingToolCalls.values()].some(call => call.blocking);
         if (next === currentBlockingToolPending) return;
@@ -455,8 +445,7 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
             return;
         }
 
-        // The speech is over, so there is nothing left to barge in on. Lifted explicitly:
-        // this event still carries the finished speech's own flag.
+        // The done event still carries the finished speech's own flag, so lift it explicitly.
         videoInterruptible = true;
         recomputeInterruptible();
 

--- a/src/services/streaming-manager/livekit-manager.ts
+++ b/src/services/streaming-manager/livekit-manager.ts
@@ -127,8 +127,8 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
     let trackSubscriptionTimeoutId: ReturnType<typeof setTimeout> | null = null;
     let currentActivityState: AgentActivityState = AgentActivityState.Idle;
     let currentInterruptible = true;
-    // The agent's current speech, which the backend marks non-interruptible while it is
-    // speaking into a tool call. An input to the aggregate, not a second writer of it.
+    // Whether the speech currently playing can be barged in on. An input to the aggregate,
+    // not a second writer of it, and only meaningful while the agent is speaking.
     let videoInterruptible = true;
     const pendingToolCalls = new Map<string, boolean>();
     let currentTurnId: number | null = null;
@@ -424,10 +424,9 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
     }
 
     function handleVideoActivityState(subject: string, data: any): void {
-        videoInterruptible = data.metadata?.interruptible !== false;
-        recomputeInterruptible();
-
         if (subject === StreamEvents.StreamVideoCreated) {
+            videoInterruptible = data.metadata?.interruptible !== false;
+            recomputeInterruptible();
             currentActivityState = AgentActivityState.Talking;
             callbacks.onAgentActivityStateChange?.(AgentActivityState.Talking);
             audioStatsDetector?.arm({
@@ -436,6 +435,11 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
             });
             return;
         }
+
+        // The speech is over, so there is nothing left to barge in on. Lifted explicitly:
+        // this event still carries the finished speech's own flag.
+        videoInterruptible = true;
+        recomputeInterruptible();
 
         if (pendingToolCalls.size > 0) {
             if (currentActivityState !== AgentActivityState.ToolActive) {

--- a/src/types/entities/agents/manager.ts
+++ b/src/types/entities/agents/manager.ts
@@ -116,13 +116,10 @@ interface ManagerCallbacks {
      */
     onInterruptibleChange?: StreamManagerCallbacks['onInterruptibleChange'];
     /**
-     * Optional callback function that will be triggered when the set of running tool calls changes.
-     * Fires when a call starts or finishes, and with an empty array when the session disconnects.
-     *
-     * This is not the same question as `onInterruptibleChange`. That one tells you whether the user can
-     * speak right now; this one tells you whether the agent is stuck waiting. They usually move together,
-     * but not always — a tool call can hold the agent while still leaving the microphone open.
-     * @param calls - The tool calls currently running
+     * Optional callback function that will be triggered when the set of running tool calls changes,
+     * including an empty array on disconnect.
+     * @param calls - The tool calls currently running. Distinct from `onInterruptibleChange`, which
+     * answers whether the user can speak rather than whether the agent is waiting.
      */
     onRunningToolCallsChange?: StreamManagerCallbacks['onRunningToolCallsChange'];
 }

--- a/src/types/entities/agents/manager.ts
+++ b/src/types/entities/agents/manager.ts
@@ -116,10 +116,15 @@ interface ManagerCallbacks {
      */
     onInterruptibleChange?: StreamManagerCallbacks['onInterruptibleChange'];
     /**
-     * Optional callback function that will be triggered when the blocking-tool state changes
-     * @param blockingToolPending - Whether a blocking-mode tool call is pending
+     * Optional callback function that will be triggered when the set of running tool calls changes.
+     * Fires when a call starts or finishes, and with an empty array when the session disconnects.
+     *
+     * This is not the same question as `onInterruptibleChange`. That one tells you whether the user can
+     * speak right now; this one tells you whether the agent is stuck waiting. They usually move together,
+     * but not always — a tool call can hold the agent while still leaving the microphone open.
+     * @param calls - The tool calls currently running
      */
-    onBlockingToolPendingChange?: StreamManagerCallbacks['onBlockingToolPendingChange'];
+    onRunningToolCallsChange?: StreamManagerCallbacks['onRunningToolCallsChange'];
 }
 
 interface StreamOptions {

--- a/src/types/entities/agents/manager.ts
+++ b/src/types/entities/agents/manager.ts
@@ -118,8 +118,7 @@ interface ManagerCallbacks {
     /**
      * Optional callback function that will be triggered when the set of running tool calls changes,
      * including an empty array on disconnect.
-     * @param calls - The tool calls currently running. Distinct from `onInterruptibleChange`, which
-     * answers whether the user can speak rather than whether the agent is waiting.
+     * @param calls - The tool calls currently running
      */
     onRunningToolCallsChange?: StreamManagerCallbacks['onRunningToolCallsChange'];
 }

--- a/src/types/entities/agents/manager.ts
+++ b/src/types/entities/agents/manager.ts
@@ -117,8 +117,7 @@ interface ManagerCallbacks {
     onInterruptibleChange?: StreamManagerCallbacks['onInterruptibleChange'];
     /**
      * Optional callback function that will be triggered when the blocking-tool state changes
-     * @param blockingToolPending - Whether a blocking-mode tool call is pending. Distinct from
-     * interruptible: this is about the agent's turn being occupied, not about barge-in.
+     * @param blockingToolPending - Whether a blocking-mode tool call is pending
      */
     onBlockingToolPendingChange?: StreamManagerCallbacks['onBlockingToolPendingChange'];
 }

--- a/src/types/entities/agents/manager.ts
+++ b/src/types/entities/agents/manager.ts
@@ -115,6 +115,12 @@ interface ManagerCallbacks {
      * @param interruptible - Whether the agent can be interrupted by the user
      */
     onInterruptibleChange?: StreamManagerCallbacks['onInterruptibleChange'];
+    /**
+     * Optional callback function that will be triggered when the blocking-tool state changes
+     * @param blockingToolPending - Whether a blocking-mode tool call is pending. Distinct from
+     * interruptible: this is about the agent's turn being occupied, not about barge-in.
+     */
+    onBlockingToolPendingChange?: StreamManagerCallbacks['onBlockingToolPendingChange'];
 }
 
 interface StreamOptions {

--- a/src/types/stream/stream.ts
+++ b/src/types/stream/stream.ts
@@ -227,7 +227,6 @@ export interface ToolCallStartedPayload {
     input: Record<string, unknown>;
     output: Record<string, unknown>;
     interruptible: boolean;
-    // Absent from workers that predate the field, which is why anything but 'async' reads as blocking.
     execution_mode?: ToolExecutionMode;
     timestamp: string;
 }

--- a/src/types/stream/stream.ts
+++ b/src/types/stream/stream.ts
@@ -75,7 +75,7 @@ export interface ManagerCallbacks {
     onStreamReady?: () => void;
     onToolEvent?: ToolEventCallback;
     onInterruptibleChange?: (interruptible: boolean) => void;
-    onBlockingToolPendingChange?: (blockingToolPending: boolean) => void;
+    onRunningToolCallsChange?: (calls: readonly ToolCall[]) => void;
     onFirstAudioDetected?: (metrics: AudioDetectionMetrics) => void;
 }
 
@@ -220,6 +220,17 @@ export interface StreamInterruptPayload {
 export type ClientToolHandler = (args: Record<string, unknown>) => Promise<string>;
 
 export type ToolExecutionMode = 'blocking' | 'async';
+
+/** A tool call currently running in the session. */
+export interface ToolCall {
+    callId: string;
+    name: string;
+    /**
+     * 'blocking' - the agent waits for the result before it can continue.
+     * 'async' - the agent keeps talking while the call runs.
+     */
+    executionMode: 'blocking' | 'async';
+}
 
 export interface ToolCallStartedPayload {
     call_id: string;

--- a/src/types/stream/stream.ts
+++ b/src/types/stream/stream.ts
@@ -75,7 +75,7 @@ export interface ManagerCallbacks {
     onStreamReady?: () => void;
     onToolEvent?: ToolEventCallback;
     onInterruptibleChange?: (interruptible: boolean) => void;
-    onRunningToolCallsChange?: (calls: readonly ToolCall[]) => void;
+    onRunningToolCallsChange?: (calls: readonly RunningToolCall[]) => void;
     onFirstAudioDetected?: (metrics: AudioDetectionMetrics) => void;
 }
 
@@ -222,14 +222,14 @@ export type ClientToolHandler = (args: Record<string, unknown>) => Promise<strin
 export type ToolExecutionMode = 'blocking' | 'async';
 
 /** A tool call currently running in the session. */
-export interface ToolCall {
+export interface RunningToolCall {
     callId: string;
     name: string;
     /**
      * 'blocking' - the agent waits for the result before it can continue.
      * 'async' - the agent keeps talking while the call runs.
      */
-    executionMode: 'blocking' | 'async';
+    executionMode: ToolExecutionMode;
 }
 
 export interface ToolCallStartedPayload {
@@ -239,6 +239,7 @@ export interface ToolCallStartedPayload {
     output: Record<string, unknown>;
     interruptible: boolean;
     execution_mode?: ToolExecutionMode;
+    turn_id?: number | null;
     timestamp: string;
 }
 

--- a/src/types/stream/stream.ts
+++ b/src/types/stream/stream.ts
@@ -75,6 +75,7 @@ export interface ManagerCallbacks {
     onStreamReady?: () => void;
     onToolEvent?: ToolEventCallback;
     onInterruptibleChange?: (interruptible: boolean) => void;
+    onBlockingToolPendingChange?: (blockingToolPending: boolean) => void;
     onFirstAudioDetected?: (metrics: AudioDetectionMetrics) => void;
 }
 
@@ -218,12 +219,16 @@ export interface StreamInterruptPayload {
 
 export type ClientToolHandler = (args: Record<string, unknown>) => Promise<string>;
 
+export type ToolExecutionMode = 'blocking' | 'async';
+
 export interface ToolCallStartedPayload {
     call_id: string;
     name: string;
     input: Record<string, unknown>;
     output: Record<string, unknown>;
     interruptible: boolean;
+    // Absent from workers that predate the field, which is why anything but 'async' reads as blocking.
+    execution_mode?: ToolExecutionMode;
     timestamp: string;
 }
 

--- a/src/utils/tool-calls.test.ts
+++ b/src/utils/tool-calls.test.ts
@@ -1,7 +1,7 @@
-import { ToolCall } from '@sdk/types';
+import { RunningToolCall } from '@sdk/types';
 import { isAwaitingTool } from './tool-calls';
 
-const call = (callId: string, executionMode: ToolCall['executionMode']): ToolCall => ({
+const call = (callId: string, executionMode: RunningToolCall['executionMode']): RunningToolCall => ({
     callId,
     name: 'tool',
     executionMode,

--- a/src/utils/tool-calls.test.ts
+++ b/src/utils/tool-calls.test.ts
@@ -1,0 +1,26 @@
+import { ToolCall } from '@sdk/types';
+import { isAwaitingTool } from './tool-calls';
+
+const call = (callId: string, executionMode: ToolCall['executionMode']): ToolCall => ({
+    callId,
+    name: 'tool',
+    executionMode,
+});
+
+describe('isAwaitingTool', () => {
+    it('should return false when nothing is running', () => {
+        expect(isAwaitingTool([])).toBe(false);
+    });
+
+    it('should return true while a blocking call is running', () => {
+        expect(isAwaitingTool([call('a', 'blocking')])).toBe(true);
+    });
+
+    it('should return false when everything running is async', () => {
+        expect(isAwaitingTool([call('a', 'async'), call('b', 'async')])).toBe(false);
+    });
+
+    it('should return true when a blocking call runs alongside async ones', () => {
+        expect(isAwaitingTool([call('a', 'async'), call('b', 'blocking')])).toBe(true);
+    });
+});

--- a/src/utils/tool-calls.ts
+++ b/src/utils/tool-calls.ts
@@ -1,10 +1,10 @@
-import { ToolCall } from '@sdk/types';
+import { RunningToolCall } from '@sdk/types';
 
 /**
  * Whether the agent is waiting on a tool call before it can continue.
  * True while any running call is 'blocking'. False when nothing is running,
  * or when everything running is 'async' and the agent is still available.
  */
-export function isAwaitingTool(calls: readonly ToolCall[]): boolean {
+export function isAwaitingTool(calls: readonly RunningToolCall[]): boolean {
     return calls.some(call => call.executionMode === 'blocking');
 }

--- a/src/utils/tool-calls.ts
+++ b/src/utils/tool-calls.ts
@@ -1,0 +1,10 @@
+import { ToolCall } from '@sdk/types';
+
+/**
+ * Whether the agent is waiting on a tool call before it can continue.
+ * True while any running call is 'blocking'. False when nothing is running,
+ * or when everything running is 'async' and the agent is still available.
+ */
+export function isAwaitingTool(calls: readonly ToolCall[]): boolean {
+    return calls.some(call => call.executionMode === 'blocking');
+}


### PR DESCRIPTION
### Pull Request Type

🐛 BugFix

### Description

-   Derives interruptibility from all pending tool calls instead of the last event — resolves the TODO at `livekit-manager.ts`.
-   Exposes the running calls: `onRunningToolCallsChange(calls: readonly RunningToolCall[])` plus an exported `isAwaitingTool(calls)`. `RunningToolCall` is `{ callId, name, executionMode }`.

Neither `ToolActive` nor `isInterruptible` can distinguish "an async tool is open" from "the tool finished and the answer is coming" — `ToolActive` stays true until the turn ends, and an empty set reads as interruptible. That gap dropped the thinking indicator after every tool call (see de-id/agents-ui#1092).

### Technical notes

-   The aggregate is sourced from `executionMode`, not `interruptible` — which returns to meaning cancellable in de-id/streaming-orchestrator-worker#635. `onInterruptibleChange` keeps its public meaning.
-   Speech interruptibility dropped as an input: it duplicated the pending-call map with different timing.
-   Stale blocking calls are dropped at `turn/ended`, so a missing terminal event can't pin interruptibility for the session.
-   Per-call `interruptible` stays internal — it's the future cancellation flag, and no consumer needs it yet.

### Tests

`yarn test` → 526/526; `tsc --noEmit` and prettier clean.

### Rollout

Release before de-id/agents-ui#1092 — it imports `isAwaitingTool` and `RunningToolCall`, so its build fails until this ships and the pin is bumped.

### Reference Links

-   [Asana](https://app.asana.com/1/856614567666442/project/1216554029921535/task/1216473369651534?focus=true)
