### PR TITLE
fix: type DocumentData.status as the values the API actually serves

### DIFF
--- a/src/types/entities/knowledge/document.ts
+++ b/src/types/entities/knowledge/document.ts
@@ -1,8 +1,19 @@
-import { KnowledgeType } from './knowledge';
+import { DocumentType, KnowledgeType } from './knowledge';
 
+/**
+ * Lifecycle status of a document, as served by the knowledge API. The API stores the
+ * status as a prefixed event subject (`document/done`) but strips the prefix on read,
+ * so the wire value is always bare.
+ */
+export type DocumentStatus = 'created' | 'processed' | 'done' | 'rejected' | 'error';
+
+/**
+ * @deprecated The knowledge API has never served these prefixed values — it strips the
+ * subject prefix on read. Use `DocumentStatus` instead. Kept for backwards compatibility
+ * and will be removed in the next major.
+ */
 export enum Subject {
     KnowledgeProcessing = 'knowledge/processing',
-    KnowledgeIndexing = 'knowledge/indexing',
     KnowledgeFailed = 'knowledge/error',
     KnowledgeDone = 'knowledge/done',
 }
@@ -13,7 +24,7 @@ export interface DocumentData {
     owner_id: string;
     id: string;
     created_by: string;
-    status: Subject;
+    status: DocumentStatus;
     documentType: DocumentType;
     type: KnowledgeType;
     source_url: string;


### PR DESCRIPTION
## What

A correctness fix to one type. The knowledge API client and the knowledge types all stay.

`DocumentData.status` was typed as the `Subject` enum — prefixed `knowledge/*` strings. The knowledge API stores status as a prefixed event subject but strips the prefix on every read (`transformStatus` in `packages/services/knowledge/src/db/utils.ts`, applied on every document read path via `transformLogical`), so it has **only ever served bare values**. The enum was also the wrong subject domain: a document's status is `document/*`, not `knowledge/*`. Net: every value the type promised is unreachable.

- Added `DocumentStatus = 'created' | 'processed' | 'done' | 'rejected' | 'error'` — the stripped `Subject.Document*` members from `@de-id/events` — and used it for the field.
- Kept `Subject` exported and `@deprecated` so external TS consumers keep compiling, **minus `KnowledgeIndexing`**. `knowledge/indexing` was removed from the platform in 2023, appears in no enum anywhere, and was never a document status — anyone referencing it is already broken at runtime.
- Drive-by: `documentType` had no import, so it silently resolved to the **DOM `DocumentType` node interface** rather than the knowledge enum of the same name, making `CreateDocumentPayload` unsatisfiable without a cast. Added the import.

## Blast radius

- Nothing in the SDK reads `.status` at runtime. `DocumentData` appears only as the response generic in `src/api/knowledge.ts` (`createDocument` / `getDocuments` / `getDocument`); `CreateDocumentPayload` already `Omit`s `status`.
- `src/index.ts` → `types` → `entities` → `knowledge` → `document` re-exports both `DocumentData` and `Subject`, and `package.json` publishes `types: ./dist/src/index.d.ts` on a public npm package — so the field was retyped rather than dropped. Pedantically the `KnowledgeIndexing` removal is semver-major for anyone importing that member, but no such reference can be doing anything useful today.
- In-house consumers: `agents-ui` depends on `@d-id/client-sdk` but references neither `Subject` nor `DocumentData`; `studio` doesn't consume the SDK.
- Origin: copied wholesale from streaming-client at repo bootstrap (`f18202a` "copied types from streaming client") and never verified against the API.

## Verification

- `tsc --noEmit` clean; `test:ci` 541 passing / 23 suites; `prettier --check` clean — all identical to baseline (type-only change).
- Built dist typings confirmed: `DocumentStatus` present in `dist/src/types/entities/knowledge/document.d.ts`, `knowledge/indexing` absent from `dist/` entirely.

## Reference Links

- [Asana](https://app.asana.com/1/856614567666442/project/1216943078884032/task/1216943731956184?focus=true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJftELCLQpj4MUq1Z86JwB