### PR TITLE
fix: forward persistentChat to streams v2 session creation

### DIFF
--- a/src/services/agent-manager/connect-to-manager.test.ts
+++ b/src/services/agent-manager/connect-to-manager.test.ts
@@ -679,6 +679,7 @@ describe('connect-to-manager', () => {
                     transport: {
                         provider: TransportProvider.Livekit,
                     },
+                    chat_persist: true,
                 },
                 expect.not.objectContaining({
                     chatId: expect.anything(),
@@ -695,6 +696,43 @@ describe('connect-to-manager', () => {
 
             // Verify createChat is NOT called for V2 agents (chat is created internally)
             expect(createChat).not.toHaveBeenCalled();
+        });
+
+        it.each([
+            ['forwards persistentChat: false as chat_persist: false', false, { chat_persist: false }],
+            ['forwards persistentChat: true as chat_persist: true', true, { chat_persist: true }],
+        ])('%s', async (_name, persistentChat, expectedSessionOptions) => {
+            const expressiveAgent: Agent = {
+                ...mockAgent,
+                avatar: { type: 'expressive', voice: { language: 'en-US' } },
+            };
+
+            await initializeStreamAndChat(
+                expressiveAgent,
+                { ...mockOptions, persistentChat },
+                mockAgentsApi,
+                mockAnalytics
+            );
+
+            expect(createStreamingManager).toHaveBeenCalledWith(
+                expressiveAgent,
+                expect.objectContaining({ version: StreamApiVersion.V2, ...expectedSessionOptions }),
+                expect.anything(),
+                undefined
+            );
+        });
+
+        it('should omit chat_persist when persistentChat is not set', async () => {
+            const expressiveAgent: Agent = {
+                ...mockAgent,
+                avatar: { type: 'expressive', voice: { language: 'en-US' } },
+            };
+            const { persistentChat: _persistentChat, ...optionsWithoutPersistentChat } = mockOptions;
+
+            await initializeStreamAndChat(expressiveAgent, optionsWithoutPersistentChat, mockAgentsApi, mockAnalytics);
+
+            const [, sessionOptions] = (createStreamingManager as jest.Mock).mock.calls[0];
+            expect(sessionOptions).not.toHaveProperty('chat_persist');
         });
 
         it('should use CreateStreamOptions for non-expressive agents', async () => {

--- a/src/services/agent-manager/connect-to-manager.ts
+++ b/src/services/agent-manager/connect-to-manager.ts
@@ -35,11 +35,12 @@ import {
 import { createChat } from '../chat';
 
 const ChatPrefix = 'cht';
-function getAgentStreamV2Options(): CreateSessionV2Options {
+function getAgentStreamV2Options(options?: ConnectToManagerOptions): CreateSessionV2Options {
     return {
         transport: {
             provider: TransportProvider.Livekit,
         },
+        ...(options?.persistentChat !== undefined && { chat_persist: options.persistentChat }),
     };
 }
 
@@ -66,7 +67,7 @@ function getAgentStreamV1Options(options?: ConnectToManagerOptions): CreateStrea
 
 function getAgentStreamOptions(agent: Agent, options?: ConnectToManagerOptions): ExtendedStreamOptions {
     return isStreamsV2Agent(agent.avatar.type)
-        ? { version: StreamApiVersion.V2, ...getAgentStreamV2Options() }
+        ? { version: StreamApiVersion.V2, ...getAgentStreamV2Options(options) }
         : { version: StreamApiVersion.V1, ...getAgentStreamV1Options(options) };
 }
 

--- a/src/services/streaming-manager/livekit-manager.test.ts
+++ b/src/services/streaming-manager/livekit-manager.test.ts
@@ -1362,6 +1362,20 @@ describe('LiveKit Streaming Manager - Verbose Mode', () => {
 
         expect(mockCreateStream).toHaveBeenCalledWith(expect.objectContaining({ verbose: false }));
     });
+
+    it('sends chat_persist: false in the createStream request when explicitly disabled', async () => {
+        await createLiveKitStreamingManager(agentId, { ...sessionOptions, chat_persist: false }, options);
+
+        expect(mockCreateStream).toHaveBeenCalledWith(expect.objectContaining({ chat_persist: false }));
+    });
+
+    it('defaults chat_persist to true in the createStream request when unset', async () => {
+        const { chat_persist: _chatPersist, ...sessionOptionsWithoutChatPersist } = sessionOptions;
+
+        await createLiveKitStreamingManager(agentId, sessionOptionsWithoutChatPersist, options);
+
+        expect(mockCreateStream).toHaveBeenCalledWith(expect.objectContaining({ chat_persist: true }));
+    });
 });
 
 describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {


### PR DESCRIPTION
### Pull Request Type

🐛 BugFix

### Description

-   `persistentChat` only reached the v1 chat endpoint (`POST /agents/{id}/chat`). Expressive (LiveKit) agents create the chat as part of session creation, and `getAgentStreamV2Options` never populated `chat_persist` — so the backend always applied its `true` default, and customers passing `persistentChat: false` silently got persisted chats.
-   Maps `persistentChat` → `chat_persist` on the v2 session payload (`POST /v2/agents/{id}/sessions`), omitting the field when unset so both the v1 and v2 backend defaults stay exactly as they are today. Only an explicit value changes behavior.
-   Tests for `true` / `false` / omitted-when-unset on the v2 options builder, plus LiveKit-manager coverage that an explicit `false` survives the existing `?? true` default.

Behavior matrix:

| `persistentChat` | v1 (`talk`/`clip`) → `persist` | v2 (`expressive`) → `chat_persist` |
| ---------------- | ------------------------------ | ---------------------------------- |
| unset            | `false` (unchanged)            | `true` (unchanged)                 |
| `true`           | `true` (unchanged)             | `true` (**was** always `true`)     |
| `false`          | `false` (unchanged)            | `false` (**was** `true`)           |

The v1/v2 unset-default asymmetry is left in place on purpose — aligning them would change behavior for everyone who omits the flag — and is now documented on `AgentManagerOptions.persistentChat`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
