### PR TITLE
feat: presentation data channel topic and generic sendDataMessage

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,16 @@ The `agentManager` object created during initialization has several built-in met
   await agentManager.unpublishMicrophoneStream();
   ```
 
+- **`agentManager.sendDataMessage(topic, payload)`**
+  **Supported only with Expressive (V4) agents.**
+  Method to send a JSON payload to the agent over a data-channel topic. `DataChannelTopic` is exported from the package root.
+
+  ```javascript
+  import { DataChannelTopic } from '@d-id/client-sdk';
+
+  await agentManager.sendDataMessage(DataChannelTopic.Presentation, { type: 'navigate', slide: 3 });
+  ```
+
 ### ➤ ✴️ Callback Functions
 
 Callback functions enable you to manage various events throughout the SDK lifecycle. Each function is linked to one or more methods within the built-in `agentManager` and triggers automatically to handle specific events efficiently

--- a/README.md
+++ b/README.md
@@ -173,12 +173,12 @@ The `agentManager` object created during initialization has several built-in met
 
 - **`agentManager.sendDataChannelMessage(topic, payload)`**
   **Supported only with Expressive (V4) agents.**
-  Method to send a JSON payload to the agent over a data-channel topic. `DataChannelTopic` is exported from the package root.
+  Method to send a JSON payload to the agent over a data-channel topic. `PublicDataChannelTopic` is exported from the package root and lists every topic this method accepts.
 
   ```javascript
-  import { DataChannelTopic } from '@d-id/client-sdk';
+  import { PublicDataChannelTopic } from '@d-id/client-sdk';
 
-  await agentManager.sendDataChannelMessage(DataChannelTopic.Presentation, { type: 'navigate', slide: 3 });
+  await agentManager.sendDataChannelMessage(PublicDataChannelTopic.Presentation, { type: 'navigate', slide: 3 });
   ```
 
 ### ➤ ✴️ Callback Functions

--- a/README.md
+++ b/README.md
@@ -171,14 +171,14 @@ The `agentManager` object created during initialization has several built-in met
   await agentManager.unpublishMicrophoneStream();
   ```
 
-- **`agentManager.sendDataMessage(topic, payload)`**
+- **`agentManager.sendDataChannelMessage(topic, payload)`**
   **Supported only with Expressive (V4) agents.**
   Method to send a JSON payload to the agent over a data-channel topic. `DataChannelTopic` is exported from the package root.
 
   ```javascript
   import { DataChannelTopic } from '@d-id/client-sdk';
 
-  await agentManager.sendDataMessage(DataChannelTopic.Presentation, { type: 'navigate', slide: 3 });
+  await agentManager.sendDataChannelMessage(DataChannelTopic.Presentation, { type: 'navigate', slide: 3 });
   ```
 
 ### ➤ ✴️ Callback Functions

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export * from './errors';
 export * from './services/agent-manager';
+export { DataChannelTopic } from './services/streaming-manager/livekit-manager';
 export * from './types';
 export { parseMessageParts } from './utils/content-parser';
 export { isAwaitingTool } from './utils/tool-calls';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 export * from './errors';
 export * from './services/agent-manager';
-export { DataChannelTopic } from './services/streaming-manager/livekit-manager';
 export * from './types';
 export { parseMessageParts } from './utils/content-parser';
 export { isAwaitingTool } from './utils/tool-calls';

--- a/src/services/agent-manager/index.test.ts
+++ b/src/services/agent-manager/index.test.ts
@@ -915,6 +915,9 @@ describe('createAgentManager', () => {
                 type: 'navigate',
                 slide: 3,
             });
