### PR TITLE
feat: register client tools on the room before connect

### DIFF
--- a/src/services/agent-manager/connect-to-manager.test.ts
+++ b/src/services/agent-manager/connect-to-manager.test.ts
@@ -226,6 +226,17 @@ describe('connect-to-manager', () => {
             expect(mockStreamingManager.disconnect).not.toHaveBeenCalled();
             expect(result.streamingManager).toBe(mockStreamingManager);
         });
+
+        it('should forward rpcMethods through to the streaming manager', async () => {
+            const rpcMethods = new Map([['did.presentation', jest.fn()]]);
+
+            await initializeStreamAndChat(mockAgent, { ...mockOptions, rpcMethods }, mockAgentsApi, mockAnalytics);
+
+            // Identity, not equality: expect.objectContaining compares a nested Map loosely,
+            // so a wrapper that replaced the map would still satisfy it.
+            const streamingManagerOptions = (createStreamingManager as jest.Mock).mock.calls[0][2];
+            expect(streamingManagerOptions.rpcMethods).toBe(rpcMethods);
+        });
     });
 
     describe('Streaming Manager Callbacks', () => {

--- a/src/services/agent-manager/connect-to-manager.ts
+++ b/src/services/agent-manager/connect-to-manager.ts
@@ -19,6 +19,7 @@ import {
     CreateStreamOptions,
     StreamEvents,
     StreamType,
+    StreamingManagerOptions,
     StreamingState,
     ToolCallDonePayload,
     ToolCallErrorPayload,
@@ -191,6 +192,7 @@ type ConnectToManagerOptions = AgentManagerOptions & {
         onFirstAudioDetected?: (metrics: AudioDetectionMetrics) => void;
     };
     chatId?: string;
+    rpcMethods?: StreamingManagerOptions['rpcMethods'];
 };
 
 function connectToManager(

--- a/src/services/agent-manager/index.test.ts
+++ b/src/services/agent-manager/index.test.ts
@@ -1227,5 +1227,47 @@ describe('createAgentManager', () => {
                 message: 'No handler registered for client tool: testTool',
             });
         });
+
+        function rpcMethodsFromStream() {
+            return (initializeStreamAndChat as jest.Mock).mock.calls[0][1].rpcMethods;
+        }
+
+        it('should hand tools registered before connect to the stream so they are live on join', async () => {
+            manager.registerClientTool('did.presentation', jest.fn().mockResolvedValue('{}'));
+
+            await manager.connect();
+
+            expect([...rpcMethodsFromStream().keys()]).toEqual(['did.presentation']);
+        });
+
+        it('should dispatch a method handed to the stream to the registered tool handler', async () => {
+            const handler = jest.fn().mockResolvedValue('{"ok":true}');
+            manager.registerClientTool('did.presentation', handler);
+
+            await manager.connect();
+
+            const rpcHandler = rpcMethodsFromStream().get('did.presentation');
+            await expect(rpcHandler({ payload: '{"type":"show_slide"}' })).resolves.toBe('{"ok":true}');
+            expect(handler).toHaveBeenCalledWith({ type: 'show_slide' });
+        });
+
+        it('should hand an empty map when no tools were registered before connect', async () => {
+            await manager.connect();
+
+            expect(rpcMethodsFromStream().size).toBe(0);
+        });
+
+        it('should unregister before re-registering a tool that was already registered pre-connect', async () => {
+            // Room.registerRpcMethod throws on a duplicate method, and the pre-connect hook has
+            // already registered this name by the time the post-connect flush runs.
+            manager.registerClientTool('did.presentation', jest.fn());
+
+            await manager.connect();
+
+            expect(mockStreamingManager.unregisterRpcMethod).toHaveBeenCalledWith('did.presentation');
+            expect(mockStreamingManager.unregisterRpcMethod.mock.invocationCallOrder[0]).toBeLessThan(
+                mockStreamingManager.registerRpcMethod.mock.invocationCallOrder[0]
+            );
+        });
     });
 });

--- a/src/services/agent-manager/index.ts
+++ b/src/services/agent-manager/index.ts
@@ -221,6 +221,7 @@ export async function createAgentManager(agent: string, options: AgentManagerOpt
                             onVideoIdChange: updateVideoId,
                             onMessage,
                         },
+                        rpcMethods: new Map([...clientToolHandlers.keys()].map(name => [name, createRpcHandler(name)])),
                     },
                     agentsApi,
                     analytics,

