### PR TITLE
feat: report why the server ended the stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,34 +215,23 @@ Callback functions enable you to manage various events throughout the SDK lifecy
     }
     ```
 
-- **`onConnectionStateChange(state):`**
+- **`onConnectionStateChange(state, reason):`**
   Displaying the different connection states with the Agent's WebRTC stream connection
   Triggered when `agentManager.connect(), agentManager.reconnect(), agentManager.disconnect()` are called.
 
     ```javascript
-    onConnectionStateChange(state) {
-        console.log("onConnectionStateChange(): ", state)
+    onConnectionStateChange(state, reason) {
+        console.log("onConnectionStateChange(): ", state, reason)
         if (state == "connected") {
             console.log("I'm ready to go!")
         }
     }
     ```
 
+    The second `reason` argument says why the connection reached that state. On `disconnected` it is a `StreamEndReason` when the server ended the stream on purpose, which lets you tell a deliberate end from a dropped connection. Any other value is an opaque transport diagnostic. `agentManager.reconnect()` still works after a deliberate end; it starts a new stream rather than resuming the old one.
+
     ```javascript Example Values
     state: ['new', 'fail', 'connecting', 'connected', 'disconnected', 'closed'];
-    ```
-
-    A second `reason` argument says why the connection reached that state. On `disconnected` it is a `StreamEndReason` when the server ended the stream on purpose, so you can tell a deliberate hang-up from a dropped connection. Any other value is an opaque transport diagnostic.
-
-    ```javascript
-    onConnectionStateChange(state, reason) {
-        if (state === 'disconnected' && reason === StreamEndReason.EndedByAgent) {
-            // the agent hung up; reconnecting will not help
-        }
-    }
-    ```
-
-    ```javascript Example Values
     reason: ['ok', 'unknown_error', 'network_issue', 'message_limit', 'time_limit', 'inactivity', 'ended_by_agent'];
     ```
 

--- a/README.md
+++ b/README.md
@@ -126,12 +126,10 @@ The `agentManager` object created during initialization has several built-in met
     ```
 
     ```javascript Audio File - JavaScript
-    let speak = agentManager.speak(
-        {
-          type: "audio",
-          audio_url: "http://www.yourwebsite.com/audio.mp3"
-        }
-    );
+    let speak = agentManager.speak({
+        type: 'audio',
+        audio_url: 'http://www.yourwebsite.com/audio.mp3',
+    });
     ```
 
 - **`agentManager.chat(string)`**
@@ -158,28 +156,28 @@ The `agentManager` object created during initialization has several built-in met
   **Supported only with Expressive (V4) agents.**
   Method to publish a microphone audio track to the session. Call after `connect()` to enable voice input.
 
-  ```javascript
-  const micStream = await navigator.mediaDevices.getUserMedia({ audio: true });
-  await agentManager.publishMicrophoneStream(micStream);
-  ```
+    ```javascript
+    const micStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    await agentManager.publishMicrophoneStream(micStream);
+    ```
 
 - **`agentManager.unpublishMicrophoneStream()`**
   **Supported only with Expressive (V4) agents.**
   Method to stop and remove the currently published microphone track from the session.
 
-  ```javascript
-  await agentManager.unpublishMicrophoneStream();
-  ```
+    ```javascript
+    await agentManager.unpublishMicrophoneStream();
+    ```
 
 - **`agentManager.sendDataChannelMessage(topic, payload)`**
   **Supported only with Expressive (V4) agents.**
   Method to send a JSON payload to the agent over a data-channel topic. `PublicDataChannelTopic` is exported from the package root and lists every topic this method accepts.
 
-  ```javascript
-  import { PublicDataChannelTopic } from '@d-id/client-sdk';
+    ```javascript
+    import { PublicDataChannelTopic } from '@d-id/client-sdk';
 
-  await agentManager.sendDataChannelMessage(PublicDataChannelTopic.Presentation, { type: 'navigate', slide: 3 });
-  ```
+    await agentManager.sendDataChannelMessage(PublicDataChannelTopic.Presentation, { type: 'navigate', slide: 3 });
+    ```
 
 ### ➤ ✴️ Callback Functions
 
@@ -232,6 +230,20 @@ Callback functions enable you to manage various events throughout the SDK lifecy
 
     ```javascript Example Values
     state: ['new', 'fail', 'connecting', 'connected', 'disconnected', 'closed'];
+    ```
+
+    A second `reason` argument says why the connection reached that state. On `disconnected` it is a `StreamEndReason` when the server ended the stream on purpose, so you can tell a deliberate hang-up from a dropped connection. Any other value is an opaque transport diagnostic.
+
+    ```javascript
+    onConnectionStateChange(state, reason) {
+        if (state === 'disconnected' && reason === StreamEndReason.EndedByAgent) {
+            // the agent hung up; reconnecting will not help
+        }
+    }
+    ```
+
+    ```javascript Example Values
+    reason: ['ok', 'unknown_error', 'network_issue', 'message_limit', 'time_limit', 'inactivity', 'ended_by_agent'];
     ```
 
 - **`onNewMessage(messages, type)`:**

--- a/src/services/agent-manager/connect-to-manager.test.ts
+++ b/src/services/agent-manager/connect-to-manager.test.ts
@@ -5,6 +5,7 @@ import {
     AgentManagerOptions,
     ChatMode,
     ConnectionState,
+    StreamEndReason,
     StreamEvents,
     StreamingState,
     StreamType,
@@ -229,7 +230,7 @@ describe('connect-to-manager', () => {
     });
 
     describe('Streaming Manager Callbacks', () => {
-        let onConnectionStateChange: (state: ConnectionState) => void;
+        let onConnectionStateChange: (state: ConnectionState, reason?: string) => void;
         let onVideoStateChange: (state: StreamingState, statsReport?: any) => void;
         let onAgentActivityStateChange: (state: AgentActivityState) => void;
         let onFirstAudioDetected: ((metrics: { latency?: number; networkLatency?: number }) => void) | undefined;
@@ -264,10 +265,13 @@ describe('connect-to-manager', () => {
         });
 
         describe('onConnectionStateChange', () => {
-            it('should forward connection state changes', () => {
-                onConnectionStateChange(ConnectionState.Connecting);
+            it('should forward connection state changes with their reason', () => {
+                onConnectionStateChange(ConnectionState.Connecting, 'livekit:connecting');
 
-                expect(mockOptions.callbacks.onConnectionStateChange).toHaveBeenCalledWith(ConnectionState.Connecting);
+                expect(mockOptions.callbacks.onConnectionStateChange).toHaveBeenCalledWith(
+                    ConnectionState.Connecting,
+                    'livekit:connecting'
+                );
             });
         });
 
@@ -511,6 +515,21 @@ describe('connect-to-manager', () => {
                     'agent-tool-call',
                     expect.objectContaining({ extra_keys: 0 })
                 );
+            });
+        });
+
+        describe('stream end reason', () => {
+            it('forwards the disconnect reason to the app and tracks it', () => {
+                onConnectionStateChange(ConnectionState.Disconnected, StreamEndReason.Inactivity);
+
+                expect(mockOptions.callbacks.onConnectionStateChange).toHaveBeenCalledWith(
+                    ConnectionState.Disconnected,
+                    StreamEndReason.Inactivity
+                );
+                expect(mockAnalytics.track).toHaveBeenCalledWith('agent-connection-state-change', {
+                    state: ConnectionState.Disconnected,
+                    reason: StreamEndReason.Inactivity,
+                });
             });
         });
     });

--- a/src/services/agent-manager/connect-to-manager.ts
+++ b/src/services/agent-manager/connect-to-manager.ts
@@ -224,7 +224,7 @@ function connectToManager(
                     callbacks: {
                         ...options.callbacks,
                         onConnectionStateChange: (state, reason) => {
-                            options.callbacks.onConnectionStateChange?.(state);
+                            options.callbacks.onConnectionStateChange?.(state, reason);
 
                             trackConnectionStateChangeAnalytics(state, reason, analytics);
 

--- a/src/services/agent-manager/index.ts
+++ b/src/services/agent-manager/index.ts
@@ -108,9 +108,9 @@ export async function createAgentManager(agent: string, options: AgentManagerOpt
     const isStreamsV2 = isStreamsV2Agent(agentEntity.avatar.type);
     analytics.enrich(getAgentInfo(agentEntity));
 
-    const { onMessage, clearQueue } = createMessageEventQueue(analytics, items, options, agentEntity, () => {
+    const { onMessage, clearQueue } = createMessageEventQueue(analytics, items, options, agentEntity, reason => {
         items.socketManager?.disconnect();
-        options.callbacks.onConnectionStateChange?.(ConnectionState.Disconnected);
+        options.callbacks.onConnectionStateChange?.(ConnectionState.Disconnected, reason);
     });
 
     items.messages = getInitialMessages(options.initialMessages);

--- a/src/services/socket-manager/message-queue.ts
+++ b/src/services/socket-manager/message-queue.ts
@@ -1,8 +1,9 @@
 import { StreamError } from '@sdk/errors';
-import { Agent, AgentManagerOptions, ChatProgress, StreamEvents } from '@sdk/types';
+import { Agent, AgentManagerOptions, ChatProgress, StreamEndReason, StreamEvents } from '@sdk/types';
 import { Message } from '@sdk/types/entities/agents/chat';
 import { getStreamAnalyticsProps } from '@sdk/utils/analytics';
 import { parseMessagePartsMemo } from '@sdk/utils/content-parser';
+import { toStreamEndReason } from '@sdk/utils/stream-end';
 import { AgentManagerItems } from '../agent-manager';
 import { Analytics } from '../analytics/mixpanel';
 
@@ -132,7 +133,7 @@ export function createMessageEventQueue(
     items: AgentManagerItems,
     options: AgentManagerOptions,
     agentEntity: Agent,
-    onStreamDone: () => void
+    onStreamDone: (reason: StreamEndReason) => void
 ) {
     const chatEventQueue: ChatEventQueue = {};
     const clearQueue = () => {
@@ -233,7 +234,7 @@ export function createMessageEventQueue(
                 }
 
                 if (data.event === SEvent.StreamDone) {
-                    onStreamDone();
+                    onStreamDone(toStreamEndReason(data));
                 }
             }
         },

--- a/src/services/socket-manager/message-queue.ts
+++ b/src/services/socket-manager/message-queue.ts
@@ -1,5 +1,5 @@
 import { StreamError } from '@sdk/errors';
-import { Agent, AgentManagerOptions, ChatProgress, StreamEndReason, StreamEvents } from '@sdk/types';
+import { Agent, AgentManagerOptions, ChatProgress, StreamEvents } from '@sdk/types';
 import { Message } from '@sdk/types/entities/agents/chat';
 import { getStreamAnalyticsProps } from '@sdk/utils/analytics';
 import { parseMessagePartsMemo } from '@sdk/utils/content-parser';
@@ -133,7 +133,7 @@ export function createMessageEventQueue(
     items: AgentManagerItems,
     options: AgentManagerOptions,
     agentEntity: Agent,
-    onStreamDone: (reason: StreamEndReason) => void
+    onStreamDone: (reason?: string) => void
 ) {
     const chatEventQueue: ChatEventQueue = {};
     const clearQueue = () => {

--- a/src/services/streaming-manager/livekit-manager.test.ts
+++ b/src/services/streaming-manager/livekit-manager.test.ts
@@ -2019,7 +2019,7 @@ describe('LiveKit Streaming Manager - Stream End Reason', () => {
     });
 
     async function receiveThenDisconnect(topic: string | null, data: object) {
-        await createLiveKitStreamingManager(agentId, sessionOptions, options);
+        const manager = await createLiveKitStreamingManager(agentId, sessionOptions, options);
 
         if (topic) {
             getDataReceivedHandler()(createDataChannelPayload(data), undefined, undefined, topic);
@@ -2027,6 +2027,8 @@ describe('LiveKit Streaming Manager - Stream End Reason', () => {
 
         onConnectionStateChange.mockClear();
         getConnectionStateHandler()('disconnected');
+
+        return manager;
     }
 
     it('should report the disconnect with the reason the server sent', async () => {
@@ -2049,6 +2051,20 @@ describe('LiveKit Streaming Manager - Stream End Reason', () => {
 
     it('should ignore an end reason on an unknown topic', async () => {
         await receiveThenDisconnect('stream/unknown', { reason: StreamEndReason.EndedByAgent });
+
+        expect(onConnectionStateChange).toHaveBeenCalledWith('disconnected', 'livekit:disconnected');
+    });
+
+    it('should not carry a reason from an ended stream into the next connection', async () => {
+        const manager = await receiveThenDisconnect(StreamEvents.StreamDone, {
+            reason: StreamEndReason.Inactivity,
+        });
+        (mockRoom as any).state = 'disconnected';
+        (mockRoom as any).remoteParticipants = { size: 1 };
+
+        await manager.reconnect();
+        onConnectionStateChange.mockClear();
+        getConnectionStateHandler()('disconnected');
 
         expect(onConnectionStateChange).toHaveBeenCalledWith('disconnected', 'livekit:disconnected');
     });

--- a/src/services/streaming-manager/livekit-manager.test.ts
+++ b/src/services/streaming-manager/livekit-manager.test.ts
@@ -3,6 +3,7 @@ import { StreamingManagerOptionsFactory } from '../../test-utils/factories';
 import {
     AgentActivityState,
     CreateSessionV2Options,
+    StreamEndReason,
     StreamEvents,
     StreamingManagerOptions,
     StreamingState,
@@ -1988,5 +1989,67 @@ describe('LiveKit Streaming Manager - Tool Events and Activity State', () => {
             expect(onAgentActivityStateChange).not.toHaveBeenCalledWith(AgentActivityState.Idle);
             expect(onMessage).toHaveBeenCalled();
         });
+    });
+});
+
+describe('LiveKit Streaming Manager - Stream End Reason', () => {
+    let agentId: string;
+    let sessionOptions: CreateSessionV2Options;
+    let options: StreamingManagerOptions;
+    let onConnectionStateChange: jest.Mock;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockRoom.connect.mockResolvedValue(undefined);
+        mockRoom.prepareConnection.mockResolvedValue(undefined);
+        mockRoom.disconnect.mockResolvedValue(undefined);
+        mockRoom.on.mockReturnThis();
+        mockLocalParticipant.audioTrackPublications = new Map();
+        mockLocalParticipant.videoTrackPublications = new Map();
+        agentId = TEST_AGENT_ID;
+        sessionOptions = {
+            chat_persist: true,
+            transport: {
+                provider: TransportProvider.Livekit,
+            },
+        };
+        options = StreamingManagerOptionsFactory.build();
+        onConnectionStateChange = jest.fn();
+        options.callbacks.onConnectionStateChange = onConnectionStateChange;
+    });
+
+    async function receiveThenDisconnect(topic: string | null, data: object) {
+        await createLiveKitStreamingManager(agentId, sessionOptions, options);
+
+        if (topic) {
+            getDataReceivedHandler()(createDataChannelPayload(data), undefined, undefined, topic);
+        }
+
+        onConnectionStateChange.mockClear();
+        getConnectionStateHandler()('disconnected');
+    }
+
+    it('should report the disconnect with the reason the server sent', async () => {
+        await receiveThenDisconnect(StreamEvents.StreamDone, { reason: StreamEndReason.EndedByAgent });
+
+        expect(onConnectionStateChange).toHaveBeenCalledWith('disconnected', StreamEndReason.EndedByAgent);
+    });
+
+    it('should report a failed stream the same way', async () => {
+        await receiveThenDisconnect(StreamEvents.StreamFailed, { reason: StreamEndReason.UnknownError });
+
+        expect(onConnectionStateChange).toHaveBeenCalledWith('disconnected', StreamEndReason.UnknownError);
+    });
+
+    it('should keep the transport diagnostic when the server sent no reason', async () => {
+        await receiveThenDisconnect(null, {});
+
+        expect(onConnectionStateChange).toHaveBeenCalledWith('disconnected', 'livekit:disconnected');
+    });
+
+    it('should ignore an end reason on an unknown topic', async () => {
+        await receiveThenDisconnect('stream/unknown', { reason: StreamEndReason.EndedByAgent });
+
+        expect(onConnectionStateChange).toHaveBeenCalledWith('disconnected', 'livekit:disconnected');
     });
 });

--- a/src/services/streaming-manager/livekit-manager.ts
+++ b/src/services/streaming-manager/livekit-manager.ts
@@ -796,6 +796,7 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
 
             log('Reconnecting to LiveKit room, state:', room.state);
             hasEmittedConnected = false;
+            streamEndReason = null;
             callbacks.onConnectionStateChange?.(ConnectionState.Connecting, 'user:reconnect');
 
             try {

--- a/src/services/streaming-manager/livekit-manager.ts
+++ b/src/services/streaming-manager/livekit-manager.ts
@@ -9,6 +9,7 @@ import {
     Message,
     PayloadType,
     RunningToolCall,
+    StreamEndReason,
     StreamEvents,
     StreamingManagerOptions,
     StreamingState,
@@ -132,6 +133,7 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
     let currentInterruptible = true;
     const pendingToolCalls = new Map<string, PendingToolCall>();
     let currentTurnId: number | null = null;
+    let streamEndReason: StreamEndReason | null = null;
 
     const streamApi = createStreamApiV2(auth, baseURL || didApiUrl, agentId, callbacks.onError);
     let sessionId: string | undefined;
@@ -236,7 +238,10 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
                 hasEmittedConnected = false;
                 microphoneState.publication = null;
                 cameraState.publication = null;
-                callbacks.onConnectionStateChange?.(ConnectionState.Disconnected, 'livekit:disconnected');
+                callbacks.onConnectionStateChange?.(
+                    ConnectionState.Disconnected,
+                    streamEndReason ?? 'livekit:disconnected'
+                );
                 break;
             case LiveKitConnectionState.Reconnecting:
                 log('LiveKit room reconnecting...');
@@ -508,6 +513,10 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
         callbacks.onAgentActivityStateChange?.(AgentActivityState.Idle);
     }
 
+    function handleStreamEnded(_subject: string, data: { reason: StreamEndReason }): void {
+        streamEndReason = data?.reason ?? null;
+    }
+
     type DataChannelHandler = (subject: string, data: any) => void;
     const dataChannelHandlers: Record<string, DataChannelHandler> = {
         [StreamEvents.ChatAnswer]: handleChatEvents,
@@ -522,6 +531,8 @@ export async function createLiveKitStreamingManager<T extends CreateSessionV2Opt
         [StreamEvents.ChatAudioTranscribed]: handleTranscriptionEvents,
         [StreamEvents.TurnStarted]: handleTurnStarted,
         [StreamEvents.TurnEnded]: handleTurnEnded,
+        [StreamEvents.StreamDone]: handleStreamEnded,
+        [StreamEvents.StreamFailed]: handleStreamEnded,
     };
 
     function handleDataReceived(

--- a/src/types/entities/agents/manager.ts
+++ b/src/types/entities/agents/manager.ts
@@ -55,9 +55,7 @@ interface ManagerCallbacks {
     /**
      * Optional callback will be triggered each time the RTC connection changes state
      * @param state
-     * @param reason - why the connection reached this state. On disconnect this is a
-     * `StreamEndReason` when the server ended the stream on purpose (the agent's end-call
-     * tool, inactivity, a time or message limit); otherwise an opaque diagnostic string.
+     * @param reason - a `StreamEndReason` when the server ended the stream, otherwise a diagnostic string
      */
     onConnectionStateChange?(state: ConnectionState, reason?: string): void;
     /**

--- a/src/types/entities/agents/manager.ts
+++ b/src/types/entities/agents/manager.ts
@@ -55,8 +55,11 @@ interface ManagerCallbacks {
     /**
      * Optional callback will be triggered each time the RTC connection changes state
      * @param state
+     * @param reason - why the connection reached this state. On disconnect this is a
+     * `StreamEndReason` when the server ended the stream on purpose (the agent's end-call
+     * tool, inactivity, a time or message limit); otherwise an opaque diagnostic string.
      */
-    onConnectionStateChange?(state: ConnectionState): void;
+    onConnectionStateChange?(state: ConnectionState, reason?: string): void;
     /**
      * Optional callback function that will be triggered each time video events happen
      * @param state

--- a/src/types/stream/stream.ts
+++ b/src/types/stream/stream.ts
@@ -283,6 +283,16 @@ export interface TurnEventPayload {
     turn_id: number | null;
 }
 
+export enum StreamEndReason {
+    Ok = 'ok',
+    UnknownError = 'unknown_error',
+    NetworkIssue = 'network_issue',
+    MessageLimit = 'message_limit',
+    TimeLimit = 'time_limit',
+    Inactivity = 'inactivity',
+    EndedByAgent = 'ended_by_agent',
+}
+
 export type ToolEventCallback = {
     (event: StreamEvents.ToolCallStarted, data: ToolCallStartedPayload): void;
     (event: StreamEvents.ToolCallDone, data: ToolCallDonePayload): void;

--- a/src/utils/stream-end.test.ts
+++ b/src/utils/stream-end.test.ts
@@ -1,0 +1,16 @@
+import { StreamEndReason } from '@sdk/types';
+import { toStreamEndReason } from './stream-end';
+
+describe('toStreamEndReason', () => {
+    it('should map every close reason the legacy streams report', () => {
+        expect(toStreamEndReason({ close_reason: 'manual' })).toBe(StreamEndReason.Ok);
+        expect(toStreamEndReason({ close_reason: 'inactivity' })).toBe(StreamEndReason.Inactivity);
+        expect(toStreamEndReason({ close_reason: 'peer_disconnected' })).toBe(StreamEndReason.NetworkIssue);
+        expect(toStreamEndReason({ close_reason: 'shutdown' })).toBe(StreamEndReason.UnknownError);
+    });
+
+    it('should report an unrecognised or missing close reason as an unknown error', () => {
+        expect(toStreamEndReason({ close_reason: 'something-new' })).toBe(StreamEndReason.UnknownError);
+        expect(toStreamEndReason({})).toBe(StreamEndReason.UnknownError);
+    });
+});

--- a/src/utils/stream-end.test.ts
+++ b/src/utils/stream-end.test.ts
@@ -9,8 +9,11 @@ describe('toStreamEndReason', () => {
         expect(toStreamEndReason({ close_reason: 'shutdown' })).toBe(StreamEndReason.UnknownError);
     });
 
-    it('should report an unrecognised or missing close reason as an unknown error', () => {
-        expect(toStreamEndReason({ close_reason: 'something-new' })).toBe(StreamEndReason.UnknownError);
-        expect(toStreamEndReason({})).toBe(StreamEndReason.UnknownError);
+    it('should forward a reason it does not recognise rather than calling it an error', () => {
+        expect(toStreamEndReason({ close_reason: 'something-new' })).toBe('something-new');
+    });
+
+    it('should report no reason when the stream sent none', () => {
+        expect(toStreamEndReason({})).toBeUndefined();
     });
 });

--- a/src/utils/stream-end.ts
+++ b/src/utils/stream-end.ts
@@ -7,7 +7,10 @@ const LEGACY_CLOSE_REASON_TO_END_REASON: Record<string, StreamEndReason> = {
     shutdown: StreamEndReason.UnknownError,
 };
 
-/** Legacy streams report the session end as `stream/done` with a `close_reason`. */
-export function toStreamEndReason(data: any): StreamEndReason {
-    return LEGACY_CLOSE_REASON_TO_END_REASON[data.close_reason] ?? StreamEndReason.UnknownError;
+/**
+ * Legacy streams report the session end as `stream/done` with a `close_reason`.
+ * A reason we do not recognise is forwarded as-is rather than reported as an error.
+ */
+export function toStreamEndReason(data: any): string | undefined {
+    return LEGACY_CLOSE_REASON_TO_END_REASON[data.close_reason] ?? data.close_reason;
 }

--- a/src/utils/stream-end.ts
+++ b/src/utils/stream-end.ts
@@ -1,0 +1,13 @@
+import { StreamEndReason } from '@sdk/types';
+
+const LEGACY_CLOSE_REASON_TO_END_REASON: Record<string, StreamEndReason> = {
+    manual: StreamEndReason.Ok,
+    inactivity: StreamEndReason.Inactivity,
+    peer_disconnected: StreamEndReason.NetworkIssue,
+    shutdown: StreamEndReason.UnknownError,
+};
+
+/** Legacy streams report the session end as `stream/done` with a `close_reason`. */
+export function toStreamEndReason(data: any): StreamEndReason {
+    return LEGACY_CLOSE_REASON_TO_END_REASON[data.close_reason] ?? StreamEndReason.UnknownError;
+}


### PR DESCRIPTION
### Pull Request Type

🔮 Feature

### Description

- `onConnectionStateChange` now receives a second `reason` argument. On `disconnected` it is a `StreamEndReason` when the server ended the stream on purpose, so an app can tell the agent hanging up, an inactivity timeout or a time or message limit from a dropped connection. Otherwise it is an opaque transport diagnostic such as `livekit:disconnected`.
- No new callback. The SDK has always passed this reason internally and dropped it at the public boundary, so every disconnect gains a cause, not just this one. The existing `agent-connection-state-change` event already tracks it.
- Expressive agents read it from the `stream/done` and `stream/error` data-channel events added in streaming-orchestrator-worker #734. Legacy agents read it from the session-level `stream/done` they already receive over the websocket, mapped from `close_reason`.
- Nothing about the connection behaviour changes, and the per-video `stream/done` on the legacy WebRTC data channel is untouched.

### Reference Links

-   [Asana](https://app.asana.com/1/856614567666442/project/1217184354211990/task/1216916819996461?focus=true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
