### PR TITLE
feat: mid-session STT language switch

### DIFF
--- a/src/services/agent-manager/index.test.ts
+++ b/src/services/agent-manager/index.test.ts
@@ -868,6 +868,33 @@ describe('createAgentManager', () => {
         });
     });
 
+    describe('setSttLanguage', () => {
+        let manager: AgentManager;
+
+        beforeEach(async () => {
+            manager = await createAgentManager('agent-123', mockOptions);
+            await manager.connect();
+        });
+
+        it('should set STT language when available', async () => {
+            const mockSetSttLanguage = jest.fn().mockResolvedValue(undefined);
+            mockStreamingManager.setSttLanguage = mockSetSttLanguage;
+
+            await manager.setSttLanguage('French');
+
+            expect(mockSetSttLanguage).toHaveBeenCalledWith('French');
+            expect(mockAnalytics.track).toHaveBeenCalledWith('agent-stt-language-change', { language: 'French' });
+        });
+
+        it('should throw error when setSttLanguage is not available', async () => {
+            mockStreamingManager.setSttLanguage = undefined;
+
+            await expect(manager.setSttLanguage('French')).rejects.toThrow(
+                'setSttLanguage is not available for this streaming manager'
+            );
+        });
+    });
+
     describe('unpublishMicrophoneStream', () => {
         let manager: AgentManager;
 

--- a/src/services/agent-manager/index.ts
+++ b/src/services/agent-manager/index.ts
@@ -327,6 +327,15 @@ export async function createAgentManager(agent: string, options: AgentManagerOpt
             }
             return items.streamingManager.publishMicrophoneStream(stream);
         },
+        setSttLanguage(language: string): Promise<void> {
+            if (!items.streamingManager?.setSttLanguage) {
+                return Promise.reject(new Error('setSttLanguage is not available for this streaming manager'));
+            }
+
+            analytics.track('agent-stt-language-change', { language });
+
+            return items.streamingManager.setSttLanguage(language);
+        },
         unpublishMicrophoneStream(): Promise<void> {
             if (!items.streamingManager?.unpublishMicrophoneStream) {
                 return Promise.resolve();

--- a/src/services/streaming-manager/common.ts
+++ b/src/services/streaming-manager/common.ts
@@ -105,6 +105,13 @@ export type StreamingManager<T extends CreateStreamOptions | CreateSessionV2Opti
     interrupt(type: Interrupt['type']): void;
 
     /**
+     * Switch the STT language mid-session.
+     * supported only for livekit manager
+     * @param language Language name or BCP-47 code (e.g. "English" or "en-US")
+     */
+    setSttLanguage?(language: string): Promise<void>;
+
+    /**
      * Register an RPC method handler on the LiveKit room.
      * Used internally by the agent-manager for client tool delegation.
      * supported only for livekit manager

--- a/src/services/streaming-manager/common.ts
+++ b/src/services/streaming-manager/common.ts
@@ -106,6 +106,7 @@ export type StreamingManager<T extends CreateStreamOptions | CreateSessionV2Opti
 
     /**
      * Switch the STT language mid-session.
+     * Only available for Expressive (V4) agents.
      * supported only for livekit manager
      * @param language Language name or BCP-47 code (e.g. "English" or "en-US")
      */

--- a/src/services/streaming-manager/livekit-manager.test.ts
+++ b/src/services/streaming-manager/livekit-manager.test.ts
@@ -7,7 +7,7 @@ import {
     StreamingState,
     TransportProvider,
 } from '../../types/index';
-import { createLiveKitStreamingManager } from './livekit-manager';
+import { createLiveKitStreamingManager, DataChannelTopic } from './livekit-manager';
 
 // Mock livekit-client
 const mockPublishTrack = jest.fn();
@@ -318,6 +318,28 @@ describe('LiveKit Streaming Manager - Microphone Stream', () => {
                 source: 'microphone',
             });
             expect(mockPublishTrack).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('STT Language Switching', () => {
+        it('should send did.stt-language message with the language payload', async () => {
+            const manager = await createLiveKitStreamingManager(agentId, sessionOptions, options);
+            await simulateConnection();
+
+            await manager.setSttLanguage?.('French');
+
+            expect(mockLocalParticipant.sendText).toHaveBeenCalledWith(JSON.stringify({ language: 'French' }), {
+                topic: DataChannelTopic.SttLanguage,
+            });
+        });
+
+        it('should not send did.stt-language message before the room connects', async () => {
+            const manager = await createLiveKitStreamingManager(agentId, sessionOptions, options);
+
+            await manager.setSttLanguage?.('French');
+
+            expect(mockLocalParticipant.sendText).not.toHaveBeenCalled();
+            expect(options.callbacks.onError).toHaveBeenCalled();
         });
     });
 

--- a/src/services/streaming-manager/livekit-manager.ts
+++ b/src/services/streaming-manager/livekit-manager.ts
@@ -819,7 +819,8 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
         },
 
         /**
-         * Switches the server-side STT language mid-session.
+         * Switch the STT language mid-session.
+         * Only available for Expressive (V4) agents.
          * @param language - Language name or BCP-47 code (e.g. "French" or "fr-FR").
          * @returns Promise that resolves after the send attempt completes; failures are reported via onError.
          */

--- a/src/services/streaming-manager/livekit-manager.ts
+++ b/src/services/streaming-manager/livekit-manager.ts
@@ -80,6 +80,7 @@ export enum DataChannelTopic {
     Chat = 'lk.chat',
     Speak = 'did.speak',
     Interrupt = 'did.interrupt',
+    SttLanguage = 'did.stt-language',
 }
 
 type VideoMessageData = Pick<Message, 'role' | 'sentiment'>;
@@ -809,6 +810,15 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
             // a previous one is still settling causes races.
             if (type === 'text') return;
             sendDataChannelMessage(JSON.stringify({ topic: DataChannelTopic.Interrupt }));
+        },
+
+        /**
+         * Switches the server-side STT language mid-session.
+         * @param language - Language name or BCP-47 code (e.g. "French" or "fr-FR").
+         * @returns Promise that resolves after the send attempt completes; failures are reported via onError.
+         */
+        setSttLanguage(language: string) {
+            return sendMessage(JSON.stringify({ language }), DataChannelTopic.SttLanguage);
         },
 
         registerRpcMethod(method: string, handler: (data: any) => Promise<string>) {

--- a/src/services/streaming-manager/livekit-manager.ts
+++ b/src/services/streaming-manager/livekit-manager.ts
@@ -821,7 +821,7 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
         /**
          * Switch the STT language mid-session.
          * Only available for Expressive (V4) agents.
-         * @param language - Language name or BCP-47 code (e.g. "French" or "fr-FR").
+         * @param language - Language name or BCP-47 code (e.g. "English" or "en-US").
          * @returns Promise that resolves after the send attempt completes; failures are reported via onError.
          */
         setSttLanguage(language: string) {

--- a/src/types/entities/agents/manager.ts
+++ b/src/types/entities/agents/manager.ts
@@ -305,8 +305,8 @@ export interface AgentManager {
     interrupt: (interrupt: Interrupt) => void;
 
     /**
-     * Switch the server-side STT language mid-session
-     * Only available for Fluent (LiveKit) streams
+     * Switch the STT language mid-session
+     * Only available for Expressive (V4) agents
      * @param language - Language name or BCP-47 code (e.g. "English" or "en-US")
      */
     setSttLanguage: (language: string) => Promise<void>;

--- a/src/types/entities/agents/manager.ts
+++ b/src/types/entities/agents/manager.ts
@@ -305,6 +305,13 @@ export interface AgentManager {
     interrupt: (interrupt: Interrupt) => void;
 
     /**
+     * Switch the server-side STT language mid-session
+     * Only available for Fluent (LiveKit) streams
+     * @param language - Language name or BCP-47 code (e.g. "English" or "en-US")
+     */
+    setSttLanguage: (language: string) => Promise<void>;
+
+    /**
      * Register a handler for a client tool. When the agent's LLM calls this tool,
      * the handler executes on the client and returns the result to the LLM.
      * @param name - Tool name (must match the tool name defined in the agent config)


### PR DESCRIPTION
### Pull Request Type

🔮 Feature

### General Description

- Adds a `setSttLanguage(language)` method to the agent manager, allowing clients to switch the speech-to-text language in the middle of a live session.
- Available on Expressive (V4) agents.

### Technical Description

- New `DataChannelTopic.SttLanguage` (`did.stt-language`); the Expressive streaming manager sends `{"language": "..."}` as a text stream message on that topic.
- `setSttLanguage?` added to the `StreamingManager` interface (Expressive only) and delegated from the agent manager, which rejects when the active streaming manager does not support it.
- Tracks an `agent-stt-language-change` analytics event on each switch.
- Public `AgentManager` type documented with TSDoc.
- Tests: send path with the correct topic and payload, no send before the room connects (with `onError` emitted), and delegation available/unavailable cases including the analytics event.