### PR TITLE
🚀 Release: main => prod (Wix embed fix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@d-id/client-sdk",
   "private": false,
-  "version": "2.0.8",
+  "version": "2.0.9",
   "type": "module",
   "description": "d-id client sdk",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "ci:test": "yarn type-check && yarn test:ci"
   },
   "dependencies": {
-    "livekit-client": "^2.17.2"
+    "livekit-client": "2.18.4"
   },
   "devDependencies": {
     "@preact/preset-vite": "^2.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -789,10 +789,10 @@
   resolved "https://registry.yarnpkg.com/@livekit/mutex/-/mutex-1.1.1.tgz#72492b611d55be8130ba2271b7a436d94b1bc6d4"
   integrity sha512-EsshAucklmpuUAfkABPxJNhzj9v2sG7JuzFDL4ML1oJQSV14sqrpTYnsaOudMAw9yOaW53NU3QQTlUQoRs4czw==
 
-"@livekit/protocol@1.44.0":
-  version "1.44.0"
-  resolved "https://registry.yarnpkg.com/@livekit/protocol/-/protocol-1.44.0.tgz#f94a34690dc7dcf1a808f0095f2e480c471747d9"
-  integrity sha512-/vfhDUGcUKO8Q43r6i+5FrDhl5oZjm/X3U4x2Iciqvgn5C8qbj+57YPcWSJ1kyIZm5Cm6AV2nAPjMm3ETD/iyg==
+"@livekit/protocol@1.45.3":
+  version "1.45.3"
+  resolved "https://registry.yarnpkg.com/@livekit/protocol/-/protocol-1.45.3.tgz#1f0b8d45057c6d76aa4966e356a2d3d29048c2f4"
+  integrity sha512-WmMxBTsy4dRBqcrswFwUUlgq3Z0nnhOqKR6tX749Rb/PcB1yBMUtrHxZvcsS6qi3/5+86zHeVG+exmu1sZqfJg==
   dependencies:
     "@bufbuild/protobuf" "^1.10.0"
 
@@ -2899,21 +2899,20 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-livekit-client@^2.17.2:
-  version "2.17.2"
-  resolved "https://registry.yarnpkg.com/livekit-client/-/livekit-client-2.17.2.tgz#5f4393240fb5ceaca256d297e8bc92f2ac4311b3"
-  integrity sha512-+67y2EtAWZabARlY7kANl/VT1Uu1EJYR5a8qwpT2ub/uBCltsEgEDOxCIMwE9HFR5w+z41HR6GL9hyEvW/y6CQ==
+livekit-client@2.18.4:
+  version "2.18.4"
+  resolved "https://registry.yarnpkg.com/livekit-client/-/livekit-client-2.18.4.tgz#83b5c3b61e65c8bb4bae164bb4c42ee8fae4df1b"
+  integrity sha512-kjbH9WdA85gZNqFiAMY9jKJ3HArk8F+AQvAvSE5N6PnY+wNCV9OYe9yeb9BVezZiD6ltGyB3CkTxGyuX6BXYAw==
   dependencies:
     "@livekit/mutex" "1.1.1"
-    "@livekit/protocol" "1.44.0"
+    "@livekit/protocol" "1.45.3"
     events "^3.3.0"
     jose "^6.1.0"
     loglevel "^1.9.2"
     sdp-transform "^2.15.0"
-    ts-debounce "^4.0.0"
     tslib "2.8.1"
     typed-emitter "^2.1.0"
-    webrtc-adapter "^9.0.1"
+    webrtc-adapter "9.0.5"
 
 locate-path@^5.0.0:
   version "5.0.0"
@@ -3688,11 +3687,6 @@ tr46@^3.0.0:
   dependencies:
     punycode "^2.1.1"
 
-ts-debounce@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/ts-debounce/-/ts-debounce-4.0.0.tgz#33440ef64fab53793c3d546a8ca6ae539ec15841"
-  integrity sha512-+1iDGY6NmOGidq7i7xZGA4cm8DAa6fqdYcvO5Z6yBevH++Bdo9Qt/mN0TzHUgcCcKv1gmh9+W5dHqz8pMWbCbg==
-
 ts-jest@^29.4.1:
   version "29.4.1"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-29.4.1.tgz#42d33beb74657751d315efb9a871fe99e3b9b519"
@@ -3902,10 +3896,10 @@ webidl-conversions@^7.0.0:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
   integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
 
-webrtc-adapter@^9.0.1:
-  version "9.0.3"
-  resolved "https://registry.yarnpkg.com/webrtc-adapter/-/webrtc-adapter-9.0.3.tgz#b446ed7cd72129d00c652dd7b9a5716d9ffdd87d"
-  integrity sha512-5fALBcroIl31OeXAdd1YUntxiZl1eHlZZWzNg3U4Fn+J9/cGL3eT80YlrsWGvj2ojuz1rZr2OXkgCzIxAZ7vRQ==
+webrtc-adapter@9.0.5:
+  version "9.0.5"
+  resolved "https://registry.yarnpkg.com/webrtc-adapter/-/webrtc-adapter-9.0.5.tgz#fb036c3db06e1a0d86c264da649e130187783b3f"
+  integrity sha512-U9vjByy/sK2OMXu5mmfuZFKTMIUQe34c0JXRO+oDrxJTsntdYT2iIFwYMOV7HhMTuktcZLGf2W1N/OcSf9ssWg==
   dependencies:
     sdp "^3.2.0"
 


### PR DESCRIPTION
### Pull Request Type

🚀 Release

### Description

-   Promotes [#474](https://github.com/de-id/agents-sdk/pull/474) to prod so `agents-ui` can bump to a **stable** `@d-id/client-sdk` instead of the `2.0.9-staging.409` build currently pinned in [agents-ui#1125](https://github.com/de-id/agents-ui/pull/1125).
-   **Scope is exactly the fix** — `git diff prod..main` is `package.json` + `yarn.lock` only (`livekit-client` 2.17.2 → 2.18.4). The only other commit is a `chore: sync version 2.0.9 from prod [skip ci]`. Nothing else rides along.
-   Unblocks two self-serve Pro clients whose Wix embeds have been dead since ~26 Aug: Wix locks `EventTarget.prototype.addEventListener`, the bundled `webrtc-adapter` assigned it at import time and threw, and the widget never rendered. Adapter 9.0.5 guards the write; livekit-client picked it up in 2.18.4.

#### Verified on the staging build

Simulated Wix lockdown locally (`addEventListener`/`removeEventListener` made non-writable before the module loads), with only the SDK version differing:

| `@d-id/client-sdk` | result under lock |
| --- | --- |
| `2.0.9` | `Uncaught TypeError: Cannot assign to read only property 'addEventListener'` — no widget |
| `2.0.9-staging.409` | no error, script evaluates, widget mounts (shadow root, 3 video elements, launcher rendered) |

`yarn ci:test` green (565 tests). Agent also confirmed loading against `api-dev` with a real dev agent.

#### QA attention for this release

The jump is 2.17.2 → 2.18.4, which is six livekit releases, not just the adapter bump. Highest-value areas to sanity check:

-   **Connection handshake** — [#1846](https://github.com/livekit/client-sdk-js/pull/1846) now sends the publisher offer with the join request to accelerate connect. This changes the connect path itself.
-   **Data channel / chat ordering** — [#1867](https://github.com/livekit/client-sdk-js/pull/1867) buffers stream events until connected and [#1885](https://github.com/livekit/client-sdk-js/pull/1885) adds a new serializer. We just shipped [#472](https://github.com/de-id/agents-sdk/pull/472) ("emit the first chat partial and never lose the first video event") — worth re-checking that first-message behaviour still holds.
-   **Reconnect / fallback** — [#1893](https://github.com/livekit/client-sdk-js/pull/1893) resets the transport manager before the legacy fallback path; [#1843](https://github.com/livekit/client-sdk-js/pull/1843) changes RTCEngine reuse on join.
-   **Mic mute/unmute** — [#1793](https://github.com/livekit/client-sdk-js/pull/1793) changes track-restart behaviour during unmute.
-   **Logging** — [#1842](https://github.com/livekit/client-sdk-js/pull/1842) renames `pID` to `participantID` in log context. Check any Datadog facet or dashboard that keys on `pID`.
-   **Wix specifically** — on locked pages the adapter now skips its `icecandidate` / `datachannel` event wrapping rather than applying it, so a real Wix embed should be exercised end to end, not just loaded.

### Reference Links
-   [Asana](https://app.asana.com/1/856614567666442/project/1217823176333868/task/1218322198188046?focus=true)