+            expect(mockAnalytics.track).toHaveBeenCalledWith('agent-data-message', {
+                topic: DataChannelTopic.Presentation,
+            });
         });
 
         it('should throw error when sendDataMessage is not available', async () => {

--- a/src/services/agent-manager/index.test.ts
+++ b/src/services/agent-manager/index.test.ts
@@ -906,25 +906,25 @@ describe('createAgentManager', () => {
         });
 
         it('should delegate to the streaming manager when available', async () => {
-            const mockSendDataMessage = jest.fn().mockResolvedValue(undefined);
-            mockStreamingManager.sendDataMessage = mockSendDataMessage;
+            const mockSendDataChannelMessage = jest.fn();
+            mockStreamingManager.sendDataChannelMessage = mockSendDataChannelMessage;
 
             await manager.sendDataMessage(DataChannelTopic.Presentation, { type: 'navigate', slide: 3 });
 
-            expect(mockSendDataMessage).toHaveBeenCalledWith(DataChannelTopic.Presentation, {
-                type: 'navigate',
-                slide: 3,
-            });
+            expect(mockSendDataChannelMessage).toHaveBeenCalledWith(
+                DataChannelTopic.Presentation,
+                JSON.stringify({ type: 'navigate', slide: 3 })
+            );
             expect(mockAnalytics.track).toHaveBeenCalledWith('agent-data-message', {
                 topic: DataChannelTopic.Presentation,
             });
         });
 
-        it('should throw error when sendDataMessage is not available', async () => {
-            mockStreamingManager.sendDataMessage = undefined;
+        it('should throw error when sendDataChannelMessage is not available', async () => {
+            mockStreamingManager.sendDataChannelMessage = undefined;
 
             await expect(manager.sendDataMessage(DataChannelTopic.Presentation, { slide: 1 })).rejects.toThrow(
-                'sendDataMessage is not available for this streaming manager'
+                'sendDataChannelMessage is not available for this streaming manager'
             );
         });
     });

--- a/src/services/agent-manager/index.test.ts
+++ b/src/services/agent-manager/index.test.ts
@@ -871,29 +871,29 @@ describe('createAgentManager', () => {
     });
 
     describe('setSttLanguage', () => {
-        let manager: AgentManager;
+        it('should send the language on the stt-language topic for v2 agents', async () => {
+            mockAgent.avatar = { type: 'expressive', voice: { language: 'en-US' } };
 
-        beforeEach(async () => {
-            manager = await createAgentManager('agent-123', mockOptions);
+            const manager = await createAgentManager('agent-123', mockOptions);
             await manager.connect();
-        });
-
-        it('should set STT language when available', async () => {
-            const mockSetSttLanguage = jest.fn().mockResolvedValue(undefined);
-            mockStreamingManager.setSttLanguage = mockSetSttLanguage;
 
             await manager.setSttLanguage('French');
 
-            expect(mockSetSttLanguage).toHaveBeenCalledWith('French');
+            expect(mockStreamingManager.sendDataChannelMessage).toHaveBeenCalledWith(
+                DataChannelTopic.SttLanguage,
+                JSON.stringify({ language: 'French' })
+            );
             expect(mockAnalytics.track).toHaveBeenCalledWith('agent-stt-language-change', { language: 'French' });
         });
 
-        it('should throw error when setSttLanguage is not available', async () => {
-            mockStreamingManager.setSttLanguage = undefined;
+        it('should throw error when the agent is not a v2 agent', async () => {
+            const manager = await createAgentManager('agent-123', mockOptions);
+            await manager.connect();
 
             await expect(manager.setSttLanguage('French')).rejects.toThrow(
                 'setSttLanguage is not available for this streaming manager'
             );
+            expect(mockStreamingManager.sendDataChannelMessage).not.toHaveBeenCalled();
         });
     });
 

--- a/src/services/agent-manager/index.test.ts
+++ b/src/services/agent-manager/index.test.ts
@@ -919,14 +919,14 @@ describe('createAgentManager', () => {
         });
     });
 
-    describe('sendDataMessage', () => {
+    describe('sendDataChannelMessage', () => {
         it('should delegate to the streaming manager for v2 agents', async () => {
             mockAgent.avatar = { type: 'expressive', voice: { language: 'en-US' } };
 
             const manager = await createAgentManager('agent-123', mockOptions);
             await manager.connect();
 
-            await manager.sendDataMessage(DataChannelTopic.Presentation, { type: 'navigate', slide: 3 });
+            await manager.sendDataChannelMessage(DataChannelTopic.Presentation, { type: 'navigate', slide: 3 });
 
             expect(mockStreamingManager.sendDataChannelMessage).toHaveBeenCalledWith(
                 DataChannelTopic.Presentation,
@@ -941,8 +941,8 @@ describe('createAgentManager', () => {
             const manager = await createAgentManager('agent-123', mockOptions);
             await manager.connect();
 
-            await expect(manager.sendDataMessage(DataChannelTopic.Presentation, { slide: 1 })).rejects.toThrow(
-                'sendDataMessage is not available for this streaming manager'
+            await expect(manager.sendDataChannelMessage(DataChannelTopic.Presentation, { slide: 1 })).rejects.toThrow(
+                'sendDataChannelMessage is not available for this streaming manager'
             );
             expect(mockStreamingManager.sendDataChannelMessage).not.toHaveBeenCalled();
         });
@@ -958,7 +958,7 @@ describe('createAgentManager', () => {
             await manager.connect();
 
             const onSettled = jest.fn();
-            const pending = manager.sendDataMessage(DataChannelTopic.Presentation, { slide: 3 }).then(onSettled);
+            const pending = manager.sendDataChannelMessage(DataChannelTopic.Presentation, { slide: 3 }).then(onSettled);
             await Promise.resolve();
 
             expect(onSettled).not.toHaveBeenCalled();

--- a/src/services/agent-manager/index.test.ts
+++ b/src/services/agent-manager/index.test.ts
@@ -24,6 +24,7 @@ import { createChat } from '../chat';
 import { getInitialMessages } from '../chat/intial-messages';
 import { createSocketManager } from '../socket-manager';
 import { createMessageEventQueue } from '../socket-manager/message-queue';
+import { DataChannelTopic } from '../streaming-manager/livekit-manager';
 import { initializeStreamAndChat } from './connect-to-manager';
 import { createAgentManager } from './index';
 
@@ -892,6 +893,35 @@ describe('createAgentManager', () => {
 
             await expect(manager.setSttLanguage('French')).rejects.toThrow(
                 'setSttLanguage is not available for this streaming manager'
+            );
+        });
+    });
+
+    describe('sendDataMessage', () => {
+        let manager: AgentManager;
+
+        beforeEach(async () => {
+            manager = await createAgentManager('agent-123', mockOptions);
+            await manager.connect();
+        });
+
+        it('should delegate to the streaming manager when available', async () => {
+            const mockSendDataMessage = jest.fn().mockResolvedValue(undefined);
+            mockStreamingManager.sendDataMessage = mockSendDataMessage;
+
+            await manager.sendDataMessage(DataChannelTopic.Presentation, { type: 'navigate', slide: 3 });
+
+            expect(mockSendDataMessage).toHaveBeenCalledWith(DataChannelTopic.Presentation, {
+                type: 'navigate',
+                slide: 3,
+            });
+        });
+
+        it('should throw error when sendDataMessage is not available', async () => {
+            mockStreamingManager.sendDataMessage = undefined;
+
+            await expect(manager.sendDataMessage(DataChannelTopic.Presentation, { slide: 1 })).rejects.toThrow(
+                'sendDataMessage is not available for this streaming manager'
             );
         });
     });

--- a/src/services/agent-manager/index.test.ts
+++ b/src/services/agent-manager/index.test.ts
@@ -895,6 +895,28 @@ describe('createAgentManager', () => {
             );
             expect(mockStreamingManager.sendDataChannelMessage).not.toHaveBeenCalled();
         });
+
+        it('resolves only once the send settles', async () => {
+            mockAgent.avatar = { type: 'expressive', voice: { language: 'en-US' } };
+            let settleSend = () => {};
+            mockStreamingManager.sendDataChannelMessage = jest.fn(
+                () => new Promise<void>(resolve => (settleSend = resolve))
+            );
+
+            const manager = await createAgentManager('agent-123', mockOptions);
+            await manager.connect();
+
+            const onSettled = jest.fn();
+            const pending = manager.setSttLanguage('French').then(onSettled);
+            await Promise.resolve();
+
+            expect(onSettled).not.toHaveBeenCalled();
+
+            settleSend();
+            await pending;
+
+            expect(onSettled).toHaveBeenCalled();
+        });
     });
 
     describe('sendDataMessage', () => {
@@ -923,6 +945,28 @@ describe('createAgentManager', () => {
                 'sendDataMessage is not available for this streaming manager'
             );
             expect(mockStreamingManager.sendDataChannelMessage).not.toHaveBeenCalled();
+        });
+
+        it('resolves only once the send settles', async () => {
+            mockAgent.avatar = { type: 'expressive', voice: { language: 'en-US' } };
+            let settleSend = () => {};
+            mockStreamingManager.sendDataChannelMessage = jest.fn(
+                () => new Promise<void>(resolve => (settleSend = resolve))
+            );
+
+            const manager = await createAgentManager('agent-123', mockOptions);
+            await manager.connect();
+
+            const onSettled = jest.fn();
+            const pending = manager.sendDataMessage(DataChannelTopic.Presentation, { slide: 3 }).then(onSettled);
+            await Promise.resolve();
+
+            expect(onSettled).not.toHaveBeenCalled();
+
+            settleSend();
+            await pending;
+
+            expect(onSettled).toHaveBeenCalled();
         });
     });
 

--- a/src/services/agent-manager/index.test.ts
+++ b/src/services/agent-manager/index.test.ts
@@ -16,6 +16,7 @@ import {
     AgentManagerOptions,
     ChatMode,
     ConnectionState,
+    DataChannelTopic,
     Providers,
     StreamType,
 } from '../../types';
@@ -24,7 +25,6 @@ import { createChat } from '../chat';
 import { getInitialMessages } from '../chat/intial-messages';
 import { createSocketManager } from '../socket-manager';
 import { createMessageEventQueue } from '../socket-manager/message-queue';
-import { DataChannelTopic } from '../streaming-manager/livekit-manager';
 import { initializeStreamAndChat } from './connect-to-manager';
 import { createAgentManager } from './index';
 

--- a/src/services/agent-manager/index.test.ts
+++ b/src/services/agent-manager/index.test.ts
@@ -898,20 +898,15 @@ describe('createAgentManager', () => {
     });
 
     describe('sendDataMessage', () => {
-        let manager: AgentManager;
+        it('should delegate to the streaming manager for v2 agents', async () => {
+            mockAgent.avatar = { type: 'expressive', voice: { language: 'en-US' } };
 
-        beforeEach(async () => {
-            manager = await createAgentManager('agent-123', mockOptions);
+            const manager = await createAgentManager('agent-123', mockOptions);
             await manager.connect();
-        });
-
-        it('should delegate to the streaming manager when available', async () => {
-            const mockSendDataChannelMessage = jest.fn();
-            mockStreamingManager.sendDataChannelMessage = mockSendDataChannelMessage;
 
             await manager.sendDataMessage(DataChannelTopic.Presentation, { type: 'navigate', slide: 3 });
 
-            expect(mockSendDataChannelMessage).toHaveBeenCalledWith(
+            expect(mockStreamingManager.sendDataChannelMessage).toHaveBeenCalledWith(
                 DataChannelTopic.Presentation,
                 JSON.stringify({ type: 'navigate', slide: 3 })
             );
@@ -920,12 +915,14 @@ describe('createAgentManager', () => {
             });
         });
 
-        it('should throw error when sendDataChannelMessage is not available', async () => {
-            mockStreamingManager.sendDataChannelMessage = undefined;
+        it('should throw error when the agent is not a v2 agent', async () => {
+            const manager = await createAgentManager('agent-123', mockOptions);
+            await manager.connect();
 
             await expect(manager.sendDataMessage(DataChannelTopic.Presentation, { slide: 1 })).rejects.toThrow(
-                'sendDataChannelMessage is not available for this streaming manager'
+                'sendDataMessage is not available for this streaming manager'
             );
+            expect(mockStreamingManager.sendDataChannelMessage).not.toHaveBeenCalled();
         });
     });
 

--- a/src/services/agent-manager/index.test.ts
+++ b/src/services/agent-manager/index.test.ts
@@ -1,4 +1,5 @@
 import { MAX_CHAT_MESSAGE_LENGTH } from '@sdk/config/consts';
+import { DataChannelTopic } from '@sdk/types/stream/data-channel';
 import { RpcError } from 'livekit-client';
 import { createAgentsApi } from '../../api/agents';
 import {
@@ -16,8 +17,8 @@ import {
     AgentManagerOptions,
     ChatMode,
     ConnectionState,
-    DataChannelTopic,
     Providers,
+    PublicDataChannelTopic,
     StreamType,
 } from '../../types';
 import { initializeAnalytics } from '../analytics/mixpanel';
@@ -926,14 +927,14 @@ describe('createAgentManager', () => {
             const manager = await createAgentManager('agent-123', mockOptions);
             await manager.connect();
 
-            await manager.sendDataChannelMessage(DataChannelTopic.Presentation, { type: 'navigate', slide: 3 });
+            await manager.sendDataChannelMessage(PublicDataChannelTopic.Presentation, { type: 'navigate', slide: 3 });
 
             expect(mockStreamingManager.sendDataChannelMessage).toHaveBeenCalledWith(
-                DataChannelTopic.Presentation,
+                PublicDataChannelTopic.Presentation,
                 JSON.stringify({ type: 'navigate', slide: 3 })
             );
             expect(mockAnalytics.track).toHaveBeenCalledWith('agent-data-message', {
-                topic: DataChannelTopic.Presentation,
+                topic: PublicDataChannelTopic.Presentation,
             });
         });
 
@@ -941,9 +942,9 @@ describe('createAgentManager', () => {
             const manager = await createAgentManager('agent-123', mockOptions);
             await manager.connect();
 
-            await expect(manager.sendDataChannelMessage(DataChannelTopic.Presentation, { slide: 1 })).rejects.toThrow(
-                'sendDataChannelMessage is not available for this streaming manager'
-            );
+            await expect(
+                manager.sendDataChannelMessage(PublicDataChannelTopic.Presentation, { slide: 1 })
+            ).rejects.toThrow('sendDataChannelMessage is not available for this streaming manager');
             expect(mockStreamingManager.sendDataChannelMessage).not.toHaveBeenCalled();
         });
 
@@ -958,7 +959,9 @@ describe('createAgentManager', () => {
             await manager.connect();
 
             const onSettled = jest.fn();
-            const pending = manager.sendDataChannelMessage(DataChannelTopic.Presentation, { slide: 3 }).then(onSettled);
+            const pending = manager
+                .sendDataChannelMessage(PublicDataChannelTopic.Presentation, { slide: 3 })
+                .then(onSettled);
             await Promise.resolve();
 
             expect(onSettled).not.toHaveBeenCalled();

--- a/src/services/agent-manager/index.ts
+++ b/src/services/agent-manager/index.ts
@@ -34,7 +34,7 @@ import { getInitialMessages } from '../chat/intial-messages';
 import { SocketManager, createSocketManager } from '../socket-manager';
 import { createMessageEventQueue } from '../socket-manager/message-queue';
 import { StreamingManager } from '../streaming-manager';
-import type { DataChannelTopic } from '../streaming-manager/livekit-manager';
+import { DataChannelTopic } from '../streaming-manager/livekit-manager';
 import { initializeStreamAndChat } from './connect-to-manager';
 
 export interface AgentManagerItems {
@@ -344,13 +344,15 @@ export async function createAgentManager(agent: string, options: AgentManagerOpt
             return items.streamingManager.publishMicrophoneStream(stream);
         },
         setSttLanguage(language: string): Promise<void> {
-            if (!items.streamingManager?.setSttLanguage) {
+            if (!isStreamsV2 || !items.streamingManager) {
                 return Promise.reject(new Error('setSttLanguage is not available for this streaming manager'));
             }
 
             analytics.track('agent-stt-language-change', { language });
 
-            return items.streamingManager.setSttLanguage(language);
+            items.streamingManager.sendDataChannelMessage(DataChannelTopic.SttLanguage, JSON.stringify({ language }));
+
+            return Promise.resolve();
         },
         sendDataMessage(topic: DataChannelTopic, payload: Record<string, unknown>): Promise<void> {
             if (!items.streamingManager?.sendDataChannelMessage) {
@@ -435,7 +437,7 @@ export async function createAgentManager(agent: string, options: AgentManagerOpt
 
                 const chatRequestFn = useV2Path
                     ? async () => {
-                          await items.streamingManager?.sendTextMessage?.(userMessage);
+                          items.streamingManager?.sendDataChannelMessage(DataChannelTopic.Chat, userMessage);
                           return Promise.resolve({} as ChatResponse);
                       }
                     : async () => {

--- a/src/services/agent-manager/index.ts
+++ b/src/services/agent-manager/index.ts
@@ -353,13 +353,15 @@ export async function createAgentManager(agent: string, options: AgentManagerOpt
             return items.streamingManager.setSttLanguage(language);
         },
         sendDataMessage(topic: DataChannelTopic, payload: Record<string, unknown>): Promise<void> {
-            if (!items.streamingManager?.sendDataMessage) {
-                return Promise.reject(new Error('sendDataMessage is not available for this streaming manager'));
+            if (!items.streamingManager?.sendDataChannelMessage) {
+                return Promise.reject(new Error('sendDataChannelMessage is not available for this streaming manager'));
             }
 
             analytics.track('agent-data-message', { topic });
 
-            return items.streamingManager.sendDataMessage(topic, payload);
+            items.streamingManager.sendDataChannelMessage(topic, JSON.stringify(payload));
+
+            return Promise.resolve();
         },
         unpublishMicrophoneStream(): Promise<void> {
             if (!items.streamingManager?.unpublishMicrophoneStream) {

--- a/src/services/agent-manager/index.ts
+++ b/src/services/agent-manager/index.ts
@@ -357,6 +357,8 @@ export async function createAgentManager(agent: string, options: AgentManagerOpt
                 return Promise.reject(new Error('sendDataMessage is not available for this streaming manager'));
             }
 
+            analytics.track('agent-data-message', { topic });
+
             return items.streamingManager.sendDataMessage(topic, payload);
         },
         unpublishMicrophoneStream(): Promise<void> {

--- a/src/services/agent-manager/index.ts
+++ b/src/services/agent-manager/index.ts
@@ -355,8 +355,8 @@ export async function createAgentManager(agent: string, options: AgentManagerOpt
             return Promise.resolve();
         },
         sendDataMessage(topic: DataChannelTopic, payload: Record<string, unknown>): Promise<void> {
-            if (!items.streamingManager?.sendDataChannelMessage) {
-                return Promise.reject(new Error('sendDataChannelMessage is not available for this streaming manager'));
+            if (!isStreamsV2 || !items.streamingManager) {
+                return Promise.reject(new Error('sendDataMessage is not available for this streaming manager'));
             }
 
             analytics.track('agent-data-message', { topic });

--- a/src/services/agent-manager/index.ts
+++ b/src/services/agent-manager/index.ts
@@ -1,3 +1,4 @@
+import { DataChannelTopic } from '@sdk/types/stream/data-channel';
 import {
     AgentManager,
     AgentManagerOptions,
@@ -7,9 +8,9 @@ import {
     ClientToolHandler,
     ConnectionState,
     CreateStreamOptions,
-    DataChannelTopic,
     Interrupt,
     Message,
+    PublicDataChannelTopic,
     StreamScript,
     SupportedStreamScript,
 } from '../../types';
@@ -355,7 +356,7 @@ export async function createAgentManager(agent: string, options: AgentManagerOpt
                 JSON.stringify({ language })
             );
         },
-        sendDataChannelMessage(topic: DataChannelTopic, payload: Record<string, unknown>): Promise<void> {
+        sendDataChannelMessage(topic: PublicDataChannelTopic, payload: Record<string, unknown>): Promise<void> {
             if (!isStreamsV2 || !items.streamingManager) {
                 return Promise.reject(new Error('sendDataChannelMessage is not available for this streaming manager'));
             }

--- a/src/services/agent-manager/index.ts
+++ b/src/services/agent-manager/index.ts
@@ -350,9 +350,10 @@ export async function createAgentManager(agent: string, options: AgentManagerOpt
 
             analytics.track('agent-stt-language-change', { language });
 
-            items.streamingManager.sendDataChannelMessage(DataChannelTopic.SttLanguage, JSON.stringify({ language }));
-
-            return Promise.resolve();
+            return items.streamingManager.sendDataChannelMessage(
+                DataChannelTopic.SttLanguage,
+                JSON.stringify({ language })
+            );
         },
         sendDataMessage(topic: DataChannelTopic, payload: Record<string, unknown>): Promise<void> {
             if (!isStreamsV2 || !items.streamingManager) {
@@ -361,9 +362,7 @@ export async function createAgentManager(agent: string, options: AgentManagerOpt
 
             analytics.track('agent-data-message', { topic });
 
-            items.streamingManager.sendDataChannelMessage(topic, JSON.stringify(payload));
-
-            return Promise.resolve();
+            return items.streamingManager.sendDataChannelMessage(topic, JSON.stringify(payload));
         },
         unpublishMicrophoneStream(): Promise<void> {
             if (!items.streamingManager?.unpublishMicrophoneStream) {
@@ -437,7 +436,7 @@ export async function createAgentManager(agent: string, options: AgentManagerOpt
 
                 const chatRequestFn = useV2Path
                     ? async () => {
-                          items.streamingManager?.sendDataChannelMessage(DataChannelTopic.Chat, userMessage);
+                          await items.streamingManager?.sendDataChannelMessage(DataChannelTopic.Chat, userMessage);
                           return Promise.resolve({} as ChatResponse);
                       }
                     : async () => {

--- a/src/services/agent-manager/index.ts
+++ b/src/services/agent-manager/index.ts
@@ -355,9 +355,9 @@ export async function createAgentManager(agent: string, options: AgentManagerOpt
                 JSON.stringify({ language })
             );
         },
-        sendDataMessage(topic: DataChannelTopic, payload: Record<string, unknown>): Promise<void> {
+        sendDataChannelMessage(topic: DataChannelTopic, payload: Record<string, unknown>): Promise<void> {
             if (!isStreamsV2 || !items.streamingManager) {
-                return Promise.reject(new Error('sendDataMessage is not available for this streaming manager'));
+                return Promise.reject(new Error('sendDataChannelMessage is not available for this streaming manager'));
             }
 
             analytics.track('agent-data-message', { topic });

--- a/src/services/agent-manager/index.ts
+++ b/src/services/agent-manager/index.ts
@@ -34,6 +34,7 @@ import { getInitialMessages } from '../chat/intial-messages';
 import { SocketManager, createSocketManager } from '../socket-manager';
 import { createMessageEventQueue } from '../socket-manager/message-queue';
 import { StreamingManager } from '../streaming-manager';
+import type { DataChannelTopic } from '../streaming-manager/livekit-manager';
 import { initializeStreamAndChat } from './connect-to-manager';
 
 export interface AgentManagerItems {
@@ -350,6 +351,13 @@ export async function createAgentManager(agent: string, options: AgentManagerOpt
             analytics.track('agent-stt-language-change', { language });
 
             return items.streamingManager.setSttLanguage(language);
+        },
+        sendDataMessage(topic: DataChannelTopic, payload: Record<string, unknown>): Promise<void> {
+            if (!items.streamingManager?.sendDataMessage) {
+                return Promise.reject(new Error('sendDataMessage is not available for this streaming manager'));
+            }
+
+            return items.streamingManager.sendDataMessage(topic, payload);
         },
         unpublishMicrophoneStream(): Promise<void> {
             if (!items.streamingManager?.unpublishMicrophoneStream) {

--- a/src/services/agent-manager/index.ts
+++ b/src/services/agent-manager/index.ts
@@ -7,6 +7,7 @@ import {
     ClientToolHandler,
     ConnectionState,
     CreateStreamOptions,
+    DataChannelTopic,
     Interrupt,
     Message,
     StreamScript,
@@ -34,7 +35,6 @@ import { getInitialMessages } from '../chat/intial-messages';
 import { SocketManager, createSocketManager } from '../socket-manager';
 import { createMessageEventQueue } from '../socket-manager/message-queue';
 import { StreamingManager } from '../streaming-manager';
-import { DataChannelTopic } from '../streaming-manager/livekit-manager';
 import { initializeStreamAndChat } from './connect-to-manager';
 
 export interface AgentManagerItems {

--- a/src/services/streaming-manager/advanced.test.ts
+++ b/src/services/streaming-manager/advanced.test.ts
@@ -201,7 +201,7 @@ describe('Streaming Manager Advanced', () => {
 
             mockDC.readyState = 'connecting';
 
-            manager.sendDataChannelMessage('test-message');
+            manager.sendDataChannelMessage('did.test', 'test-message');
 
             expect(options.callbacks.onError).toHaveBeenCalledWith(expect.any(Error), { streamId: 'streamId' });
         });

--- a/src/services/streaming-manager/advanced.test.ts
+++ b/src/services/streaming-manager/advanced.test.ts
@@ -1,10 +1,11 @@
+import { DataChannelTopic } from '@sdk/types/stream/data-channel';
 /**
  * Advanced functionality tests for streaming manager
  * Tests complex scenarios, edge cases, and advanced features
  */
 
 import { StreamApiFactory, StreamingAgentFactory, StreamingManagerOptionsFactory } from '../../test-utils/factories';
-import { CreateStreamOptions, DataChannelTopic, StreamType, StreamingManagerOptions } from '../../types/index';
+import { CreateStreamOptions, StreamType, StreamingManagerOptions } from '../../types/index';
 import { createVideoStatsMonitor } from './stats/poll';
 import {
     createParseDataChannelMessage,

--- a/src/services/streaming-manager/advanced.test.ts
+++ b/src/services/streaming-manager/advanced.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { StreamApiFactory, StreamingAgentFactory, StreamingManagerOptionsFactory } from '../../test-utils/factories';
-import { CreateStreamOptions, StreamType, StreamingManagerOptions } from '../../types/index';
+import { CreateStreamOptions, DataChannelTopic, StreamType, StreamingManagerOptions } from '../../types/index';
 import { createVideoStatsMonitor } from './stats/poll';
 import {
     createParseDataChannelMessage,
@@ -201,7 +201,7 @@ describe('Streaming Manager Advanced', () => {
 
             mockDC.readyState = 'connecting';
 
-            manager.sendDataChannelMessage('did.test', 'test-message');
+            manager.sendDataChannelMessage(DataChannelTopic.Interrupt, 'test-message');
 
             expect(options.callbacks.onError).toHaveBeenCalledWith(expect.any(Error), { streamId: 'streamId' });
         });

--- a/src/services/streaming-manager/common.ts
+++ b/src/services/streaming-manager/common.ts
@@ -9,7 +9,9 @@ export const createStreamingLogger = (debug: boolean, prefix: string) => (messag
  */
 export type StreamingManager<T extends CreateStreamOptions | CreateSessionV2Options> = {
     /**
-     * Method to send request to server to get clip or talk depending on payload
+     * Method to send request to server to get clip or talk depending on payload.
+     * Each implementation owns the transport details (V1 posts a stream request
+     * to the API; V2 sends the serialized payload on the `did.speak` topic).
      * @param payload The payload to send to the streaming service
      */
     speak(payload: PayloadType<T>): Promise<any>;
@@ -20,21 +22,18 @@ export type StreamingManager<T extends CreateStreamOptions | CreateSessionV2Opti
     disconnect(): Promise<void>;
 
     /**
-     * Method to send a serialized message to the agent over the data channel.
-     * LiveKit sends it as a text stream on the given topic; WebRTC sends the
-     * payload as-is on the RTC data channel and ignores the topic, having no
-     * topic concept.
+     * The single send primitive: every message leaving the client goes out
+     * through here. LiveKit sends it as a text stream on the given topic;
+     * WebRTC sends the payload as-is on the RTC data channel and ignores the
+     * topic, having no topic concept. Callers that need a specific message
+     * (chat, STT language, presentation, ...) call this with the matching
+     * topic rather than getting a method of their own; only `speak` and
+     * `interrupt` keep members, because their mechanics genuinely differ per
+     * transport, and whatever they put on the data channel goes through here.
      * @param topic Data-channel topic to send on (see `DataChannelTopic`)
      * @param payload The message payload to send, already serialized
      */
     sendDataChannelMessage(topic: string, payload: string): void;
-
-    /**
-     * Method to send text messages to the server
-     * @param payload The message payload to send
-     * supported only for livekit manager
-     */
-    sendTextMessage?(payload: string): Promise<void>;
 
     /**
      * Publish a microphone stream to the DataChannel
@@ -107,14 +106,6 @@ export type StreamingManager<T extends CreateStreamOptions | CreateSessionV2Opti
      * `did.interrupt` and ignores `text` interrupts to avoid races).
      */
     interrupt(type: Interrupt['type']): void;
-
-    /**
-     * Switch the STT language mid-session.
-     * Only available for Expressive (V4) agents.
-     * supported only for livekit manager
-     * @param language Language name or BCP-47 code (e.g. "English" or "en-US")
-     */
-    setSttLanguage?(language: string): Promise<void>;
 
     /**
      * Register an RPC method handler on the LiveKit room.

--- a/src/services/streaming-manager/common.ts
+++ b/src/services/streaming-manager/common.ts
@@ -1,5 +1,4 @@
 import { CreateSessionV2Options, CreateStreamOptions, Interrupt, PayloadType, StreamType } from '@sdk/types';
-import type { DataChannelTopic } from './livekit-manager';
 
 export const createStreamingLogger = (debug: boolean, prefix: string) => (message: string, extra?: any) =>
     debug && console.log(`[${prefix}] ${message}`, extra ?? '');
@@ -21,11 +20,14 @@ export type StreamingManager<T extends CreateStreamOptions | CreateSessionV2Opti
     disconnect(): Promise<void>;
 
     /**
-     * Method to send data channel messages to the server
-     * @param payload The message payload to send
-     * supported only for webrtc manager
+     * Method to send a serialized message to the agent over the data channel.
+     * LiveKit sends it as a text stream on the given topic; WebRTC sends the
+     * payload as-is on the RTC data channel and ignores the topic, having no
+     * topic concept.
+     * @param topic Data-channel topic to send on (see `DataChannelTopic`)
+     * @param payload The message payload to send, already serialized
      */
-    sendDataChannelMessage?(payload: string): void;
+    sendDataChannelMessage(topic: string, payload: string): void;
 
     /**
      * Method to send text messages to the server
@@ -113,14 +115,6 @@ export type StreamingManager<T extends CreateStreamOptions | CreateSessionV2Opti
      * @param language Language name or BCP-47 code (e.g. "English" or "en-US")
      */
     setSttLanguage?(language: string): Promise<void>;
-
-    /**
-     * Send a JSON payload to the agent over a data-channel topic.
-     * supported only for livekit manager
-     * @param topic Data-channel topic to send on
-     * @param payload Plain object, serialized as JSON
-     */
-    sendDataMessage?(topic: DataChannelTopic, payload: Record<string, unknown>): Promise<void>;
 
     /**
      * Register an RPC method handler on the LiveKit room.

--- a/src/services/streaming-manager/common.ts
+++ b/src/services/streaming-manager/common.ts
@@ -1,11 +1,5 @@
-import {
-    CreateSessionV2Options,
-    CreateStreamOptions,
-    DataChannelTopic,
-    Interrupt,
-    PayloadType,
-    StreamType,
-} from '@sdk/types';
+import { CreateSessionV2Options, CreateStreamOptions, Interrupt, PayloadType, StreamType } from '@sdk/types';
+import { DataChannelTopic } from '@sdk/types/stream/data-channel';
 
 export const createStreamingLogger = (debug: boolean, prefix: string) => (message: string, extra?: any) =>
     debug && console.log(`[${prefix}] ${message}`, extra ?? '');

--- a/src/services/streaming-manager/common.ts
+++ b/src/services/streaming-manager/common.ts
@@ -1,4 +1,5 @@
 import { CreateSessionV2Options, CreateStreamOptions, Interrupt, PayloadType, StreamType } from '@sdk/types';
+import type { DataChannelTopic } from './livekit-manager';
 
 export const createStreamingLogger = (debug: boolean, prefix: string) => (message: string, extra?: any) =>
     debug && console.log(`[${prefix}] ${message}`, extra ?? '');
@@ -111,6 +112,14 @@ export type StreamingManager<T extends CreateStreamOptions | CreateSessionV2Opti
      * @param language Language name or BCP-47 code (e.g. "English" or "en-US")
      */
     setSttLanguage?(language: string): Promise<void>;
+
+    /**
+     * Send a JSON payload to the agent over a data-channel topic.
+     * supported only for livekit manager
+     * @param topic Data-channel topic to send on
+     * @param payload Plain object, serialized as JSON
+     */
+    sendDataMessage?(topic: DataChannelTopic, payload: Record<string, unknown>): Promise<void>;
 
     /**
      * Register an RPC method handler on the LiveKit room.

--- a/src/services/streaming-manager/common.ts
+++ b/src/services/streaming-manager/common.ts
@@ -37,10 +37,12 @@ export type StreamingManager<T extends CreateStreamOptions | CreateSessionV2Opti
      * topic rather than getting a method of their own; only `speak` and
      * `interrupt` keep members, because their mechanics genuinely differ per
      * transport, and whatever they put on the data channel goes through here.
+     * The returned promise tracks the send attempt and never rejects - send
+     * failures are reported through `callbacks.onError`.
      * @param topic Data-channel topic to send on
      * @param payload The message payload to send, already serialized
      */
-    sendDataChannelMessage(topic: DataChannelTopic, payload: string): void;
+    sendDataChannelMessage(topic: DataChannelTopic, payload: string): Promise<void>;
 
     /**
      * Publish a microphone stream to the DataChannel

--- a/src/services/streaming-manager/common.ts
+++ b/src/services/streaming-manager/common.ts
@@ -1,4 +1,11 @@
-import { CreateSessionV2Options, CreateStreamOptions, Interrupt, PayloadType, StreamType } from '@sdk/types';
+import {
+    CreateSessionV2Options,
+    CreateStreamOptions,
+    DataChannelTopic,
+    Interrupt,
+    PayloadType,
+    StreamType,
+} from '@sdk/types';
 
 export const createStreamingLogger = (debug: boolean, prefix: string) => (message: string, extra?: any) =>
     debug && console.log(`[${prefix}] ${message}`, extra ?? '');
@@ -30,10 +37,10 @@ export type StreamingManager<T extends CreateStreamOptions | CreateSessionV2Opti
      * topic rather than getting a method of their own; only `speak` and
      * `interrupt` keep members, because their mechanics genuinely differ per
      * transport, and whatever they put on the data channel goes through here.
-     * @param topic Data-channel topic to send on (see `DataChannelTopic`)
+     * @param topic Data-channel topic to send on
      * @param payload The message payload to send, already serialized
      */
-    sendDataChannelMessage(topic: string, payload: string): void;
+    sendDataChannelMessage(topic: DataChannelTopic, payload: string): void;
 
     /**
      * Publish a microphone stream to the DataChannel

--- a/src/services/streaming-manager/common.ts
+++ b/src/services/streaming-manager/common.ts
@@ -16,9 +16,7 @@ export const createStreamingLogger = (debug: boolean, prefix: string) => (messag
  */
 export type StreamingManager<T extends CreateStreamOptions | CreateSessionV2Options> = {
     /**
-     * Method to send request to server to get clip or talk depending on payload.
-     * Each implementation owns the transport details (V1 posts a stream request
-     * to the API; V2 sends the serialized payload on the `did.speak` topic).
+     * Method to send request to server to get clip or talk depending on payload
      * @param payload The payload to send to the streaming service
      */
     speak(payload: PayloadType<T>): Promise<any>;
@@ -29,16 +27,9 @@ export type StreamingManager<T extends CreateStreamOptions | CreateSessionV2Opti
     disconnect(): Promise<void>;
 
     /**
-     * The single send primitive: every message leaving the client goes out
-     * through here. LiveKit sends it as a text stream on the given topic;
-     * WebRTC sends the payload as-is on the RTC data channel and ignores the
-     * topic, having no topic concept. Callers that need a specific message
-     * (chat, STT language, presentation, ...) call this with the matching
-     * topic rather than getting a method of their own; only `speak` and
-     * `interrupt` keep members, because their mechanics genuinely differ per
-     * transport, and whatever they put on the data channel goes through here.
-     * The returned promise tracks the send attempt and never rejects - send
-     * failures are reported through `callbacks.onError`.
+     * The single send primitive: every message leaving the client goes out through here.
+     * V2 routes on the topic; V1 has no topic concept and ignores it.
+     * The promise tracks the send attempt and never rejects - failures go to `callbacks.onError`.
      * @param topic Data-channel topic to send on
      * @param payload The message payload to send, already serialized
      */
@@ -109,10 +100,7 @@ export type StreamingManager<T extends CreateStreamOptions | CreateSessionV2Opti
     isInterruptible: boolean;
 
     /**
-     * Send an interrupt for the current stream segment.
-     * Each implementation owns the validation/transport details (e.g. V1
-     * sends a `stream/interrupt` payload over the data channel; V2 sends
-     * `did.interrupt` and ignores `text` interrupts to avoid races).
+     * Send an interrupt for the current stream segment
      */
     interrupt(type: Interrupt['type']): void;
 

--- a/src/services/streaming-manager/common.ts
+++ b/src/services/streaming-manager/common.ts
@@ -23,8 +23,9 @@ export type StreamingManager<T extends CreateStreamOptions | CreateSessionV2Opti
     /**
      * Method to send data channel messages to the server
      * @param payload The message payload to send
+     * supported only for webrtc manager
      */
-    sendDataChannelMessage(payload: string): void;
+    sendDataChannelMessage?(payload: string): void;
 
     /**
      * Method to send text messages to the server

--- a/src/services/streaming-manager/edge-cases.test.ts
+++ b/src/services/streaming-manager/edge-cases.test.ts
@@ -1,3 +1,4 @@
+import { DataChannelTopic } from '@sdk/types/stream/data-channel';
 /**
  * Edge cases and branch coverage tests for streaming manager
  * Tests detailed edge cases, error conditions, and branch coverage scenarios
@@ -8,7 +9,6 @@ import {
     AgentActivityState,
     ConnectionState,
     CreateStreamOptions,
-    DataChannelTopic,
     StreamType,
     StreamingManagerOptions,
 } from '../../types/index';

--- a/src/services/streaming-manager/edge-cases.test.ts
+++ b/src/services/streaming-manager/edge-cases.test.ts
@@ -68,7 +68,7 @@ describe('Streaming Manager Edge Cases', () => {
             const mockDC = mockPC.createDataChannel.mock.results[0].value;
 
             mockDC.readyState = 'connecting';
-            manager.sendDataChannelMessage('test');
+            manager.sendDataChannelMessage('did.test', 'test');
             expect(options.callbacks.onError).toHaveBeenCalled();
 
             mockDC.readyState = 'open';
@@ -232,15 +232,15 @@ describe('Streaming Manager Edge Cases', () => {
             const mockDC = mockPC.createDataChannel.mock.results[0].value;
 
             mockDC.readyState = 'connecting';
-            manager.sendDataChannelMessage('test1');
+            manager.sendDataChannelMessage('did.test', 'test1');
             expect(options.callbacks.onError).toHaveBeenCalled();
 
             mockDC.readyState = 'closing';
-            manager.sendDataChannelMessage('test2');
+            manager.sendDataChannelMessage('did.test', 'test2');
             expect(options.callbacks.onError).toHaveBeenCalled();
 
             mockDC.readyState = 'closed';
-            manager.sendDataChannelMessage('test3');
+            manager.sendDataChannelMessage('did.test', 'test3');
             expect(options.callbacks.onError).toHaveBeenCalled();
         });
 
@@ -538,7 +538,7 @@ describe('Streaming Manager Edge Cases', () => {
             mockPC.iceConnectionState = 'connected';
             mockPC.oniceconnectionstatechange();
 
-            manager.sendDataChannelMessage('test-message');
+            manager.sendDataChannelMessage('did.test', 'test-message');
 
             await manager.disconnect();
 

--- a/src/services/streaming-manager/edge-cases.test.ts
+++ b/src/services/streaming-manager/edge-cases.test.ts
@@ -8,6 +8,7 @@ import {
     AgentActivityState,
     ConnectionState,
     CreateStreamOptions,
+    DataChannelTopic,
     StreamType,
     StreamingManagerOptions,
 } from '../../types/index';
@@ -68,7 +69,7 @@ describe('Streaming Manager Edge Cases', () => {
             const mockDC = mockPC.createDataChannel.mock.results[0].value;
 
             mockDC.readyState = 'connecting';
-            manager.sendDataChannelMessage('did.test', 'test');
+            manager.sendDataChannelMessage(DataChannelTopic.Interrupt, 'test');
             expect(options.callbacks.onError).toHaveBeenCalled();
 
             mockDC.readyState = 'open';
@@ -232,15 +233,15 @@ describe('Streaming Manager Edge Cases', () => {
             const mockDC = mockPC.createDataChannel.mock.results[0].value;
 
             mockDC.readyState = 'connecting';
-            manager.sendDataChannelMessage('did.test', 'test1');
+            manager.sendDataChannelMessage(DataChannelTopic.Interrupt, 'test1');
             expect(options.callbacks.onError).toHaveBeenCalled();
 
             mockDC.readyState = 'closing';
-            manager.sendDataChannelMessage('did.test', 'test2');
+            manager.sendDataChannelMessage(DataChannelTopic.Interrupt, 'test2');
             expect(options.callbacks.onError).toHaveBeenCalled();
 
             mockDC.readyState = 'closed';
-            manager.sendDataChannelMessage('did.test', 'test3');
+            manager.sendDataChannelMessage(DataChannelTopic.Interrupt, 'test3');
             expect(options.callbacks.onError).toHaveBeenCalled();
         });
 
@@ -538,7 +539,7 @@ describe('Streaming Manager Edge Cases', () => {
             mockPC.iceConnectionState = 'connected';
             mockPC.oniceconnectionstatechange();
 
-            manager.sendDataChannelMessage('did.test', 'test-message');
+            manager.sendDataChannelMessage(DataChannelTopic.Interrupt, 'test-message');
 
             await manager.disconnect();
 

--- a/src/services/streaming-manager/livekit-manager.test.ts
+++ b/src/services/streaming-manager/livekit-manager.test.ts
@@ -348,7 +348,10 @@ describe('LiveKit Streaming Manager - Microphone Stream', () => {
             const manager = await createLiveKitStreamingManager(agentId, sessionOptions, options);
             await simulateConnection();
 
-            await manager.sendDataMessage?.(DataChannelTopic.Presentation, { type: 'navigate', slide: 12 });
+            manager.sendDataChannelMessage(
+                DataChannelTopic.Presentation,
+                JSON.stringify({ type: 'navigate', slide: 12 })
+            );
 
             expect(mockLocalParticipant.sendText).toHaveBeenCalledWith(
                 JSON.stringify({ type: 'navigate', slide: 12 }),
@@ -359,7 +362,10 @@ describe('LiveKit Streaming Manager - Microphone Stream', () => {
         it('does not send and reports error when not connected', async () => {
             const manager = await createLiveKitStreamingManager(agentId, sessionOptions, options);
 
-            await manager.sendDataMessage?.(DataChannelTopic.Presentation, { type: 'navigate', slide: 1 });
+            manager.sendDataChannelMessage(
+                DataChannelTopic.Presentation,
+                JSON.stringify({ type: 'navigate', slide: 1 })
+            );
 
             expect(mockLocalParticipant.sendText).not.toHaveBeenCalled();
             expect(options.callbacks.onError).toHaveBeenCalled();

--- a/src/services/streaming-manager/livekit-manager.test.ts
+++ b/src/services/streaming-manager/livekit-manager.test.ts
@@ -343,6 +343,29 @@ describe('LiveKit Streaming Manager - Microphone Stream', () => {
         });
     });
 
+    describe('Generic Data Message', () => {
+        it('sends a JSON payload over the given topic', async () => {
+            const manager = await createLiveKitStreamingManager(agentId, sessionOptions, options);
+            await simulateConnection();
+
+            await manager.sendDataMessage?.(DataChannelTopic.Presentation, { type: 'navigate', slide: 12 });
+
+            expect(mockLocalParticipant.sendText).toHaveBeenCalledWith(
+                JSON.stringify({ type: 'navigate', slide: 12 }),
+                { topic: DataChannelTopic.Presentation }
+            );
+        });
+
+        it('does not send and reports error when not connected', async () => {
+            const manager = await createLiveKitStreamingManager(agentId, sessionOptions, options);
+
+            await manager.sendDataMessage?.(DataChannelTopic.Presentation, { type: 'navigate', slide: 1 });
+
+            expect(mockLocalParticipant.sendText).not.toHaveBeenCalled();
+            expect(options.callbacks.onError).toHaveBeenCalled();
+        });
+    });
+
     describe('Error Handling', () => {
         it('should throw error on publish failure', async () => {
             const mockStream = createMockStream();

--- a/src/services/streaming-manager/livekit-manager.test.ts
+++ b/src/services/streaming-manager/livekit-manager.test.ts
@@ -326,7 +326,7 @@ describe('LiveKit Streaming Manager - Microphone Stream', () => {
             const manager = await createLiveKitStreamingManager(agentId, sessionOptions, options);
             await simulateConnection();
 
-            await manager.setSttLanguage?.('French');
+            manager.sendDataChannelMessage(DataChannelTopic.SttLanguage, JSON.stringify({ language: 'French' }));
 
             expect(mockLocalParticipant.sendText).toHaveBeenCalledWith(JSON.stringify({ language: 'French' }), {
                 topic: DataChannelTopic.SttLanguage,
@@ -336,7 +336,7 @@ describe('LiveKit Streaming Manager - Microphone Stream', () => {
         it('should not send did.stt-language message before the room connects', async () => {
             const manager = await createLiveKitStreamingManager(agentId, sessionOptions, options);
 
-            await manager.setSttLanguage?.('French');
+            manager.sendDataChannelMessage(DataChannelTopic.SttLanguage, JSON.stringify({ language: 'French' }));
 
             expect(mockLocalParticipant.sendText).not.toHaveBeenCalled();
             expect(options.callbacks.onError).toHaveBeenCalled();

--- a/src/services/streaming-manager/livekit-manager.test.ts
+++ b/src/services/streaming-manager/livekit-manager.test.ts
@@ -2,12 +2,13 @@ import { StreamingManagerOptionsFactory } from '../../test-utils/factories';
 import {
     AgentActivityState,
     CreateSessionV2Options,
+    DataChannelTopic,
     StreamEvents,
     StreamingManagerOptions,
     StreamingState,
     TransportProvider,
 } from '../../types/index';
-import { createLiveKitStreamingManager, DataChannelTopic } from './livekit-manager';
+import { createLiveKitStreamingManager } from './livekit-manager';
 
 // Mock livekit-client
 const mockPublishTrack = jest.fn();

--- a/src/services/streaming-manager/livekit-manager.test.ts
+++ b/src/services/streaming-manager/livekit-manager.test.ts
@@ -1,8 +1,8 @@
+import { DataChannelTopic } from '@sdk/types/stream/data-channel';
 import { StreamingManagerOptionsFactory } from '../../test-utils/factories';
 import {
     AgentActivityState,
     CreateSessionV2Options,
-    DataChannelTopic,
     StreamEvents,
     StreamingManagerOptions,
     StreamingState,

--- a/src/services/streaming-manager/livekit-manager.ts
+++ b/src/services/streaming-manager/livekit-manager.ts
@@ -91,6 +91,7 @@ export enum DataChannelTopic {
     Speak = 'did.speak',
     Interrupt = 'did.interrupt',
     SttLanguage = 'did.stt-language',
+    Presentation = 'did.presentation',
 }
 
 type VideoMessageData = Pick<Message, 'role' | 'sentiment'>;
@@ -871,6 +872,16 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
          */
         setSttLanguage(language: string) {
             return sendMessage(JSON.stringify({ language }), DataChannelTopic.SttLanguage);
+        },
+
+        /**
+         * Send a JSON payload to the agent over a data-channel topic.
+         * @param topic - The topic to send on.
+         * @param payload - Plain object, serialized as JSON.
+         * @returns Promise that resolves after the send attempt completes; failures are reported via onError.
+         */
+        sendDataMessage(topic: DataChannelTopic, payload: Record<string, unknown>) {
+            return sendMessage(JSON.stringify(payload), topic);
         },
 
         registerRpcMethod(method: string, handler: (data: any) => Promise<string>) {

--- a/src/services/streaming-manager/livekit-manager.ts
+++ b/src/services/streaming-manager/livekit-manager.ts
@@ -5,6 +5,7 @@ import {
     ConnectivityState,
     CreateSessionV2Options,
     CreateStreamOptions,
+    DataChannelTopic,
     Interrupt,
     Message,
     PayloadType,
@@ -85,14 +86,6 @@ const connectivityQualityToState = {
 };
 
 const streamError = (message = 'Stream Error') => new StreamError(message);
-
-export enum DataChannelTopic {
-    Chat = 'lk.chat',
-    Speak = 'did.speak',
-    Interrupt = 'did.interrupt',
-    SttLanguage = 'did.stt-language',
-    Presentation = 'did.presentation',
-}
 
 type VideoMessageData = Pick<Message, 'role' | 'sentiment'>;
 
@@ -726,7 +719,7 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
         }
     }
 
-    async function sendDataChannelMessage(topic: string, payload: string) {
+    async function sendDataChannelMessage(topic: DataChannelTopic, payload: string) {
         if (!isConnected || !room) {
             log('Room is not connected for sending messages');
             callbacks.onError?.(streamError(), {

--- a/src/services/streaming-manager/livekit-manager.ts
+++ b/src/services/streaming-manager/livekit-manager.ts
@@ -744,17 +744,6 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
         }
     }
 
-    async function sendDataChannelMessage(payload: string) {
-        try {
-            const parsed = JSON.parse(payload);
-            const topic = parsed.topic;
-            return sendMessage('', topic);
-        } catch (error) {
-            log('Failed to send data channel message:', error);
-            callbacks.onError?.(streamError(), { sessionId });
-        }
-    }
-
     function sendTextMessage(message: string) {
         return sendMessage(message, DataChannelTopic.Chat);
     }
@@ -848,7 +837,6 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
             }
         },
 
-        sendDataChannelMessage,
         sendTextMessage,
         publishMicrophoneStream,
         unpublishMicrophoneStream,
@@ -861,7 +849,7 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
             // cancel the in-flight LLM token stream, and an extra interrupt while
             // a previous one is still settling causes races.
             if (type === 'text') return;
-            sendDataChannelMessage(JSON.stringify({ topic: DataChannelTopic.Interrupt }));
+            sendMessage('', DataChannelTopic.Interrupt);
         },
 
         /**

--- a/src/services/streaming-manager/livekit-manager.ts
+++ b/src/services/streaming-manager/livekit-manager.ts
@@ -5,7 +5,6 @@ import {
     ConnectivityState,
     CreateSessionV2Options,
     CreateStreamOptions,
-    DataChannelTopic,
     Interrupt,
     Message,
     PayloadType,
@@ -20,6 +19,7 @@ import {
     TurnEventPayload,
 } from '@sdk/types';
 import { ChatProgress } from '@sdk/types/entities/agents/manager';
+import { DataChannelTopic } from '@sdk/types/stream/data-channel';
 import { noop } from '@sdk/utils';
 import { getUserContextAttributes } from '@sdk/utils/user-context';
 import { createStreamApiV2 } from '../../api/streams/streamsApiV2';

--- a/src/services/streaming-manager/livekit-manager.ts
+++ b/src/services/streaming-manager/livekit-manager.ts
@@ -726,7 +726,7 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
         }
     }
 
-    async function sendMessage(message: string, topic: string) {
+    async function sendDataChannelMessage(topic: string, payload: string) {
         if (!isConnected || !room) {
             log('Room is not connected for sending messages');
             callbacks.onError?.(streamError(), {
@@ -736,20 +736,12 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
         }
 
         try {
-            await room.localParticipant.sendText(message, { topic });
-            log('Message sent successfully:', message);
+            await room.localParticipant.sendText(payload, { topic });
+            log('Message sent successfully:', payload);
         } catch (error) {
             log('Failed to send message:', error);
             callbacks.onError?.(streamError(), { sessionId });
         }
-    }
-
-    function sendDataChannelMessage(topic: string, payload: string) {
-        return sendMessage(payload, topic);
-    }
-
-    function sendTextMessage(message: string) {
-        return sendDataChannelMessage(DataChannelTopic.Chat, message);
     }
 
     async function disconnect(reason: string) {
@@ -841,7 +833,6 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
             }
         },
 
-        sendTextMessage,
         sendDataChannelMessage,
         publishMicrophoneStream,
         unpublishMicrophoneStream,
@@ -855,16 +846,6 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
             // a previous one is still settling causes races.
             if (type === 'text') return;
             sendDataChannelMessage(DataChannelTopic.Interrupt, '');
-        },
-
-        /**
-         * Switch the STT language mid-session.
-         * Only available for Expressive (V4) agents.
-         * @param language - Language name or BCP-47 code (e.g. "English" or "en-US").
-         * @returns Promise that resolves after the send attempt completes; failures are reported via onError.
-         */
-        setSttLanguage(language: string) {
-            return sendDataChannelMessage(DataChannelTopic.SttLanguage, JSON.stringify({ language }));
         },
 
         registerRpcMethod(method: string, handler: (data: any) => Promise<string>) {

--- a/src/services/streaming-manager/livekit-manager.ts
+++ b/src/services/streaming-manager/livekit-manager.ts
@@ -726,7 +726,7 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
         }
     }
 
-    async function sendMessage(message: string, topic: DataChannelTopic) {
+    async function sendMessage(message: string, topic: string) {
         if (!isConnected || !room) {
             log('Room is not connected for sending messages');
             callbacks.onError?.(streamError(), {
@@ -744,8 +744,12 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
         }
     }
 
+    function sendDataChannelMessage(topic: string, payload: string) {
+        return sendMessage(payload, topic);
+    }
+
     function sendTextMessage(message: string) {
-        return sendMessage(message, DataChannelTopic.Chat);
+        return sendDataChannelMessage(DataChannelTopic.Chat, message);
     }
 
     async function disconnect(reason: string) {
@@ -778,7 +782,7 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
     return {
         speak(payload: PayloadType<T>) {
             const message = typeof payload === 'string' ? payload : JSON.stringify(payload);
-            return sendMessage(message, DataChannelTopic.Speak);
+            return sendDataChannelMessage(DataChannelTopic.Speak, message);
         },
 
         disconnect: () => disconnect('user:disconnect'),
@@ -838,6 +842,7 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
         },
 
         sendTextMessage,
+        sendDataChannelMessage,
         publishMicrophoneStream,
         unpublishMicrophoneStream,
         replaceMicrophoneTrack,
@@ -849,7 +854,7 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
             // cancel the in-flight LLM token stream, and an extra interrupt while
             // a previous one is still settling causes races.
             if (type === 'text') return;
-            sendMessage('', DataChannelTopic.Interrupt);
+            sendDataChannelMessage(DataChannelTopic.Interrupt, '');
         },
 
         /**
@@ -859,17 +864,7 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
          * @returns Promise that resolves after the send attempt completes; failures are reported via onError.
          */
         setSttLanguage(language: string) {
-            return sendMessage(JSON.stringify({ language }), DataChannelTopic.SttLanguage);
-        },
-
-        /**
-         * Send a JSON payload to the agent over a data-channel topic.
-         * @param topic - The topic to send on.
-         * @param payload - Plain object, serialized as JSON.
-         * @returns Promise that resolves after the send attempt completes; failures are reported via onError.
-         */
-        sendDataMessage(topic: DataChannelTopic, payload: Record<string, unknown>) {
-            return sendMessage(JSON.stringify(payload), topic);
+            return sendDataChannelMessage(DataChannelTopic.SttLanguage, JSON.stringify({ language }));
         },
 
         registerRpcMethod(method: string, handler: (data: any) => Promise<string>) {

--- a/src/services/streaming-manager/webrtc-core.test.ts
+++ b/src/services/streaming-manager/webrtc-core.test.ts
@@ -1,16 +1,11 @@
+import { DataChannelTopic } from '@sdk/types/stream/data-channel';
 /**
  * Core functionality tests for streaming manager
  * Tests basic streaming manager creation, connection, and operations
  */
 
 import { StreamApiFactory, StreamingAgentFactory, StreamingManagerOptionsFactory } from '../../test-utils/factories';
-import {
-    ConnectionState,
-    CreateStreamOptions,
-    DataChannelTopic,
-    StreamType,
-    StreamingManagerOptions,
-} from '../../types/index';
+import { ConnectionState, CreateStreamOptions, StreamType, StreamingManagerOptions } from '../../types/index';
 import { createVideoStatsMonitor } from './stats/poll';
 import { createWebRTCStreamingManager as createStreamingManager } from './webrtc-manager';
 

--- a/src/services/streaming-manager/webrtc-core.test.ts
+++ b/src/services/streaming-manager/webrtc-core.test.ts
@@ -4,7 +4,13 @@
  */
 
 import { StreamApiFactory, StreamingAgentFactory, StreamingManagerOptionsFactory } from '../../test-utils/factories';
-import { ConnectionState, CreateStreamOptions, StreamType, StreamingManagerOptions } from '../../types/index';
+import {
+    ConnectionState,
+    CreateStreamOptions,
+    DataChannelTopic,
+    StreamType,
+    StreamingManagerOptions,
+} from '../../types/index';
 import { createVideoStatsMonitor } from './stats/poll';
 import { createWebRTCStreamingManager as createStreamingManager } from './webrtc-manager';
 
@@ -168,7 +174,7 @@ describe('Streaming Manager Core', () => {
         it('should send data channel message when connected', async () => {
             const manager = await createStreamingManager(agentId, agentStreamOptions, options);
 
-            expect(() => manager.sendDataChannelMessage('did.test', 'test:message')).not.toThrow();
+            expect(() => manager.sendDataChannelMessage(DataChannelTopic.Interrupt, 'test:message')).not.toThrow();
             expect(typeof manager.sendDataChannelMessage).toBe('function');
             expect(typeof manager.speak).toBe('function');
             expect(typeof manager.disconnect).toBe('function');
@@ -180,7 +186,7 @@ describe('Streaming Manager Core', () => {
             const mockDC = mockPC.createDataChannel.mock.results[0].value;
             mockPC.iceConnectionState = 'new';
             mockDC.readyState = 'closed';
-            manager.sendDataChannelMessage('did.test', 'test:message');
+            manager.sendDataChannelMessage(DataChannelTopic.Interrupt, 'test:message');
             expect(mockDC.send).not.toHaveBeenCalled();
             expect(options.callbacks.onError).toHaveBeenCalled();
         });
@@ -204,7 +210,7 @@ describe('Streaming Manager Core', () => {
                 throw new Error('Send failed');
             });
 
-            manager.sendDataChannelMessage('did.test', 'test:message');
+            manager.sendDataChannelMessage(DataChannelTopic.Interrupt, 'test:message');
             expect(options.callbacks.onError).toHaveBeenCalledWith(expect.any(Error), { streamId: 'streamId' });
         });
     });

--- a/src/services/streaming-manager/webrtc-core.test.ts
+++ b/src/services/streaming-manager/webrtc-core.test.ts
@@ -168,7 +168,7 @@ describe('Streaming Manager Core', () => {
         it('should send data channel message when connected', async () => {
             const manager = await createStreamingManager(agentId, agentStreamOptions, options);
 
-            expect(() => manager.sendDataChannelMessage('test:message')).not.toThrow();
+            expect(() => manager.sendDataChannelMessage('did.test', 'test:message')).not.toThrow();
             expect(typeof manager.sendDataChannelMessage).toBe('function');
             expect(typeof manager.speak).toBe('function');
             expect(typeof manager.disconnect).toBe('function');
@@ -180,7 +180,7 @@ describe('Streaming Manager Core', () => {
             const mockDC = mockPC.createDataChannel.mock.results[0].value;
             mockPC.iceConnectionState = 'new';
             mockDC.readyState = 'closed';
-            manager.sendDataChannelMessage('test:message');
+            manager.sendDataChannelMessage('did.test', 'test:message');
             expect(mockDC.send).not.toHaveBeenCalled();
             expect(options.callbacks.onError).toHaveBeenCalled();
         });
@@ -204,7 +204,7 @@ describe('Streaming Manager Core', () => {
                 throw new Error('Send failed');
             });
 
-            manager.sendDataChannelMessage('test:message');
+            manager.sendDataChannelMessage('did.test', 'test:message');
             expect(options.callbacks.onError).toHaveBeenCalledWith(expect.any(Error), { streamId: 'streamId' });
         });
     });

--- a/src/services/streaming-manager/webrtc-manager.ts
+++ b/src/services/streaming-manager/webrtc-manager.ts
@@ -326,7 +326,7 @@ export async function createWebRTCStreamingManager<T extends CreateStreamOptions
     await startConnection(streamIdFromServer, sessionClientAnswer, session_id, signal);
     log('start connection OK');
 
-    function sendDataChannelMessage(_topic: DataChannelTopic, payload: string) {
+    async function sendDataChannelMessage(_topic: DataChannelTopic, payload: string) {
         if (!isConnected || pcDataChannel.readyState !== 'open') {
             log('Data channel is not ready for sending messages');
             callbacks.onError?.(new StreamError('Data channel is not ready for sending messages'), {

--- a/src/services/streaming-manager/webrtc-manager.ts
+++ b/src/services/streaming-manager/webrtc-manager.ts
@@ -149,7 +149,7 @@ export async function createWebRTCStreamingManager<T extends CreateStreamOptions
     streamOptions: T,
     { debug = false, callbacks, auth, baseURL = didApiUrl, analytics }: StreamingManagerOptions,
     signal?: AbortSignal
-): Promise<StreamingManager<T>> {
+): Promise<StreamingManager<T> & { sendDataChannelMessage(payload: string): void }> {
     const log = createStreamingLogger(debug, 'WebRTCStreamingManager');
     const parseDataChannelMessage = createParseDataChannelMessage(log);
 

--- a/src/services/streaming-manager/webrtc-manager.ts
+++ b/src/services/streaming-manager/webrtc-manager.ts
@@ -5,6 +5,7 @@ import {
     AgentActivityState,
     ConnectionState,
     CreateStreamOptions,
+    DataChannelTopic,
     Interrupt,
     PayloadType,
     StreamEvents,
@@ -325,7 +326,7 @@ export async function createWebRTCStreamingManager<T extends CreateStreamOptions
     await startConnection(streamIdFromServer, sessionClientAnswer, session_id, signal);
     log('start connection OK');
 
-    function sendDataChannelMessage(_topic: string, payload: string) {
+    function sendDataChannelMessage(_topic: DataChannelTopic, payload: string) {
         if (!isConnected || pcDataChannel.readyState !== 'open') {
             log('Data channel is not ready for sending messages');
             callbacks.onError?.(new StreamError('Data channel is not ready for sending messages'), {
@@ -418,7 +419,9 @@ export async function createWebRTCStreamingManager<T extends CreateStreamOptions
                 videoId: currentVideoId,
                 timestamp: Date.now(),
             };
-            sendDataChannelMessage(StreamEvents.StreamInterrupt, JSON.stringify(payload));
+            // The topic is ignored here - V1 has no topic concept and the interrupt
+            // is identified by the payload's `type`.
+            sendDataChannelMessage(DataChannelTopic.Interrupt, JSON.stringify(payload));
         },
     };
 }

--- a/src/services/streaming-manager/webrtc-manager.ts
+++ b/src/services/streaming-manager/webrtc-manager.ts
@@ -149,7 +149,7 @@ export async function createWebRTCStreamingManager<T extends CreateStreamOptions
     streamOptions: T,
     { debug = false, callbacks, auth, baseURL = didApiUrl, analytics }: StreamingManagerOptions,
     signal?: AbortSignal
-): Promise<StreamingManager<T> & { sendDataChannelMessage(payload: string): void }> {
+): Promise<StreamingManager<T>> {
     const log = createStreamingLogger(debug, 'WebRTCStreamingManager');
     const parseDataChannelMessage = createParseDataChannelMessage(log);
 
@@ -325,7 +325,7 @@ export async function createWebRTCStreamingManager<T extends CreateStreamOptions
     await startConnection(streamIdFromServer, sessionClientAnswer, session_id, signal);
     log('start connection OK');
 
-    function sendDataChannelMessage(payload: string) {
+    function sendDataChannelMessage(_topic: string, payload: string) {
         if (!isConnected || pcDataChannel.readyState !== 'open') {
             log('Data channel is not ready for sending messages');
             callbacks.onError?.(new StreamError('Data channel is not ready for sending messages'), {
@@ -418,7 +418,7 @@ export async function createWebRTCStreamingManager<T extends CreateStreamOptions
                 videoId: currentVideoId,
                 timestamp: Date.now(),
             };
-            sendDataChannelMessage(JSON.stringify(payload));
+            sendDataChannelMessage(StreamEvents.StreamInterrupt, JSON.stringify(payload));
         },
     };
 }

--- a/src/services/streaming-manager/webrtc-manager.ts
+++ b/src/services/streaming-manager/webrtc-manager.ts
@@ -5,7 +5,6 @@ import {
     AgentActivityState,
     ConnectionState,
     CreateStreamOptions,
-    DataChannelTopic,
     Interrupt,
     PayloadType,
     StreamEvents,
@@ -14,6 +13,7 @@ import {
     StreamInterruptPayload,
     StreamType,
 } from '@sdk/types';
+import { DataChannelTopic } from '@sdk/types/stream/data-channel';
 import { createStreamingLogger, StreamingManager } from './common';
 import { createVideoStatsMonitor } from './stats/poll';
 import { VideoRTCStatsReport } from './stats/report';

--- a/src/types/entities/agents/manager.ts
+++ b/src/types/entities/agents/manager.ts
@@ -6,7 +6,7 @@ import {
     CompatibilityMode,
     ConnectionState,
     ConnectivityState,
-    DataChannelTopic,
+    PublicDataChannelTopic,
     SendStreamPayloadResponse,
     StreamEvents,
     StreamType,
@@ -321,10 +321,10 @@ export interface AgentManager {
     /**
      * Send a JSON payload to the agent over a data-channel topic
      * Only available for Expressive (V4) agents
-     * @param topic - Data-channel topic to send on (see `DataChannelTopic`)
+     * @param topic - Data-channel topic to send on (see `PublicDataChannelTopic`)
      * @param payload - Plain object, serialized as JSON
      */
-    sendDataChannelMessage: (topic: DataChannelTopic, payload: Record<string, unknown>) => Promise<void>;
+    sendDataChannelMessage: (topic: PublicDataChannelTopic, payload: Record<string, unknown>) => Promise<void>;
 
     /**
      * Register a handler for a client tool. When the agent's LLM calls this tool,

--- a/src/types/entities/agents/manager.ts
+++ b/src/types/entities/agents/manager.ts
@@ -324,7 +324,7 @@ export interface AgentManager {
      * @param topic - Data-channel topic to send on (see `DataChannelTopic`)
      * @param payload - Plain object, serialized as JSON
      */
-    sendDataMessage: (topic: DataChannelTopic, payload: Record<string, unknown>) => Promise<void>;
+    sendDataChannelMessage: (topic: DataChannelTopic, payload: Record<string, unknown>) => Promise<void>;
 
     /**
      * Register a handler for a client tool. When the agent's LLM calls this tool,

--- a/src/types/entities/agents/manager.ts
+++ b/src/types/entities/agents/manager.ts
@@ -1,4 +1,3 @@
-import type { DataChannelTopic } from '@sdk/services/streaming-manager/livekit-manager';
 import { STTTokenResponse } from '@sdk/types';
 import { Auth } from '@sdk/types/auth';
 import {
@@ -7,6 +6,7 @@ import {
     CompatibilityMode,
     ConnectionState,
     ConnectivityState,
+    DataChannelTopic,
     SendStreamPayloadResponse,
     StreamEvents,
     StreamType,

--- a/src/types/entities/agents/manager.ts
+++ b/src/types/entities/agents/manager.ts
@@ -1,3 +1,4 @@
+import type { DataChannelTopic } from '@sdk/services/streaming-manager/livekit-manager';
 import { STTTokenResponse } from '@sdk/types';
 import { Auth } from '@sdk/types/auth';
 import {
@@ -316,6 +317,14 @@ export interface AgentManager {
      * @param language - Language name or BCP-47 code (e.g. "English" or "en-US")
      */
     setSttLanguage: (language: string) => Promise<void>;
+
+    /**
+     * Send a JSON payload to the agent over a data-channel topic
+     * Only available for Expressive (V4) agents
+     * @param topic - Data-channel topic to send on (see `DataChannelTopic`)
+     * @param payload - Plain object, serialized as JSON
+     */
+    sendDataMessage: (topic: DataChannelTopic, payload: Record<string, unknown>) => Promise<void>;
 
     /**
      * Register a handler for a client tool. When the agent's LLM calls this tool,

--- a/src/types/stream/data-channel.ts
+++ b/src/types/stream/data-channel.ts
@@ -1,0 +1,16 @@
+/**
+ * Data-channel topics messages can be sent on.
+ * V2 (LiveKit) routes by topic; V1 (WebRTC) has no topic concept and ignores it.
+ *
+ * Internal on purpose: this module is deliberately left out of the `stream`
+ * barrel so the topics driven by dedicated methods (`chat`, `speak`,
+ * `interrupt`, `setSttLanguage`) never reach the package's public API.
+ * Customers get `PublicDataChannelTopic` instead.
+ */
+export enum DataChannelTopic {
+    Chat = 'lk.chat',
+    Speak = 'did.speak',
+    Interrupt = 'did.interrupt',
+    SttLanguage = 'did.stt-language',
+    Presentation = 'did.presentation',
+}

--- a/src/types/stream/stream.ts
+++ b/src/types/stream/stream.ts
@@ -3,6 +3,7 @@ import { VideoRTCStatsReport } from '@sdk/services/streaming-manager/stats/repor
 import { Auth } from '../auth';
 import { ChatProgressCallback } from '../entities/agents/manager';
 import { CreateClipStreamRequest, CreateTalkStreamRequest, SendClipStreamPayload, SendTalkStreamPayload } from './api';
+import { DataChannelTopic } from './data-channel';
 import { ICreateStreamRequestResponse, IceCandidate, SendStreamPayloadResponse, Status } from './rtc';
 
 export type CompatibilityMode = 'on' | 'off' | 'auto';
@@ -47,16 +48,17 @@ export enum StreamEvents {
 }
 
 /**
- * Data-channel topics messages can be sent on.
- * V2 (LiveKit) routes by topic; V1 (WebRTC) has no topic concept and ignores it.
+ * Topics a customer can send on via `agentManager.sendDataChannelMessage`.
+ * The remaining `DataChannelTopic` members are driven by their own methods
+ * (`chat`, `speak`, `interrupt`, `setSttLanguage`), which own the payload shape
+ * and bookkeeping those topics expect, so they stay internal.
+ *
+ * A const object rather than a second enum: it borrows the value from
+ * `DataChannelTopic`, so there is one source of truth for the wire string and
+ * no cast is needed where the topic reaches the transport.
  */
-export enum DataChannelTopic {
-    Chat = 'lk.chat',
-    Speak = 'did.speak',
-    Interrupt = 'did.interrupt',
-    SttLanguage = 'did.stt-language',
-    Presentation = 'did.presentation',
-}
+export const PublicDataChannelTopic = { Presentation: DataChannelTopic.Presentation } as const;
+export type PublicDataChannelTopic = (typeof PublicDataChannelTopic)[keyof typeof PublicDataChannelTopic];
 
 export enum ConnectionState {
     New = 'new',

--- a/src/types/stream/stream.ts
+++ b/src/types/stream/stream.ts
@@ -46,6 +46,18 @@ export enum StreamEvents {
     TurnEnded = 'turn/ended',
 }
 
+/**
+ * Data-channel topics messages can be sent on.
+ * V2 (LiveKit) routes by topic; V1 (WebRTC) has no topic concept and ignores it.
+ */
+export enum DataChannelTopic {
+    Chat = 'lk.chat',
+    Speak = 'did.speak',
+    Interrupt = 'did.interrupt',
+    SttLanguage = 'did.stt-language',
+    Presentation = 'did.presentation',
+}
+
 export enum ConnectionState {
     New = 'new',
     Fail = 'fail',


### PR DESCRIPTION
### Pull Request Type

🔮 Feature

### Description

- Presenter Mode client machinery: `DataChannelTopic.Presentation = 'did.presentation'` and a generic `sendDataChannelMessage(topic, payload)` on the `AgentManager` (JSON over the LiveKit text-stream path, same as `did.stt-language`), consumed by agents-ui's presenter UI via dev:local-sdk. Documented in the README alongside the other Expressive-only methods.
- Send-surface cleanup (review-driven): the `StreamingManager` type now has ONE send primitive, `sendDataChannelMessage(topic: DataChannelTopic, payload: string): Promise<void>`, implemented by both transports — LiveKit routes it over the topic'd text stream; WebRTC sends the payload as-is and ignores the topic (it has no topic concept). LiveKit's private `sendMessage` twin is gone (the public method is the implementation), and the members that were only a topic in disguise moved to their call sites: the V2 chat path sends on `lk.chat` and the agent-manager's `setSttLanguage` sends on `did.stt-language`, so `sendTextMessage` and `StreamingManager.setSttLanguage` are deleted. Only `speak` and `interrupt` keep members, because their mechanics genuinely differ per transport (V1 `speak` posts a stream request; V1 `interrupt` sends a `stream/interrupt` payload where V2 sends an empty `did.interrupt`), and everything they put on the data channel goes through the primitive. The old LiveKit `sendDataChannelMessage(payload)` wrapper is deleted — it JSON-parsed the payload only to read `.topic` and then sent an empty body (a latent bug), and the test-only intersection type on the WebRTC factory is gone.
- `DataChannelTopic` moved out of `livekit-manager.ts` into `src/types/stream` next to `StreamEvents`, which removes the types→service import edge and the cycle that typing the primitive would otherwise have created; the package root still exports it, so the public surface is unchanged. The topic is now typed `DataChannelTopic` (not `string`) on the shared type, both implementations and the AgentManager method.
- Type-surface changes for SDK consumers: `StreamingManager`'s send-ish surface is now `sendDataChannelMessage` + `speak` + `interrupt`; `DataChannelTopic` is exported from the package root; `AgentManager` gains a required `sendDataChannelMessage(topic, payload)` — same name as the transport primitive it stringifies into, one concept with one name at both layers. `AgentManager.setSttLanguage` keeps its signature and its promise contract: it resolves when the send settles, as it did on main. Wire behavior is byte-identical on both transports (pinned by the existing sendText / dataChannel.send assertions).
- Regression caught in review and fixed (`cc56144`): moving the call sites had dropped two `await`s against LiveKit's async send — the V2 chat path and `setSttLanguage`, which had started returning `Promise.resolve()` — because the shared type declared the primitive `void`; it is now typed `Promise<void>`, WebRTC's implementation is async to match, and both callers await/return the send's promise again (the promise tracks the send attempt and never rejects — failures route to `onError`, on main too). `sendDataChannelMessage` is gated to Expressive (V4) agents as its doc says (`1d96caa`).
- Analytics: `agent-data-message` Mixpanel event with `{ topic }` (mirroring `setSttLanguage`); the event name stays as-is for analytics consumers even after the method rename. The duplicate UI-level navigate event was removed in agents-ui.
- Tests: `yarn ci:test` 536/536 (534 + two pins that the send is awaited); coverage above all thresholds; lint clean.
- Release path: merge to main publishes a `staging`-tagged version; agents-ui #1105 no-ops safely on the published 2.0.6 pin and bumps after promotion.

### Reference Links

-   [Asana](https://app.asana.com/1/856614567666442/project/1216943078884032/task/1216943731956184?focus=true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJftELCLQpj4MUq1Z86JwB