--- a/src/services/streaming-manager/livekit-manager.test.ts
+++ b/src/services/streaming-manager/livekit-manager.test.ts
@@ -26,6 +26,7 @@ const mockRoom = {
     connect: jest.fn().mockResolvedValue(undefined),
     prepareConnection: jest.fn().mockResolvedValue(undefined),
     disconnect: jest.fn().mockResolvedValue(undefined),
+    registerRpcMethod: jest.fn(),
     localParticipant: mockLocalParticipant,
 };
 
@@ -1223,6 +1224,33 @@ describe('LiveKit Streaming Manager - Camera Stream', () => {
 
             // ASSERT:
             expect(mockPublishTrack).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('RPC method registration', () => {
+        it('registers the given rpc methods on the room before connecting', async () => {
+            // ARRANGE:
+            const handler = jest.fn().mockResolvedValue('{}');
+
+            // ACT:
+            await createLiveKitStreamingManager(agentId, sessionOptions, {
+                ...options,
+                rpcMethods: new Map([['did.presentation', handler]]),
+            });
+
+            // ASSERT:
+            expect(mockRoom.registerRpcMethod).toHaveBeenCalledWith('did.presentation', handler);
+            expect(mockRoom.registerRpcMethod.mock.invocationCallOrder[0]).toBeLessThan(
+                mockRoom.connect.mock.invocationCallOrder[0]
+            );
+        });
+
+        it('registers nothing when no rpc methods are given', async () => {
+            // ACT:
+            await createLiveKitStreamingManager(agentId, sessionOptions, options);
+
+            // ASSERT:
+            expect(mockRoom.registerRpcMethod).not.toHaveBeenCalled();
         });
     });
 });

--- a/src/services/streaming-manager/livekit-manager.ts
+++ b/src/services/streaming-manager/livekit-manager.ts
@@ -127,6 +127,10 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
         dynacast: true,
     });
 
+    for (const [method, handler] of options.rpcMethods ?? []) {
+        room.registerRpcMethod(method, handler);
+    }
+
     let trackSubscriptionTimeoutId: ReturnType<typeof setTimeout> | null = null;
     let currentActivityState: AgentActivityState = AgentActivityState.Idle;
     let currentInterruptible = true;

--- a/src/types/stream/stream.ts
+++ b/src/types/stream/stream.ts
@@ -76,6 +76,9 @@ export enum StreamType {
     Fluent = 'fluent',
 }
 
+/** @internal */
+export type RpcMethodHandler = (data: { payload: string }) => Promise<string>;
+
 export interface ManagerCallbacks {
     onMessage?: ChatProgressCallback;
     onConnectionStateChange?: (state: ConnectionState, reason?: string) => void;
@@ -157,6 +160,12 @@ export interface StreamingManagerOptions {
      * Supported by LiveKit streaming managers.
      */
     microphoneStream?: MediaStream;
+    /**
+     * RPC methods to register on the room before it connects, so the agent can
+     * call them from the moment this participant joins.
+     * @internal
+     */
+    rpcMethods?: ReadonlyMap<string, RpcMethodHandler>;
 }
 
 export interface SlimRTCStatsReport {


### PR DESCRIPTION
### Pull Request Type

🔮 Feature

### Description
-   Client tools registered via `registerClientTool` before `connect()` are now registered on the LiveKit `Room` right after it is constructed, before `room.connect()`. Previously they were pushed only after connect resolved, leaving a ~1.5s window where the agent's RPC calls hit `UNSUPPORTED_METHOD`.
-   `connect()` snapshots the buffered tools into a new internal `StreamingManagerOptions.rpcMethods` map; `createLiveKitStreamingManager` loops it after `new Room(...)`. `Room.registerRpcMethod` is a local map insert, so no connection is needed. The post-connect flush is unchanged and covers tools registered later.
-   Needed by presenter-mode auto-start in the orchestrator worker, which fires an agent turn as soon as the participant joins. agents-ui already registers `did.presentation` before connect; it needs only a version bump once this ships.
-   Tests: room registration ordered before `connect`; snapshot keys and dispatch through `createRpcHandler`; pass-through in `connect-to-manager`; flush unregisters before re-registering. 548 passing, prettier and tsc clean.

### Reference Links
-   [Worker PR](https://github.com/de-id/streaming-orchestrator-worker/pull/729)
-   [agents-ui PR](https://github.com/de-id/agents-ui/pull/1118)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CXAuKEuqTp6XtE7u8P9r6A
