### PR TITLE
🐛 BugFix: agent embed crashes on load on Wix (locked addEventListener)

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "ci:test": "yarn type-check && yarn test:ci"
   },
   "dependencies": {
-    "livekit-client": "^2.17.2"
+    "livekit-client": "2.18.4"
   },
   "devDependencies": {
     "@preact/preset-vite": "^2.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -789,10 +789,10 @@
   resolved "https://registry.yarnpkg.com/@livekit/mutex/-/mutex-1.1.1.tgz#72492b611d55be8130ba2271b7a436d94b1bc6d4"
   integrity sha512-EsshAucklmpuUAfkABPxJNhzj9v2sG7JuzFDL4ML1oJQSV14sqrpTYnsaOudMAw9yOaW53NU3QQTlUQoRs4czw==
 
-"@livekit/protocol@1.44.0":
-  version "1.44.0"
-  resolved "https://registry.yarnpkg.com/@livekit/protocol/-/protocol-1.44.0.tgz#f94a34690dc7dcf1a808f0095f2e480c471747d9"
-  integrity sha512-/vfhDUGcUKO8Q43r6i+5FrDhl5oZjm/X3U4x2Iciqvgn5C8qbj+57YPcWSJ1kyIZm5Cm6AV2nAPjMm3ETD/iyg==
+"@livekit/protocol@1.45.3":
+  version "1.45.3"
+  resolved "https://registry.yarnpkg.com/@livekit/protocol/-/protocol-1.45.3.tgz#1f0b8d45057c6d76aa4966e356a2d3d29048c2f4"
+  integrity sha512-WmMxBTsy4dRBqcrswFwUUlgq3Z0nnhOqKR6tX749Rb/PcB1yBMUtrHxZvcsS6qi3/5+86zHeVG+exmu1sZqfJg==
   dependencies:
     "@bufbuild/protobuf" "^1.10.0"
 
@@ -2899,21 +2899,20 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-livekit-client@^2.17.2:
-  version "2.17.2"
-  resolved "https://registry.yarnpkg.com/livekit-client/-/livekit-client-2.17.2.tgz#5f4393240fb5ceaca256d297e8bc92f2ac4311b3"
-  integrity sha512-+67y2EtAWZabARlY7kANl/VT1Uu1EJYR5a8qwpT2ub/uBCltsEgEDOxCIMwE9HFR5w+z41HR6GL9hyEvW/y6CQ==
+livekit-client@2.18.4:
+  version "2.18.4"
+  resolved "https://registry.yarnpkg.com/livekit-client/-/livekit-client-2.18.4.tgz#83b5c3b61e65c8bb4bae164bb4c42ee8fae4df1b"
+  integrity sha512-kjbH9WdA85gZNqFiAMY9jKJ3HArk8F+AQvAvSE5N6PnY+wNCV9OYe9yeb9BVezZiD6ltGyB3CkTxGyuX6BXYAw==
   dependencies:
     "@livekit/mutex" "1.1.1"
-    "@livekit/protocol" "1.44.0"
+    "@livekit/protocol" "1.45.3"
     events "^3.3.0"
     jose "^6.1.0"
     loglevel "^1.9.2"
     sdp-transform "^2.15.0"
-    ts-debounce "^4.0.0"
     tslib "2.8.1"
     typed-emitter "^2.1.0"
-    webrtc-adapter "^9.0.1"
+    webrtc-adapter "9.0.5"
 
 locate-path@^5.0.0:
   version "5.0.0"
@@ -3688,11 +3687,6 @@ tr46@^3.0.0:
   dependencies:
     punycode "^2.1.1"
 
-ts-debounce@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/ts-debounce/-/ts-debounce-4.0.0.tgz#33440ef64fab53793c3d546a8ca6ae539ec15841"
-  integrity sha512-+1iDGY6NmOGidq7i7xZGA4cm8DAa6fqdYcvO5Z6yBevH++Bdo9Qt/mN0TzHUgcCcKv1gmh9+W5dHqz8pMWbCbg==
-
 ts-jest@^29.4.1:
   version "29.4.1"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-29.4.1.tgz#42d33beb74657751d315efb9a871fe99e3b9b519"
@@ -3902,10 +3896,10 @@ webidl-conversions@^7.0.0:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
   integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
 
-webrtc-adapter@^9.0.1:
-  version "9.0.3"
-  resolved "https://registry.yarnpkg.com/webrtc-adapter/-/webrtc-adapter-9.0.3.tgz#b446ed7cd72129d00c652dd7b9a5716d9ffdd87d"
-  integrity sha512-5fALBcroIl31OeXAdd1YUntxiZl1eHlZZWzNg3U4Fn+J9/cGL3eT80YlrsWGvj2ojuz1rZr2OXkgCzIxAZ7vRQ==
+webrtc-adapter@9.0.5:
+  version "9.0.5"
+  resolved "https://registry.yarnpkg.com/webrtc-adapter/-/webrtc-adapter-9.0.5.tgz#fb036c3db06e1a0d86c264da649e130187783b3f"
+  integrity sha512-U9vjByy/sK2OMXu5mmfuZFKTMIUQe34c0JXRO+oDrxJTsntdYT2iIFwYMOV7HhMTuktcZLGf2W1N/OcSf9ssWg==
   dependencies:
     sdp "^3.2.0"
 


### PR DESCRIPTION
### Pull Request Type

🐛 BugFix

### Description

-   **Symptom:** the agent embed renders nothing on any Wix site, in every browser. The script 200s, then throws during module evaluation: `TypeError: Cannot assign to read only property 'addEventListener' of object '#<RTCPeerConnection>'`. Because it throws at load, there is no widget and no visible error — two self-serve Pro clients have been down since ~26 Aug.
-   **Cause:** Wix's frontend-security policy makes `EventTarget.prototype.addEventListener` non-writable. `webrtc-adapter` assigns `RTCPeerConnection.prototype.addEventListener` unconditionally at import time; the write is refused, and since ESM is always strict the refusal throws rather than failing silently, aborting evaluation of the entry chunk.
-   **Fix:** bump `livekit-client` 2.17.2 → 2.18.4. Upstream fixed this in `webrtc-adapter` 9.0.5 ([webrtcHacks/adapter#1178](https://github.com/webrtcHacks/adapter/pull/1178)), which checks writability first and bails out; livekit-client picked it up in 2.18.4 and closed [livekit/client-sdk-js#1806](https://github.com/livekit/client-sdk-js/issues/1806) — a report of this exact failure, naming Wix — the same day. 2.18.3 is still broken, so 2.18.4 is the minimum.
-   **Why not just bump `webrtc-adapter`:** it has no effect. `livekit-client` inlines the adapter into its own published dist, so our direct dependency is never consulted at build time — I tried it first and the guard was absent from the build output. Only a `livekit-client` bump changes the bytes we ship.
-   **Why an exact pin:** a floating range is what let a broken adapter sit here unnoticed. Happy to switch to `^2.18.4` if reviewers prefer the repo convention.
-   **Verified against build output, not the lockfile:** `dist` now contains the `Unable to polyfill events` guard and the adapter fingerprint for 9.0.5+. `yarn ci:test` green (565 tests, 24 suites), `prettier --check` clean.

**Not covered here:** this stops the crash, but the guard makes the adapter *skip* its `track` / `icecandidate` / `datachannel` / `negotiationneeded` wrapping rather than fix it. Upstream classifies these as obsolete on modern browsers (unified-plan only since M102), so streaming is expected to work — but someone should load a real Wix embed to confirm before we tell the clients it's fixed.

**Follow-up (separate PR):** `agent-manager/index.ts` value-imports `RpcError` from `livekit-client`, which defeats the deliberate lazy-loading in `livekit-manager.ts` and pulls all of LiveKit into the eager chunk. That is why this failure blanked the widget instead of only breaking the stream, and it costs ~739 KB at first paint.

### Reference Links
-   [Asana](https://app.asana.com/1/856614567666442/project/1217823176333868/task/1218322198188046?focus=true)
